### PR TITLE
[WIP] Replace unwrap calls in asyncgit with error handling - closes #53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /release
 .DS_Store
+/.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "rayon-core",
  "scopetime",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -566,6 +567,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +739,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
+name = "syn"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +761,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467e5ff447618a916519a4e0d62772ab14f434897f3d63f05d8700ef1e9b22c1"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63c1091225b9834089b429bc4a2e01223470e3183e891582909e9d1c4cb55d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -787,6 +837,12 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -18,3 +18,4 @@ log = "0.4"
 is_executable = "0.1"
 scopetime = { path = "../scopetime", version = "0.1" }
 tempfile = "3.1"
+thiserror = "1.0"

--- a/asyncgit/src/diff.rs
+++ b/asyncgit/src/diff.rs
@@ -92,7 +92,8 @@ impl AsyncDiff {
             arc_pending.fetch_add(1, Ordering::Relaxed);
 
             let res =
-                sync::diff::get_diff(CWD, params.0.clone(), params.1);
+                sync::diff::get_diff(CWD, params.0.clone(), params.1)
+                    .unwrap();
             let mut notify = false;
             {
                 let mut current = arc_current.lock().unwrap();

--- a/asyncgit/src/diff.rs
+++ b/asyncgit/src/diff.rs
@@ -1,7 +1,5 @@
 use crate::error::Returns;
-use crate::{
-    error::Error, hash, sync, AsyncNotification, FileDiff, CWD,
-};
+use crate::{hash, sync, AsyncNotification, FileDiff, CWD};
 use crossbeam_channel::Sender;
 use log::trace;
 use std::{
@@ -47,7 +45,7 @@ impl AsyncDiff {
     ///
     pub fn last(
         &mut self,
-    ) -> Result<Option<(DiffParams, FileDiff)>, Error> {
+    ) -> Returns<Option<(DiffParams, FileDiff)>> {
         let last = self.last.lock()?;
 
         Ok(match last.clone() {

--- a/asyncgit/src/diff.rs
+++ b/asyncgit/src/diff.rs
@@ -1,4 +1,4 @@
-use crate::error::Returns;
+use crate::error::Result;
 use crate::{hash, sync, AsyncNotification, FileDiff, CWD};
 use crossbeam_channel::Sender;
 use log::trace;
@@ -43,9 +43,7 @@ impl AsyncDiff {
     }
 
     ///
-    pub fn last(
-        &mut self,
-    ) -> Returns<Option<(DiffParams, FileDiff)>> {
+    pub fn last(&mut self) -> Result<Option<(DiffParams, FileDiff)>> {
         let last = self.last.lock()?;
 
         Ok(match last.clone() {
@@ -55,7 +53,7 @@ impl AsyncDiff {
     }
 
     ///
-    pub fn refresh(&mut self) -> Returns<()> {
+    pub fn refresh(&mut self) -> Result<()> {
         if let Ok(Some(param)) = self.get_last_param() {
             self.clear_current()?;
             self.request(param)?;
@@ -72,7 +70,7 @@ impl AsyncDiff {
     pub fn request(
         &mut self,
         params: DiffParams,
-    ) -> Returns<Option<FileDiff>> {
+    ) -> Result<Option<FileDiff>> {
         trace!("request");
 
         let hash = hash(&params);
@@ -122,7 +120,7 @@ impl AsyncDiff {
         >,
         arc_current: Arc<Mutex<Request<u64, FileDiff>>>,
         hash: u64,
-    ) -> Returns<bool> {
+    ) -> Result<bool> {
         let res =
             sync::diff::get_diff(CWD, params.0.clone(), params.1)?;
 
@@ -147,11 +145,11 @@ impl AsyncDiff {
         Ok(notify)
     }
 
-    fn get_last_param(&self) -> Returns<Option<DiffParams>> {
+    fn get_last_param(&self) -> Result<Option<DiffParams>> {
         Ok(self.last.lock()?.clone().map(|e| e.params))
     }
 
-    fn clear_current(&mut self) -> Returns<()> {
+    fn clear_current(&mut self) -> Result<()> {
         let mut current = self.current.lock()?;
         current.0 = 0;
         current.1 = None;

--- a/asyncgit/src/diff.rs
+++ b/asyncgit/src/diff.rs
@@ -108,7 +108,7 @@ impl AsyncDiff {
             arc_pending.fetch_sub(1, Ordering::Relaxed);
 
             if notify {
-                let _ = sender
+                sender
                     .send(AsyncNotification::Diff)
                     .expect("error sending diff");
             }

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -6,14 +6,14 @@ pub enum Error {
     Generic(String),
 
     #[error("io error")]
-    Io {
-        #[from]
-        source: std::io::Error,
-    },
+    Io(#[from] std::io::Error),
 
     #[error("git error")]
-    Git {
+    Git(#[from] git2::Error),
+
+    #[error("encoding error.")]
+    Encoding {
         #[from]
-        source: git2::Error,
+        source: std::string::FromUtf8Error,
     },
 }

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("`{0}`")]
+    Generic(String),
+
+    #[error("io error")]
+    Io {
+        #[from]
+        source: std::io::Error,
+    },
+
+    #[error("git error")]
+    Git {
+        #[from]
+        source: git2::Error,
+    },
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error>),
+}

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -16,7 +16,4 @@ pub enum Error {
         #[from]
         source: git2::Error,
     },
-
-    #[error(transparent)]
-    Other(#[from] Box<dyn std::error::Error>),
 }

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -13,20 +13,9 @@ pub enum Error {
 
     #[error("encoding error:{0}")]
     Encoding(#[from] std::string::FromUtf8Error),
-
-    #[error("unspecified error:{0}")]
-    Unspecified(Box<dyn std::error::Error>),
 }
 
-pub type Returns<T> = std::result::Result<T, Error>;
-
-// impl From<&dyn std::error::Error> for Error {
-//     fn from(error: &dyn std::error::Error) -> Self {
-//         let e = error.clone().to_owned();
-//         let b = Box::new(e);
-//         Error::Unspecified(b)
-//     }
-// }
+pub type Result<T> = std::result::Result<T, Error>;
 
 impl<T> From<std::sync::PoisonError<T>> for Error {
     fn from(error: std::sync::PoisonError<T>) -> Self {

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -5,15 +5,31 @@ pub enum Error {
     #[error("`{0}`")]
     Generic(String),
 
-    #[error("io error")]
+    #[error("io error:{0}")]
     Io(#[from] std::io::Error),
 
-    #[error("git error")]
+    #[error("git error:{0}")]
     Git(#[from] git2::Error),
 
-    #[error("encoding error.")]
-    Encoding {
-        #[from]
-        source: std::string::FromUtf8Error,
-    },
+    #[error("encoding error:{0}")]
+    Encoding(#[from] std::string::FromUtf8Error),
+
+    #[error("unspecified error:{0}")]
+    Unspecified(Box<dyn std::error::Error>),
+}
+
+pub type Returns<T> = std::result::Result<T, Error>;
+
+// impl From<&dyn std::error::Error> for Error {
+//     fn from(error: &dyn std::error::Error) -> Self {
+//         let e = error.clone().to_owned();
+//         let b = Box::new(e);
+//         Error::Unspecified(b)
+//     }
+// }
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(error: std::sync::PoisonError<T>) -> Self {
+        Error::Generic(format!("poison error: {}", error))
+    }
 }

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -10,9 +10,6 @@ pub enum Error {
 
     #[error("git error:{0}")]
     Git(#[from] git2::Error),
-
-    #[error("encoding error:{0}")]
-    Encoding(#[from] std::string::FromUtf8Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::all)]
 
 mod diff;
+mod error;
 mod revlog;
 mod status;
 pub mod sync;

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
         utils::is_repo,
     },
 };
+use error::{Error, Returns};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -48,9 +49,11 @@ pub fn hash<T: Hash + ?Sized>(v: &T) -> u64 {
 }
 
 /// helper function to return the current tick since unix epoch
-pub fn current_tick() -> u64 {
-    SystemTime::now()
+pub fn current_tick() -> Returns<u64> {
+    Ok(SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
+        .map_err(|_| {
+            Error::Generic("can't get system time".to_string())
+        })?
+        .as_millis() as u64)
 }

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -20,7 +20,6 @@ pub use crate::{
         utils::is_repo,
     },
 };
-use error::{Error, Result};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -49,11 +48,9 @@ pub fn hash<T: Hash + ?Sized>(v: &T) -> u64 {
 }
 
 /// helper function to return the current tick since unix epoch
-pub fn current_tick() -> Result<u64> {
-    Ok(SystemTime::now()
+pub fn current_tick() -> u64 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|_| {
-            Error::Generic("can't get system time".to_string())
-        })?
-        .as_millis() as u64)
+        .unwrap()
+        .as_millis() as u64
 }

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::{
         utils::is_repo,
     },
 };
-use error::{Error, Returns};
+use error::{Error, Result};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -49,7 +49,7 @@ pub fn hash<T: Hash + ?Sized>(v: &T) -> u64 {
 }
 
 /// helper function to return the current tick since unix epoch
-pub fn current_tick() -> Returns<u64> {
+pub fn current_tick() -> Result<u64> {
     Ok(SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|_| {

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -1,4 +1,4 @@
-use crate::error::Returns;
+use crate::error::Result;
 use crate::{sync, AsyncNotification, CWD};
 use crossbeam_channel::Sender;
 use git2::Oid;
@@ -32,7 +32,7 @@ impl AsyncLog {
     }
 
     ///
-    pub fn count(&mut self) -> Returns<usize> {
+    pub fn count(&mut self) -> Result<usize> {
         Ok(self.current.lock()?.len())
     }
 
@@ -41,7 +41,7 @@ impl AsyncLog {
         &self,
         start_index: usize,
         amount: usize,
-    ) -> Returns<Vec<Oid>> {
+    ) -> Result<Vec<Oid>> {
         let list = self.current.lock()?;
         let list_len = list.len();
         let min = start_index.min(list_len);
@@ -56,7 +56,7 @@ impl AsyncLog {
     }
 
     ///
-    pub fn fetch(&mut self) -> Returns<()> {
+    pub fn fetch(&mut self) -> Result<()> {
         if !self.is_pending() {
             self.clear()?;
 
@@ -79,7 +79,7 @@ impl AsyncLog {
     fn fetch_helper(
         arc_current: Arc<Mutex<Vec<Oid>>>,
         sender: &Sender<AsyncNotification>,
-    ) -> Returns<()> {
+    ) -> Result<()> {
         let mut entries = Vec::with_capacity(LIMIT_COUNT);
         let r = repo(CWD)?;
         let mut walker = LogWalker::new(&r);
@@ -103,7 +103,7 @@ impl AsyncLog {
         Ok(())
     }
 
-    fn clear(&mut self) -> Returns<()> {
+    fn clear(&mut self) -> Result<()> {
         self.current.lock()?.clear();
         Ok(())
     }

--- a/asyncgit/src/status.rs
+++ b/asyncgit/src/status.rs
@@ -1,6 +1,5 @@
 use crate::{
-    error::{Error, Returns},
-    hash, sync, AsyncNotification, StatusItem, CWD,
+    error::Returns, hash, sync, AsyncNotification, StatusItem, CWD,
 };
 use crossbeam_channel::Sender;
 use log::trace;
@@ -115,7 +114,7 @@ impl AsyncStatus {
         Ok(())
     }
 
-    fn get_status() -> Result<Status, Error> {
+    fn get_status() -> Returns<Status> {
         let work_dir =
             sync::status::get_status(CWD, StatusType::WorkingDir)?;
         let stage = sync::status::get_status(CWD, StatusType::Stage)?;

--- a/asyncgit/src/status.rs
+++ b/asyncgit/src/status.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::Returns, hash, sync, AsyncNotification, StatusItem, CWD,
+    error::Result, hash, sync, AsyncNotification, StatusItem, CWD,
 };
 use crossbeam_channel::Sender;
 use log::trace;
@@ -40,7 +40,7 @@ impl AsyncStatus {
     }
 
     ///
-    pub fn last(&mut self) -> Returns<Status> {
+    pub fn last(&mut self) -> Result<Status> {
         let last = self.last.lock()?;
         Ok(last.clone())
     }
@@ -51,7 +51,7 @@ impl AsyncStatus {
     }
 
     ///
-    pub fn fetch(&mut self, request: u64) -> Returns<Option<Status>> {
+    pub fn fetch(&mut self, request: u64) -> Result<Option<Status>> {
         let hash_request = hash(&request);
 
         trace!("request: {} [hash: {}]", request, hash_request);
@@ -95,7 +95,7 @@ impl AsyncStatus {
         hash_request: u64,
         arc_current: Arc<Mutex<Request<u64, Status>>>,
         arc_last: Arc<Mutex<Status>>,
-    ) -> Returns<()> {
+    ) -> Result<()> {
         let res = Self::get_status()?;
         trace!("status fetched: {}", hash(&res));
 
@@ -114,7 +114,7 @@ impl AsyncStatus {
         Ok(())
     }
 
-    fn get_status() -> Returns<Status> {
+    fn get_status() -> Result<Status> {
         let work_dir =
             sync::status::get_status(CWD, StatusType::WorkingDir)?;
         let stage = sync::status::get_status(CWD, StatusType::Stage)?;

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -1,5 +1,5 @@
 use super::utils::repo;
-use crate::error::Returns;
+use crate::error::Result;
 use git2::{Commit, Error, Oid};
 use scopetime::scope_time;
 
@@ -20,7 +20,7 @@ pub struct CommitInfo {
 pub fn get_commits_info(
     repo_path: &str,
     ids: &[Oid],
-) -> Returns<Vec<CommitInfo>> {
+) -> Result<Vec<CommitInfo>> {
     scope_time!("get_commits_info");
 
     let repo = repo(repo_path)?;
@@ -28,7 +28,7 @@ pub fn get_commits_info(
     let commits = ids
         .iter()
         .map(|id| repo.find_commit(*id))
-        .collect::<Result<Vec<Commit>, Error>>()?
+        .collect::<std::result::Result<Vec<Commit>, Error>>()?
         .into_iter();
 
     let res = commits
@@ -71,14 +71,14 @@ fn limit_str(s: &str, limit: usize) -> String {
 mod tests {
 
     use super::get_commits_info;
-    use crate::error::Returns;
+    use crate::error::Result;
     use crate::sync::{
         commit, stage_add_file, tests::repo_init_empty,
     };
     use std::{fs::File, io::Write, path::Path};
 
     #[test]
-    fn test_log() -> Returns<()> {
+    fn test_log() -> Result<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -1,4 +1,5 @@
 use super::utils::repo;
+use crate::error::Returns;
 use git2::{Commit, Error, Oid};
 use scopetime::scope_time;
 
@@ -19,10 +20,10 @@ pub struct CommitInfo {
 pub fn get_commits_info(
     repo_path: &str,
     ids: &[Oid],
-) -> Result<Vec<CommitInfo>, Error> {
+) -> Returns<Vec<CommitInfo>> {
     scope_time!("get_commits_info");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
     let commits = ids
         .iter()
@@ -82,15 +83,15 @@ mod tests {
     #[test]
     fn test_log() -> Result<(), Error> {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init_empty();
+        let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         let c1 = commit(repo_path, "commit1").unwrap();
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         let c2 = commit(repo_path, "commit2").unwrap();
 
         let res = get_commits_info(repo_path, &vec![c2, c1]).unwrap();

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -24,7 +24,11 @@ pub fn get_commits_info(
 
     let repo = repo(repo_path);
 
-    let commits = ids.iter().map(|id| repo.find_commit(*id).unwrap());
+    let commits = ids
+        .iter()
+        .map(|id| repo.find_commit(*id))
+        .collect::<Result<Vec<Commit>, Error>>()?
+        .into_iter();
 
     let res = commits
         .map(|c: Commit| {

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -71,17 +71,14 @@ fn limit_str(s: &str, limit: usize) -> String {
 mod tests {
 
     use super::get_commits_info;
+    use crate::error::Returns;
     use crate::sync::{
         commit, stage_add_file, tests::repo_init_empty,
     };
-    use std::{
-        fs::File,
-        io::{Error, Write},
-        path::Path,
-    };
+    use std::{fs::File, io::Write, path::Path};
 
     #[test]
-    fn test_log() -> Result<(), Error> {
+    fn test_log() -> Returns<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -118,7 +118,6 @@ pub(crate) fn get_diff_raw<'a>(
     Ok(diff)
 }
 
-//TODO: return Option
 ///
 pub fn get_diff(
     repo_path: &str,

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -304,21 +304,21 @@ mod tests {
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
 
         File::create(&root.join(file_path))
             .unwrap()
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
 
         assert_eq!(
             stage_add_file(repo_path, file_path).unwrap(),
             true
         );
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
 
         let diff = get_diff(
             repo_path,
@@ -362,7 +362,7 @@ mod tests {
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
 
         let file_path = root.join("bar.txt");
 
@@ -381,7 +381,7 @@ mod tests {
         let res =
             stage_add_file(repo_path, Path::new("bar.txt")).unwrap();
         assert_eq!(res, true);
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
 
         // overwrite with next content
         {
@@ -391,7 +391,7 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
+        assert_eq!(get_statuses(repo_path), (1, 1));
 
         let res = get_diff(repo_path, "bar.txt".to_string(), false)
             .unwrap();

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -1,10 +1,10 @@
 //! sync git api for fetching a diff
 
 use super::utils;
-use crate::hash;
+use crate::{error::Error, hash};
 use git2::{
-    Delta, Diff, DiffDelta, DiffFormat, DiffHunk, DiffOptions, Error,
-    Patch, Repository,
+    Delta, Diff, DiffDelta, DiffFormat, DiffHunk, DiffOptions, Patch,
+    Repository,
 };
 use scopetime::scope_time;
 use std::{fs, path::Path};
@@ -87,8 +87,15 @@ pub(crate) fn get_diff_raw<'a>(
     let diff = if stage {
         // diff against head
         if let Ok(ref_head) = repo.head() {
-            let parent =
-                repo.find_commit(ref_head.target().unwrap())?;
+            let parent = repo.find_commit(
+                ref_head.target().ok_or_else(|| {
+                    let name = ref_head.name().unwrap_or("??");
+                    Error::Generic(
+                        format!("can not find the target of symbolic references: {}", name)
+                    )
+                })?,
+            )?;
+
             let tree = parent.tree()?;
             repo.diff_tree_to_index(
                 Some(&tree),
@@ -113,13 +120,21 @@ pub(crate) fn get_diff_raw<'a>(
 
 //TODO: return Option
 ///
-pub fn get_diff(repo_path: &str, p: String, stage: bool) -> FileDiff {
+pub fn get_diff(
+    repo_path: &str,
+    p: String,
+    stage: bool,
+) -> Result<FileDiff, Error> {
     scope_time!("get_diff");
 
     let repo = utils::repo(repo_path);
-    let repo_path = repo.path().parent().unwrap();
-
-    let diff = get_diff_raw(&repo, &p, stage, false).unwrap();
+    let repo_path = repo.path().parent().ok_or_else(|| {
+        Error::Generic(
+            "repositories located at root are not supported."
+                .to_string(),
+        )
+    })?;
+    let diff = get_diff_raw(&repo, &p, stage, false)?;
 
     let mut res: FileDiff = FileDiff::default();
     let mut current_lines = Vec::new();
@@ -165,11 +180,18 @@ pub fn get_diff(repo_path: &str, p: String, stage: bool) -> FileDiff {
     };
 
     let new_file_diff = if diff.deltas().len() == 1 {
+        // it's safe to unwrap here because we check first that diff.deltas has a single element.
         let delta: DiffDelta = diff.deltas().next().unwrap();
 
         if delta.status() == Delta::Untracked {
-            let newfile_path =
-                repo_path.join(delta.new_file().path().unwrap());
+            let relative_path =
+                delta.new_file().path().ok_or_else(|| {
+                    Error::Generic(
+                        "new file path is unspecified.".to_string(),
+                    )
+                })?;
+
+            let newfile_path = repo_path.join(relative_path);
 
             if let Some(newfile_content) =
                 new_file_content(&newfile_path)
@@ -180,15 +202,13 @@ pub fn get_diff(repo_path: &str, p: String, stage: bool) -> FileDiff {
                     newfile_content.as_bytes(),
                     Some(&newfile_path),
                     None,
-                )
-                .unwrap();
+                )?;
 
                 patch
                     .print(&mut |_delta, hunk:Option<DiffHunk>, line: git2::DiffLine| {
                         put(hunk,line);
                         true
-                    })
-                    .unwrap();
+                    })?;
 
                 true
             } else {
@@ -208,15 +228,14 @@ pub fn get_diff(repo_path: &str, p: String, stage: bool) -> FileDiff {
                 put(hunk, line);
                 true
             },
-        )
-        .unwrap();
+        )?;
     }
 
     if !current_lines.is_empty() {
         adder(&current_hunk.unwrap(), &current_lines);
     }
 
-    res
+    Ok(res)
 }
 
 fn new_file_content(path: &Path) -> Option<String> {
@@ -268,7 +287,8 @@ mod tests {
         assert_eq!(res.len(), 1);
 
         let diff =
-            get_diff(repo_path, "foo/bar.txt".to_string(), false);
+            get_diff(repo_path, "foo/bar.txt".to_string(), false)
+                .unwrap();
 
         assert_eq!(diff.hunks.len(), 1);
         assert_eq!(diff.hunks[0].lines[1].content, "test\n");
@@ -298,7 +318,8 @@ mod tests {
             repo_path,
             String::from(file_path.to_str().unwrap()),
             true,
-        );
+        )
+        .unwrap();
 
         assert_eq!(diff.hunks.len(), 1);
     }
@@ -364,7 +385,8 @@ mod tests {
 
         assert_eq!(get_statuses(repo_path), (1, 1));
 
-        let res = get_diff(repo_path, "bar.txt".to_string(), false);
+        let res = get_diff(repo_path, "bar.txt".to_string(), false)
+            .unwrap();
 
         assert_eq!(res.hunks.len(), 2)
     }
@@ -387,7 +409,8 @@ mod tests {
             sub_path.to_str().unwrap(),
             String::from(file_path.to_str().unwrap()),
             false,
-        );
+        )
+        .unwrap();
 
         assert_eq!(diff.hunks[0].lines[1].content, "test");
     }
@@ -407,7 +430,8 @@ mod tests {
             repo_path,
             String::from(file_path.to_str().unwrap()),
             false,
-        );
+        )
+        .unwrap();
 
         assert_eq!(diff.hunks.len(), 0);
 

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -1,7 +1,7 @@
 //! sync git api for fetching a diff
 
 use super::utils;
-use crate::error::Returns;
+use crate::error::Result;
 use crate::{error::Error, hash};
 use git2::{
     Delta, Diff, DiffDelta, DiffFormat, DiffHunk, DiffOptions, Patch,
@@ -80,7 +80,7 @@ pub(crate) fn get_diff_raw<'a>(
     p: &str,
     stage: bool,
     reverse: bool,
-) -> Returns<Diff<'a>> {
+) -> Result<Diff<'a>> {
     let mut opt = DiffOptions::new();
     opt.pathspec(p);
     opt.reverse(reverse);
@@ -124,7 +124,7 @@ pub fn get_diff(
     repo_path: &str,
     p: String,
     stage: bool,
-) -> Returns<FileDiff> {
+) -> Result<FileDiff> {
     scope_time!("get_diff");
 
     let repo = utils::repo(repo_path)?;
@@ -257,7 +257,7 @@ fn new_file_content(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::get_diff;
-    use crate::error::Returns;
+    use crate::error::Result;
     use crate::sync::{
         stage_add_file,
         status::{get_status, StatusType},
@@ -424,7 +424,7 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_new_binary_file_using_invalid_utf8() -> Returns<()> {
+    fn test_diff_new_binary_file_using_invalid_utf8() -> Result<()> {
         let file_path = Path::new("bar");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -1,6 +1,7 @@
 //! sync git api for fetching a diff
 
 use super::utils;
+use crate::error::Returns;
 use crate::{error::Error, hash};
 use git2::{
     Delta, Diff, DiffDelta, DiffFormat, DiffHunk, DiffOptions, Patch,
@@ -79,7 +80,7 @@ pub(crate) fn get_diff_raw<'a>(
     p: &str,
     stage: bool,
     reverse: bool,
-) -> Result<Diff<'a>, Error> {
+) -> Returns<Diff<'a>> {
     let mut opt = DiffOptions::new();
     opt.pathspec(p);
     opt.reverse(reverse);
@@ -123,7 +124,7 @@ pub fn get_diff(
     repo_path: &str,
     p: String,
     stage: bool,
-) -> Result<FileDiff, Error> {
+) -> Returns<FileDiff> {
     scope_time!("get_diff");
 
     let repo = utils::repo(repo_path)?;
@@ -256,6 +257,7 @@ fn new_file_content(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::get_diff;
+    use crate::error::Returns;
     use crate::sync::{
         stage_add_file,
         status::{get_status, StatusType},
@@ -263,7 +265,7 @@ mod tests {
     };
     use std::{
         fs::{self, File},
-        io::{Error, Write},
+        io::Write,
         path::Path,
     };
 
@@ -422,8 +424,7 @@ mod tests {
     }
 
     #[test]
-    fn test_diff_new_binary_file_using_invalid_utf8(
-    ) -> Result<(), Error> {
+    fn test_diff_new_binary_file_using_invalid_utf8() -> Returns<()> {
         let file_path = Path::new("bar");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -71,19 +71,19 @@ pub enum HookResult {
 }
 
 fn run_hook(path: &str, cmd: &str, args: &[&str]) -> HookResult {
-    let output =
-        Command::new(cmd).args(args).current_dir(path).output();
+    match Command::new(cmd).args(args).current_dir(path).output() {
+        Ok(output) => {
+            if output.status.success() {
+                HookResult::Ok
+            } else {
+                let err = String::from_utf8_lossy(&output.stderr);
+                let out = String::from_utf8_lossy(&output.stdout);
+                let formatted = format!("{}{}", out, err);
 
-    let output = output.expect("general hook error");
-
-    if output.status.success() {
-        HookResult::Ok
-    } else {
-        let err = String::from_utf8_lossy(&output.stderr);
-        let out = String::from_utf8_lossy(&output.stdout);
-        let formatted = format!("{}{}", out, err);
-
-        HookResult::NotOk(formatted)
+                HookResult::NotOk(formatted)
+            }
+        }
+        Err(e) => HookResult::NotOk(format!("{}", e)),
     }
 }
 

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -84,8 +84,8 @@ fn run_hook(
     if output.status.success() {
         Ok(HookResult::Ok)
     } else {
-        let err = String::from_utf8(output.stderr)?;
-        let out = String::from_utf8(output.stdout)?;
+        let err = String::from_utf8_lossy(&output.stderr);
+        let out = String::from_utf8_lossy(&output.stdout);
         let formatted = format!("{}{}", out, err);
 
         Ok(HookResult::NotOk(formatted))

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn test_hooks_commit_msg_ok() {
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
@@ -149,7 +149,7 @@ exit 0
     #[test]
     #[cfg(not(windows))]
     fn test_hooks_commit_msg() {
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
@@ -176,7 +176,7 @@ exit 1
     #[test]
     #[cfg(not(windows))]
     fn test_commit_msg_no_block_but_alter() {
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -30,8 +30,7 @@ pub fn hooks_commit_msg(
             )
         })?;
 
-        let res =
-            run_hook(repo_path, HOOK_COMMIT_MSG, &[&file_path])?;
+        let res = run_hook(repo_path, HOOK_COMMIT_MSG, &[&file_path]);
 
         // load possibly altered msg
         let mut file = file.reopen()?;
@@ -49,7 +48,7 @@ pub fn hooks_post_commit(repo_path: &str) -> Result<HookResult> {
     scope_time!("hooks_post_commit");
 
     if hook_runable(repo_path, HOOK_POST_COMMIT) {
-        Ok(run_hook(repo_path, HOOK_POST_COMMIT, &[])?)
+        Ok(run_hook(repo_path, HOOK_POST_COMMIT, &[]))
     } else {
         Ok(HookResult::Ok)
     }
@@ -71,24 +70,20 @@ pub enum HookResult {
     NotOk(String),
 }
 
-fn run_hook(
-    path: &str,
-    cmd: &str,
-    args: &[&str],
-) -> Result<HookResult> {
+fn run_hook(path: &str, cmd: &str, args: &[&str]) -> HookResult {
     let output =
         Command::new(cmd).args(args).current_dir(path).output();
 
     let output = output.expect("general hook error");
 
     if output.status.success() {
-        Ok(HookResult::Ok)
+        HookResult::Ok
     } else {
         let err = String::from_utf8_lossy(&output.stderr);
         let out = String::from_utf8_lossy(&output.stdout);
         let formatted = format!("{}{}", out, err);
 
-        Ok(HookResult::NotOk(formatted))
+        HookResult::NotOk(formatted)
     }
 }
 

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Returns};
+use crate::error::{Error, Result};
 use is_executable::IsExecutable;
 use scopetime::scope_time;
 use std::{
@@ -15,7 +15,7 @@ const HOOK_COMMIT_MSG: &str = ".git/hooks/commit-msg";
 pub fn hooks_commit_msg(
     repo_path: &str,
     msg: &mut String,
-) -> Returns<HookResult> {
+) -> Result<HookResult> {
     scope_time!("hooks_commit_msg");
 
     if hook_runable(repo_path, HOOK_COMMIT_MSG) {
@@ -42,7 +42,7 @@ pub fn hooks_commit_msg(
 }
 
 ///
-pub fn hooks_post_commit(repo_path: &str) -> Returns<HookResult> {
+pub fn hooks_post_commit(repo_path: &str) -> Result<HookResult> {
     scope_time!("hooks_post_commit");
 
     if hook_runable(repo_path, HOOK_POST_COMMIT) {
@@ -72,7 +72,7 @@ fn run_hook(
     path: &str,
     cmd: &str,
     args: &[&str],
-) -> Returns<HookResult> {
+) -> Result<HookResult> {
     let output =
         Command::new(cmd).args(args).current_dir(path).output();
 

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -15,7 +15,7 @@ const HOOK_COMMIT_MSG: &str = ".git/hooks/commit-msg";
 pub fn hooks_commit_msg(
     repo_path: &str,
     msg: &mut String,
-) -> Result<HookResult, Error> {
+) -> Returns<HookResult> {
     scope_time!("hooks_commit_msg");
 
     if hook_runable(repo_path, HOOK_COMMIT_MSG) {

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -134,7 +134,7 @@ exit 0
         create_hook(root, HOOK_COMMIT_MSG, hook);
 
         let mut msg = String::from("test");
-        let res = hooks_commit_msg(repo_path, &mut msg);
+        let res = hooks_commit_msg(repo_path, &mut msg).unwrap();
 
         assert_eq!(res, HookResult::Ok);
 
@@ -158,7 +158,7 @@ exit 1
         create_hook(root, HOOK_COMMIT_MSG, hook);
 
         let mut msg = String::from("test");
-        let res = hooks_commit_msg(repo_path, &mut msg);
+        let res = hooks_commit_msg(repo_path, &mut msg).unwrap();
 
         assert_eq!(
             res,
@@ -184,7 +184,7 @@ exit 0
         create_hook(root, HOOK_COMMIT_MSG, hook);
 
         let mut msg = String::from("test");
-        let res = hooks_commit_msg(repo_path, &mut msg);
+        let res = hooks_commit_msg(repo_path, &mut msg).unwrap();
 
         assert_eq!(res, HookResult::Ok);
         assert_eq!(msg, String::from("msg\n"));

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -24,7 +24,10 @@ pub fn hooks_commit_msg(
         write!(file, "{}", msg)?;
 
         let file_path = file.path().to_str().ok_or_else(|| {
-            Error::Generic("can't get temp file's path".to_string())
+            Error::Generic(
+                "temp file path contains invalid unicode sequences."
+                    .to_string(),
+            )
         })?;
 
         let res =

--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -2,7 +2,7 @@ use super::{
     diff::{get_diff_raw, HunkHeader},
     utils::repo,
 };
-use crate::hash;
+use crate::{error::Error, hash};
 use git2::{ApplyLocation, ApplyOptions, Diff};
 use log::error;
 use scopetime::scope_time;
@@ -12,12 +12,12 @@ pub fn stage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> bool {
+) -> Result<bool, Error> {
     scope_time!("stage_hunk");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
-    let diff = get_diff_raw(&repo, &file_path, false, false).unwrap();
+    let diff = get_diff_raw(&repo, &file_path, false, false)?;
 
     let mut opt = ApplyOptions::new();
     opt.hunk_callback(|hunk| {
@@ -25,8 +25,9 @@ pub fn stage_hunk(
         hash(&header) == hunk_hash
     });
 
-    repo.apply(&diff, ApplyLocation::Index, Some(&mut opt))
-        .is_ok()
+    repo.apply(&diff, ApplyLocation::Index, Some(&mut opt))?;
+
+    Ok(true)
 }
 
 fn find_hunk_index(diff: &Diff, hunk_hash: u64) -> Option<usize> {
@@ -60,22 +61,22 @@ pub fn unstage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> bool {
+) -> Result<bool, Error> {
     scope_time!("revert_hunk");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
-    let diff = get_diff_raw(&repo, &file_path, true, false).unwrap();
+    let diff = get_diff_raw(&repo, &file_path, true, false)?;
     let diff_count_positive = diff.deltas().len();
 
     let hunk_index = find_hunk_index(&diff, hunk_hash);
 
     if hunk_index.is_none() {
         error!("hunk not found");
-        return false;
+        return Err(Error::Generic("hunk not found".to_string()));
     }
 
-    let diff = get_diff_raw(&repo, &file_path, true, true).unwrap();
+    let diff = get_diff_raw(&repo, &file_path, true, true)?;
 
     assert_eq!(diff.deltas().len(), diff_count_positive);
 
@@ -100,9 +101,9 @@ pub fn unstage_hunk(
             .is_err()
         {
             error!("apply failed");
-            return false;
+            return Err(Error::Generic("apply failed".to_string()));
         }
     }
 
-    count == 1
+    Ok(count == 1)
 }

--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -13,7 +13,7 @@ pub fn stage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> Result<bool> {
+) -> Result<()> {
     scope_time!("stage_hunk");
 
     let repo = repo(repo_path)?;
@@ -28,7 +28,7 @@ pub fn stage_hunk(
 
     repo.apply(&diff, ApplyLocation::Index, Some(&mut opt))?;
 
-    Ok(true)
+    Ok(())
 }
 
 fn find_hunk_index(diff: &Diff, hunk_hash: u64) -> Option<usize> {

--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -2,7 +2,7 @@ use super::{
     diff::{get_diff_raw, HunkHeader},
     utils::repo,
 };
-use crate::error::Returns;
+use crate::error::Result;
 use crate::{error::Error, hash};
 use git2::{ApplyLocation, ApplyOptions, Diff};
 use log::error;
@@ -13,7 +13,7 @@ pub fn stage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> Returns<bool> {
+) -> Result<bool> {
     scope_time!("stage_hunk");
 
     let repo = repo(repo_path)?;
@@ -62,7 +62,7 @@ pub fn unstage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> Returns<bool> {
+) -> Result<bool> {
     scope_time!("revert_hunk");
 
     let repo = repo(repo_path)?;

--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -2,6 +2,7 @@ use super::{
     diff::{get_diff_raw, HunkHeader},
     utils::repo,
 };
+use crate::error::Returns;
 use crate::{error::Error, hash};
 use git2::{ApplyLocation, ApplyOptions, Diff};
 use log::error;
@@ -12,7 +13,7 @@ pub fn stage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> Result<bool, Error> {
+) -> Returns<bool> {
     scope_time!("stage_hunk");
 
     let repo = repo(repo_path)?;
@@ -61,7 +62,7 @@ pub fn unstage_hunk(
     repo_path: &str,
     file_path: String,
     hunk_hash: u64,
-) -> Result<bool, Error> {
+) -> Returns<bool> {
     scope_time!("revert_hunk");
 
     let repo = repo(repo_path)?;

--- a/asyncgit/src/sync/logwalker.rs
+++ b/asyncgit/src/sync/logwalker.rs
@@ -1,4 +1,4 @@
-use crate::error::Returns;
+use crate::error::Result;
 use git2::{Oid, Repository, Revwalk};
 
 ///
@@ -21,7 +21,7 @@ impl<'a> LogWalker<'a> {
         &mut self,
         out: &mut Vec<Oid>,
         limit: usize,
-    ) -> Returns<usize> {
+    ) -> Result<usize> {
         let mut count = 0_usize;
 
         if self.revwalk.is_none() {
@@ -57,7 +57,7 @@ mod tests {
     use std::{fs::File, io::Write, path::Path};
 
     #[test]
-    fn test_limit() -> Returns<()> {
+    fn test_limit() -> Result<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
@@ -81,7 +81,7 @@ mod tests {
     }
 
     #[test]
-    fn test_logwalker() -> Returns<()> {
+    fn test_logwalker() -> Result<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/logwalker.rs
+++ b/asyncgit/src/sync/logwalker.rs
@@ -62,15 +62,15 @@ mod tests {
     #[test]
     fn test_limit() -> Result<(), Error> {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init_empty();
+        let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         commit(repo_path, "commit1").unwrap();
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         let oid2 = commit(repo_path, "commit2").unwrap();
 
         let mut items = Vec::new();
@@ -86,15 +86,15 @@ mod tests {
     #[test]
     fn test_logwalker() -> Result<(), Error> {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init_empty();
+        let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         commit(repo_path, "commit1").unwrap();
         File::create(&root.join(file_path))?.write_all(b"a")?;
-        stage_add_file(repo_path, file_path);
+        stage_add_file(repo_path, file_path).unwrap();
         let oid2 = commit(repo_path, "commit2").unwrap();
 
         let mut items = Vec::new();

--- a/asyncgit/src/sync/logwalker.rs
+++ b/asyncgit/src/sync/logwalker.rs
@@ -1,4 +1,5 @@
-use git2::{Error, Oid, Repository, Revwalk};
+use crate::error::Returns;
+use git2::{Oid, Repository, Revwalk};
 
 ///
 pub struct LogWalker<'a> {
@@ -20,7 +21,7 @@ impl<'a> LogWalker<'a> {
         &mut self,
         out: &mut Vec<Oid>,
         limit: usize,
-    ) -> Result<usize, Error> {
+    ) -> Returns<usize> {
         let mut count = 0_usize;
 
         if self.revwalk.is_none() {
@@ -53,14 +54,10 @@ mod tests {
         commit, get_commits_info, stage_add_file,
         tests::repo_init_empty,
     };
-    use std::{
-        fs::File,
-        io::{Error, Write},
-        path::Path,
-    };
+    use std::{fs::File, io::Write, path::Path};
 
     #[test]
-    fn test_limit() -> Result<(), Error> {
+    fn test_limit() -> Returns<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
@@ -84,7 +81,7 @@ mod tests {
     }
 
     #[test]
-    fn test_logwalker() -> Result<(), Error> {
+    fn test_logwalker() -> Returns<()> {
         let file_path = Path::new("foo");
         let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -25,36 +25,37 @@ pub use utils::{
 #[cfg(test)]
 mod tests {
     use super::status::{get_status, StatusType};
+    use crate::error::Error;
     use git2::Repository;
     use std::process::Command;
     use tempfile::TempDir;
 
     ///
-    pub fn repo_init_empty() -> (TempDir, Repository) {
-        let td = TempDir::new().unwrap();
-        let repo = Repository::init(td.path()).unwrap();
+    pub fn repo_init_empty() -> Result<(TempDir, Repository), Error> {
+        let td = TempDir::new()?;
+        let repo = Repository::init(td.path())?;
         {
-            let mut config = repo.config().unwrap();
-            config.set_str("user.name", "name").unwrap();
-            config.set_str("user.email", "email").unwrap();
+            let mut config = repo.config()?;
+            config.set_str("user.name", "name")?;
+            config.set_str("user.email", "email")?;
         }
-        (td, repo)
+        Ok((td, repo))
     }
 
     ///
-    pub fn repo_init() -> (TempDir, Repository) {
-        let td = TempDir::new().unwrap();
-        let repo = Repository::init(td.path()).unwrap();
+    pub fn repo_init() -> Result<(TempDir, Repository), Error> {
+        let td = TempDir::new()?;
+        let repo = Repository::init(td.path())?;
         {
-            let mut config = repo.config().unwrap();
-            config.set_str("user.name", "name").unwrap();
-            config.set_str("user.email", "email").unwrap();
+            let mut config = repo.config()?;
+            config.set_str("user.name", "name")?;
+            config.set_str("user.email", "email")?;
 
-            let mut index = repo.index().unwrap();
-            let id = index.write_tree().unwrap();
+            let mut index = repo.index()?;
+            let id = index.write_tree()?;
 
-            let tree = repo.find_tree(id).unwrap();
-            let sig = repo.signature().unwrap();
+            let tree = repo.find_tree(id)?;
+            let sig = repo.signature()?;
             repo.commit(
                 Some("HEAD"),
                 &sig,
@@ -62,43 +63,48 @@ mod tests {
                 "initial",
                 &tree,
                 &[],
-            )
-            .unwrap();
+            )?;
         }
-        (td, repo)
+        Ok((td, repo))
     }
 
     /// helper returning amount of files with changes in the (wd,stage)
-    pub fn get_statuses(repo_path: &str) -> (usize, usize) {
-        (
-            get_status(repo_path, StatusType::WorkingDir).len(),
-            get_status(repo_path, StatusType::Stage).len(),
-        )
+    pub fn get_statuses(
+        repo_path: &str,
+    ) -> Result<(usize, usize), Error> {
+        Ok((
+            get_status(repo_path, StatusType::WorkingDir)?.len(),
+            get_status(repo_path, StatusType::Stage)?.len(),
+        ))
     }
 
     ///
-    pub fn debug_cmd_print(path: &str, cmd: &str) {
-        eprintln!("\n----\n{}", debug_cmd(path, cmd))
+    pub fn debug_cmd_print(
+        path: &str,
+        cmd: &str,
+    ) -> Result<(), Error> {
+        let cmd = debug_cmd(path, cmd)?;
+        eprintln!("\n----\n{}", cmd);
+        Ok(())
     }
 
-    fn debug_cmd(path: &str, cmd: &str) -> String {
+    fn debug_cmd(path: &str, cmd: &str) -> Result<String, Error> {
         let output = if cfg!(target_os = "windows") {
             Command::new("cmd")
                 .args(&["/C", cmd])
                 .current_dir(path)
-                .output()
+                .output()?
         } else {
             Command::new("sh")
                 .arg("-c")
                 .arg(cmd)
                 .current_dir(path)
-                .output()
+                .output()?
         };
 
-        let output = output.unwrap();
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        format!(
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+        Ok(format!(
             "{}{}",
             if stdout.is_empty() {
                 String::new()
@@ -110,6 +116,6 @@ mod tests {
             } else {
                 format!("err:\n{}", stderr)
             }
-        )
+        ))
     }
 }

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -25,13 +25,13 @@ pub use utils::{
 #[cfg(test)]
 mod tests {
     use super::status::{get_status, StatusType};
-    use crate::error::Error;
+    use crate::error::Returns;
     use git2::Repository;
     use std::process::Command;
     use tempfile::TempDir;
 
     ///
-    pub fn repo_init_empty() -> Result<(TempDir, Repository), Error> {
+    pub fn repo_init_empty() -> Returns<(TempDir, Repository)> {
         let td = TempDir::new()?;
         let repo = Repository::init(td.path())?;
         {
@@ -43,7 +43,7 @@ mod tests {
     }
 
     ///
-    pub fn repo_init() -> Result<(TempDir, Repository), Error> {
+    pub fn repo_init() -> Returns<(TempDir, Repository)> {
         let td = TempDir::new()?;
         let repo = Repository::init(td.path())?;
         {
@@ -69,9 +69,7 @@ mod tests {
     }
 
     /// helper returning amount of files with changes in the (wd,stage)
-    pub fn get_statuses(
-        repo_path: &str,
-    ) -> Result<(usize, usize), Error> {
+    pub fn get_statuses(repo_path: &str) -> Returns<(usize, usize)> {
         Ok((
             get_status(repo_path, StatusType::WorkingDir)?.len(),
             get_status(repo_path, StatusType::Stage)?.len(),
@@ -79,16 +77,13 @@ mod tests {
     }
 
     ///
-    pub fn debug_cmd_print(
-        path: &str,
-        cmd: &str,
-    ) -> Result<(), Error> {
+    pub fn debug_cmd_print(path: &str, cmd: &str) -> Returns<()> {
         let cmd = debug_cmd(path, cmd)?;
         eprintln!("\n----\n{}", cmd);
         Ok(())
     }
 
-    fn debug_cmd(path: &str, cmd: &str) -> Result<String, Error> {
+    fn debug_cmd(path: &str, cmd: &str) -> Returns<String> {
         let output = if cfg!(target_os = "windows") {
             Command::new("cmd")
                 .args(&["/C", cmd])

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -79,10 +79,9 @@ mod tests {
     }
 
     ///
-    pub fn debug_cmd_print(path: &str, cmd: &str) -> Result<()> {
-        let cmd = debug_cmd(path, cmd)?;
+    pub fn debug_cmd_print(path: &str, cmd: &str) {
+        let cmd = debug_cmd(path, cmd).unwrap();
         eprintln!("\n----\n{}", cmd);
-        Ok(())
     }
 
     fn debug_cmd(path: &str, cmd: &str) -> Result<String> {

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -69,11 +69,13 @@ mod tests {
     }
 
     /// helper returning amount of files with changes in the (wd,stage)
-    pub fn get_statuses(repo_path: &str) -> Result<(usize, usize)> {
-        Ok((
-            get_status(repo_path, StatusType::WorkingDir)?.len(),
-            get_status(repo_path, StatusType::Stage)?.len(),
-        ))
+    pub fn get_statuses(repo_path: &str) -> (usize, usize) {
+        (
+            get_status(repo_path, StatusType::WorkingDir)
+                .unwrap()
+                .len(),
+            get_status(repo_path, StatusType::Stage).unwrap().len(),
+        )
     }
 
     ///

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -25,13 +25,13 @@ pub use utils::{
 #[cfg(test)]
 mod tests {
     use super::status::{get_status, StatusType};
-    use crate::error::Returns;
+    use crate::error::Result;
     use git2::Repository;
     use std::process::Command;
     use tempfile::TempDir;
 
     ///
-    pub fn repo_init_empty() -> Returns<(TempDir, Repository)> {
+    pub fn repo_init_empty() -> Result<(TempDir, Repository)> {
         let td = TempDir::new()?;
         let repo = Repository::init(td.path())?;
         {
@@ -43,7 +43,7 @@ mod tests {
     }
 
     ///
-    pub fn repo_init() -> Returns<(TempDir, Repository)> {
+    pub fn repo_init() -> Result<(TempDir, Repository)> {
         let td = TempDir::new()?;
         let repo = Repository::init(td.path())?;
         {
@@ -69,7 +69,7 @@ mod tests {
     }
 
     /// helper returning amount of files with changes in the (wd,stage)
-    pub fn get_statuses(repo_path: &str) -> Returns<(usize, usize)> {
+    pub fn get_statuses(repo_path: &str) -> Result<(usize, usize)> {
         Ok((
             get_status(repo_path, StatusType::WorkingDir)?.len(),
             get_status(repo_path, StatusType::Stage)?.len(),
@@ -77,13 +77,13 @@ mod tests {
     }
 
     ///
-    pub fn debug_cmd_print(path: &str, cmd: &str) -> Returns<()> {
+    pub fn debug_cmd_print(path: &str, cmd: &str) -> Result<()> {
         let cmd = debug_cmd(path, cmd)?;
         eprintln!("\n----\n{}", cmd);
         Ok(())
     }
 
-    fn debug_cmd(path: &str, cmd: &str) -> Returns<String> {
+    fn debug_cmd(path: &str, cmd: &str) -> Result<String> {
         let output = if cfg!(target_os = "windows") {
             Command::new("cmd")
                 .args(&["/C", cmd])

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -97,8 +97,8 @@ mod tests {
                 .output()?
         };
 
-        let stdout = String::from_utf8(output.stdout)?;
-        let stderr = String::from_utf8(output.stderr)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         Ok(format!(
             "{}{}",
             if stdout.is_empty() {

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -80,27 +80,29 @@ mod tests {
 
     ///
     pub fn debug_cmd_print(path: &str, cmd: &str) {
-        let cmd = debug_cmd(path, cmd).unwrap();
+        let cmd = debug_cmd(path, cmd);
         eprintln!("\n----\n{}", cmd);
     }
 
-    fn debug_cmd(path: &str, cmd: &str) -> Result<String> {
+    fn debug_cmd(path: &str, cmd: &str) -> String {
         let output = if cfg!(target_os = "windows") {
             Command::new("cmd")
                 .args(&["/C", cmd])
                 .current_dir(path)
-                .output()?
+                .output()
+                .unwrap()
         } else {
             Command::new("sh")
                 .arg("-c")
                 .arg(cmd)
                 .current_dir(path)
-                .output()?
+                .output()
+                .unwrap()
         };
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        Ok(format!(
+        format!(
             "{}{}",
             if stdout.is_empty() {
                 String::new()
@@ -112,6 +114,6 @@ mod tests {
             } else {
                 format!("err:\n{}", stderr)
             }
-        ))
+        )
     }
 }

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -163,13 +163,13 @@ mod tests {
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
+        assert_eq!(get_statuses(repo_path), (1, 1));
 
         reset_workdir_file(repo_path, "bar.txt").unwrap();
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
     }
 
     #[test]
@@ -188,13 +188,13 @@ mod tests {
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
 
         reset_workdir_file(repo_path, "foo/bar.txt").unwrap();
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
     }
 
     #[test]
@@ -228,16 +228,16 @@ mod tests {
                 .write_all(b"file3\nadded line")?;
         }
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (5, 0));
+        assert_eq!(get_statuses(repo_path), (5, 0));
 
         stage_add_file(repo_path, Path::new("foo/file5.txt"))
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (4, 1));
+        assert_eq!(get_statuses(repo_path), (4, 1));
 
         reset_workdir_folder(repo_path, "foo").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
+        assert_eq!(get_statuses(repo_path), (1, 1));
 
         Ok(())
     }
@@ -272,13 +272,13 @@ mod tests {
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
+        assert_eq!(get_statuses(repo_path), (1, 1));
 
         reset_workdir_file(repo_path, file).unwrap();
 
         debug_cmd_print(repo_path, "git status").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
     }
 
     #[test]
@@ -293,17 +293,17 @@ mod tests {
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
 
         assert_eq!(
             stage_add_file(repo_path, file_path).unwrap(),
             true
         );
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
 
         reset_stage(repo_path, file_path).unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
     }
 }

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -66,7 +66,7 @@ pub fn reset_workdir_file(repo_path: &str, path: &str) -> Result<()> {
 pub fn reset_workdir_folder(
     repo_path: &str,
     path: &str,
-) -> Result<bool> {
+) -> Result<()> {
     scope_time!("reset_workdir_folder");
 
     let repo = repo(repo_path)?;
@@ -80,7 +80,7 @@ pub fn reset_workdir_folder(
         .path(path);
 
     repo.checkout_index(None, Some(&mut checkout_opts))?;
-    Ok(true)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -235,7 +235,7 @@ mod tests {
 
         assert_eq!(get_statuses(repo_path).unwrap(), (4, 1));
 
-        assert!(reset_workdir_folder(repo_path, "foo").unwrap());
+        reset_workdir_folder(repo_path, "foo").unwrap();
 
         assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
 

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -5,7 +5,7 @@ use scopetime::scope_time;
 use std::{fs, path::Path};
 
 ///
-pub fn reset_stage(repo_path: &str, path: &Path) -> Result<bool> {
+pub fn reset_stage(repo_path: &str, path: &Path) -> Result<()> {
     scope_time!("reset_stage");
 
     let repo = repo(repo_path)?;
@@ -28,7 +28,7 @@ pub fn reset_stage(repo_path: &str, path: &Path) -> Result<bool> {
         repo.reset_default(None, &[path])?;
     }
 
-    Ok(true)
+    Ok(())
 }
 
 ///
@@ -315,7 +315,7 @@ mod tests {
 
         assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
 
-        assert_eq!(reset_stage(repo_path, file_path).unwrap(), true);
+        reset_stage(repo_path, file_path).unwrap();
 
         assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
     }

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -97,6 +97,7 @@ mod tests {
     use super::{
         reset_stage, reset_workdir_file, reset_workdir_folder,
     };
+    use crate::error::Returns;
     use crate::sync::{
         status::{get_status, StatusType},
         tests::{
@@ -106,7 +107,7 @@ mod tests {
     };
     use std::{
         fs::{self, File},
-        io::{Error, Write},
+        io::Write,
         path::Path,
     };
 
@@ -209,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reset_folder() -> Result<(), Error> {
+    fn test_reset_folder() -> Returns<()> {
         let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -1,11 +1,11 @@
 use super::utils::repo;
-use crate::error::{Error, Returns};
+use crate::error::{Error, Result};
 use git2::{build::CheckoutBuilder, ObjectType, Status};
 use scopetime::scope_time;
 use std::{fs, path::Path};
 
 ///
-pub fn reset_stage(repo_path: &str, path: &Path) -> Returns<bool> {
+pub fn reset_stage(repo_path: &str, path: &Path) -> Result<bool> {
     scope_time!("reset_stage");
 
     let repo = repo(repo_path)?;
@@ -35,7 +35,7 @@ pub fn reset_stage(repo_path: &str, path: &Path) -> Returns<bool> {
 pub fn reset_workdir_file(
     repo_path: &str,
     path: &str,
-) -> Returns<bool> {
+) -> Result<bool> {
     scope_time!("reset_workdir_file");
 
     let repo = repo(repo_path)?;
@@ -75,7 +75,7 @@ pub fn reset_workdir_file(
 pub fn reset_workdir_folder(
     repo_path: &str,
     path: &str,
-) -> Returns<bool> {
+) -> Result<bool> {
     scope_time!("reset_workdir_folder");
 
     let repo = repo(repo_path)?;
@@ -97,7 +97,7 @@ mod tests {
     use super::{
         reset_stage, reset_workdir_file, reset_workdir_folder,
     };
-    use crate::error::Returns;
+    use crate::error::Result;
     use crate::sync::{
         status::{get_status, StatusType},
         tests::{
@@ -210,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reset_folder() -> Returns<()> {
+    fn test_reset_folder() -> Result<()> {
         let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();

--- a/asyncgit/src/sync/reset.rs
+++ b/asyncgit/src/sync/reset.rs
@@ -147,11 +147,11 @@ mod tests {
                 .unwrap();
         }
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         stage_add_file(repo_path, Path::new("bar.txt")).unwrap();
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         // overwrite with next content
         {
@@ -161,13 +161,13 @@ mod tests {
                 .unwrap();
         }
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (1, 1));
 
         reset_workdir_file(repo_path, "bar.txt").unwrap();
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (0, 1));
     }
@@ -186,13 +186,13 @@ mod tests {
                 .unwrap();
         }
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (1, 0));
 
         reset_workdir_file(repo_path, "foo/bar.txt").unwrap();
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (0, 0));
     }
@@ -257,11 +257,11 @@ mod tests {
                 .unwrap();
         }
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
-        debug_cmd_print(repo_path, "git add .").unwrap();
+        debug_cmd_print(repo_path, "git add .");
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         {
             File::create(&root.join(file))
@@ -270,13 +270,13 @@ mod tests {
                 .unwrap();
         }
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (1, 1));
 
         reset_workdir_file(repo_path, file).unwrap();
 
-        debug_cmd_print(repo_path, "git status").unwrap();
+        debug_cmd_print(repo_path, "git status");
 
         assert_eq!(get_statuses(repo_path), (0, 1));
     }

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -1,6 +1,6 @@
 //! sync git api for fetching a status
 
-use crate::error::Returns;
+use crate::error::Result;
 use crate::{error::Error, sync::utils};
 use git2::{Status, StatusOptions, StatusShow};
 use scopetime::scope_time;
@@ -68,7 +68,7 @@ impl Into<StatusShow> for StatusType {
 pub fn get_status(
     repo_path: &str,
     status_type: StatusType,
-) -> Returns<Vec<StatusItem>> {
+) -> Result<Vec<StatusItem>> {
     scope_time!("get_index");
 
     let repo = utils::repo(repo_path)?;

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -1,5 +1,6 @@
 //! sync git api for fetching a status
 
+use crate::error::Returns;
 use crate::{error::Error, sync::utils};
 use git2::{Status, StatusOptions, StatusShow};
 use scopetime::scope_time;
@@ -67,7 +68,7 @@ impl Into<StatusShow> for StatusType {
 pub fn get_status(
     repo_path: &str,
     status_type: StatusType,
-) -> Result<Vec<StatusItem>, Error> {
+) -> Returns<Vec<StatusItem>> {
     scope_time!("get_index");
 
     let repo = utils::repo(repo_path)?;

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -92,11 +92,18 @@ pub fn get_status(
                 .path()
                 .and_then(|x| x.to_str())
                 .map(String::from)
-                .ok_or_else(|| Error::Generic("".to_string()))?,
-            None => e
-                .path()
-                .map(String::from)
-                .ok_or_else(|| Error::Generic("".to_string()))?,
+                .ok_or_else(|| {
+                    Error::Generic(
+                        "failed to get path to diff's new file."
+                            .to_string(),
+                    )
+                })?,
+            None => e.path().map(String::from).ok_or_else(|| {
+                Error::Generic(
+                    "failed to get the path to indexed file."
+                        .to_string(),
+                )
+            })?,
         };
 
         res.push(StatusItem {

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -1,5 +1,5 @@
 use super::utils::repo;
-use git2::Error;
+use crate::error::Returns;
 use scopetime::scope_time;
 use std::collections::HashMap;
 
@@ -7,12 +7,12 @@ use std::collections::HashMap;
 pub type Tags = HashMap<String, String>;
 
 /// returns `Tags` type filled with all tags found in repo
-pub fn get_tags(repo_path: &str) -> Result<Tags, Error> {
+pub fn get_tags(repo_path: &str) -> Returns<Tags> {
     scope_time!("get_tags");
 
     let mut res = Tags::new();
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
     for name in repo.tag_names(None)?.iter() {
         if let Some(name) = name {

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -1,5 +1,5 @@
 use super::utils::repo;
-use crate::error::Returns;
+use crate::error::Result;
 use scopetime::scope_time;
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 pub type Tags = HashMap<String, String>;
 
 /// returns `Tags` type filled with all tags found in repo
-pub fn get_tags(repo_path: &str) -> Returns<Tags> {
+pub fn get_tags(repo_path: &str) -> Result<Tags> {
     scope_time!("get_tags");
 
     let mut res = Tags::new();

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -146,18 +146,18 @@ mod tests {
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
 
         assert_eq!(
             stage_add_file(repo_path, file_path).unwrap(),
             true
         );
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
 
         commit(repo_path, "commit msg").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
     }
 
     #[test]
@@ -167,25 +167,25 @@ mod tests {
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
 
         File::create(&root.join(file_path))
             .unwrap()
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
+        assert_eq!(get_statuses(repo_path), (1, 0));
 
         assert_eq!(
             stage_add_file(repo_path, file_path).unwrap(),
             true
         );
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
+        assert_eq!(get_statuses(repo_path), (0, 1));
 
         commit(repo_path, "commit msg").unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
+        assert_eq!(get_statuses(repo_path), (0, 0));
     }
 
     #[test]
@@ -218,14 +218,14 @@ mod tests {
             .write_all(b"test file2 content")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (2, 0));
+        assert_eq!(get_statuses(repo_path), (2, 0));
 
         assert_eq!(
             stage_add_file(repo_path, file_path).unwrap(),
             true
         );
 
-        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
+        assert_eq!(get_statuses(repo_path), (1, 1));
     }
 
     #[test]

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -133,7 +133,7 @@ mod tests {
     };
     use std::{
         fs::{self, remove_file, File},
-        io::{Error, Write},
+        io::Write,
         path::Path,
     };
 
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_staging_folder() -> Result<(), Error> {
+    fn test_staging_folder() -> Returns<()> {
         let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -1,6 +1,6 @@
 //! sync git api (various methods)
 
-use crate::error::{Error, Returns};
+use crate::error::{Error, Result};
 use git2::{IndexAddOption, Oid, Repository, RepositoryOpenFlags};
 use scopetime::scope_time;
 use std::path::Path;
@@ -16,7 +16,7 @@ pub fn is_repo(repo_path: &str) -> bool {
 }
 
 ///
-pub fn repo(repo_path: &str) -> Returns<Repository> {
+pub fn repo(repo_path: &str) -> Result<Repository> {
     let repo = Repository::open_ext(
         repo_path,
         RepositoryOpenFlags::empty(),
@@ -31,7 +31,7 @@ pub fn repo(repo_path: &str) -> Returns<Repository> {
 }
 
 /// this does not run any git hooks
-pub fn commit(repo_path: &str, msg: &str) -> Returns<Oid> {
+pub fn commit(repo_path: &str, msg: &str) -> Result<Oid> {
     scope_time!("commit");
 
     let repo = repo(repo_path)?;
@@ -68,7 +68,7 @@ pub fn commit(repo_path: &str, msg: &str) -> Returns<Oid> {
 }
 
 /// add a file diff from workingdir to stage (will not add removed files see `stage_addremoved`)
-pub fn stage_add_file(repo_path: &str, path: &Path) -> Returns<bool> {
+pub fn stage_add_file(repo_path: &str, path: &Path) -> Result<bool> {
     scope_time!("stage_add_file");
 
     let repo = repo(repo_path)?;
@@ -84,10 +84,7 @@ pub fn stage_add_file(repo_path: &str, path: &Path) -> Returns<bool> {
 }
 
 /// like `stage_add_file` but uses a pattern to match/glob multiple files/folders
-pub fn stage_add_all(
-    repo_path: &str,
-    pattern: &str,
-) -> Returns<bool> {
+pub fn stage_add_all(repo_path: &str, pattern: &str) -> Result<bool> {
     scope_time!("stage_add_all");
 
     let repo = repo(repo_path)?;
@@ -109,7 +106,7 @@ pub fn stage_add_all(
 pub fn stage_addremoved(
     repo_path: &str,
     path: &Path,
-) -> Returns<bool> {
+) -> Result<bool> {
     scope_time!("stage_addremoved");
 
     let repo = repo(repo_path)?;
@@ -232,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_staging_folder() -> Returns<()> {
+    fn test_staging_folder() -> Result<()> {
         let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -1,8 +1,7 @@
 //! sync git api (various methods)
 
-use git2::{
-    Error, IndexAddOption, Oid, Repository, RepositoryOpenFlags,
-};
+use crate::error::{Error, Returns};
+use git2::{IndexAddOption, Oid, Repository, RepositoryOpenFlags};
 use scopetime::scope_time;
 use std::path::Path;
 
@@ -17,26 +16,25 @@ pub fn is_repo(repo_path: &str) -> bool {
 }
 
 ///
-pub fn repo(repo_path: &str) -> Repository {
+pub fn repo(repo_path: &str) -> Returns<Repository> {
     let repo = Repository::open_ext(
         repo_path,
         RepositoryOpenFlags::empty(),
         Vec::<&Path>::new(),
-    )
-    .unwrap();
+    )?;
 
     if repo.is_bare() {
         panic!("bare repo")
     }
 
-    repo
+    Ok(repo)
 }
 
 /// this does not run any git hooks
-pub fn commit(repo_path: &str, msg: &str) -> Result<Oid, Error> {
+pub fn commit(repo_path: &str, msg: &str) -> Returns<Oid> {
     scope_time!("commit");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
     let signature = repo.signature()?;
     let mut index = repo.index()?;
@@ -44,7 +42,14 @@ pub fn commit(repo_path: &str, msg: &str) -> Result<Oid, Error> {
     let tree = repo.find_tree(tree_id)?;
 
     let parents = if let Ok(reference) = repo.head() {
-        let parent = repo.find_commit(reference.target().unwrap())?;
+        let parent = repo.find_commit(
+            reference.target().ok_or_else(|| {
+                Error::Generic(
+                    "failed to get the target for reference"
+                        .to_string(),
+                )
+            })?,
+        )?;
         vec![parent]
     } else {
         Vec::new()
@@ -52,65 +57,71 @@ pub fn commit(repo_path: &str, msg: &str) -> Result<Oid, Error> {
 
     let parents = parents.iter().collect::<Vec<_>>();
 
-    repo.commit(
+    Ok(repo.commit(
         Some("HEAD"),
         &signature,
         &signature,
         msg,
         &tree,
         parents.as_slice(),
-    )
+    )?)
 }
 
 /// add a file diff from workingdir to stage (will not add removed files see `stage_addremoved`)
-pub fn stage_add_file(repo_path: &str, path: &Path) -> bool {
+pub fn stage_add_file(repo_path: &str, path: &Path) -> Returns<bool> {
     scope_time!("stage_add_file");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
-    let mut index = repo.index().unwrap();
+    let mut index = repo.index()?;
 
     if index.add_path(path).is_ok() {
-        index.write().unwrap();
-        return true;
+        index.write()?;
+        return Ok(true);
     }
 
-    false
+    Ok(false)
 }
 
 /// like `stage_add_file` but uses a pattern to match/glob multiple files/folders
-pub fn stage_add_all(repo_path: &str, pattern: &str) -> bool {
+pub fn stage_add_all(
+    repo_path: &str,
+    pattern: &str,
+) -> Returns<bool> {
     scope_time!("stage_add_all");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
-    let mut index = repo.index().unwrap();
+    let mut index = repo.index()?;
 
     if index
         .add_all(vec![pattern], IndexAddOption::DEFAULT, None)
         .is_ok()
     {
-        index.write().unwrap();
-        return true;
+        index.write()?;
+        return Ok(true);
     }
 
-    false
+    Ok(false)
 }
 
 /// stage a removed file
-pub fn stage_addremoved(repo_path: &str, path: &Path) -> bool {
+pub fn stage_addremoved(
+    repo_path: &str,
+    path: &Path,
+) -> Returns<bool> {
     scope_time!("stage_addremoved");
 
-    let repo = repo(repo_path);
+    let repo = repo(repo_path)?;
 
-    let mut index = repo.index().unwrap();
+    let mut index = repo.index()?;
 
     if index.remove_path(path).is_ok() {
-        index.write().unwrap();
-        return true;
+        index.write()?;
+        return Ok(true);
     }
 
-    false
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -129,7 +140,7 @@ mod tests {
     #[test]
     fn test_commit() {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
@@ -138,56 +149,65 @@ mod tests {
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path), (1, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
 
-        assert_eq!(stage_add_file(repo_path, file_path), true);
+        assert_eq!(
+            stage_add_file(repo_path, file_path).unwrap(),
+            true
+        );
 
-        assert_eq!(get_statuses(repo_path), (0, 1));
+        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
 
         commit(repo_path, "commit msg").unwrap();
 
-        assert_eq!(get_statuses(repo_path), (0, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
     }
 
     #[test]
     fn test_commit_in_empty_repo() {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init_empty();
+        let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        assert_eq!(get_statuses(repo_path), (0, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
 
         File::create(&root.join(file_path))
             .unwrap()
             .write_all(b"test\nfoo")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path), (1, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (1, 0));
 
-        assert_eq!(stage_add_file(repo_path, file_path), true);
+        assert_eq!(
+            stage_add_file(repo_path, file_path).unwrap(),
+            true
+        );
 
-        assert_eq!(get_statuses(repo_path), (0, 1));
+        assert_eq!(get_statuses(repo_path).unwrap(), (0, 1));
 
         commit(repo_path, "commit msg").unwrap();
 
-        assert_eq!(get_statuses(repo_path), (0, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (0, 0));
     }
 
     #[test]
     fn test_stage_add_smoke() {
         let file_path = Path::new("foo");
-        let (_td, repo) = repo_init_empty();
+        let (_td, repo) = repo_init_empty().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        assert_eq!(stage_add_file(repo_path, file_path), false);
+        assert_eq!(
+            stage_add_file(repo_path, file_path).unwrap(),
+            false
+        );
     }
 
     #[test]
     fn test_staging_one_file() {
         let file_path = Path::new("file1.txt");
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
@@ -201,21 +221,24 @@ mod tests {
             .write_all(b"test file2 content")
             .unwrap();
 
-        assert_eq!(get_statuses(repo_path), (2, 0));
+        assert_eq!(get_statuses(repo_path).unwrap(), (2, 0));
 
-        assert_eq!(stage_add_file(repo_path, file_path), true);
+        assert_eq!(
+            stage_add_file(repo_path, file_path).unwrap(),
+            true
+        );
 
-        assert_eq!(get_statuses(repo_path), (1, 1));
+        assert_eq!(get_statuses(repo_path).unwrap(), (1, 1));
     }
 
     #[test]
     fn test_staging_folder() -> Result<(), Error> {
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
         let status_count = |s: StatusType| -> usize {
-            get_status(repo_path, s).len()
+            get_status(repo_path, s).unwrap().len()
         };
 
         fs::create_dir_all(&root.join("a/d"))?;
@@ -228,7 +251,7 @@ mod tests {
 
         assert_eq!(status_count(StatusType::WorkingDir), 3);
 
-        assert_eq!(stage_add_all(repo_path, "a/d"), true);
+        assert_eq!(stage_add_all(repo_path, "a/d").unwrap(), true);
 
         assert_eq!(status_count(StatusType::WorkingDir), 1);
         assert_eq!(status_count(StatusType::Stage), 2);
@@ -239,12 +262,12 @@ mod tests {
     #[test]
     fn test_staging_deleted_file() {
         let file_path = Path::new("file1.txt");
-        let (_td, repo) = repo_init();
+        let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
         let status_count = |s: StatusType| -> usize {
-            get_status(repo_path, s).len()
+            get_status(repo_path, s).unwrap().len()
         };
 
         let full_path = &root.join(file_path);
@@ -254,7 +277,10 @@ mod tests {
             .write_all(b"test file1 content")
             .unwrap();
 
-        assert_eq!(stage_add_file(repo_path, file_path), true);
+        assert_eq!(
+            stage_add_file(repo_path, file_path).unwrap(),
+            true
+        );
 
         commit(repo_path, "commit msg").unwrap();
 
@@ -264,7 +290,10 @@ mod tests {
         // deleted file in diff now
         assert_eq!(status_count(StatusType::WorkingDir), 1);
 
-        assert_eq!(stage_addremoved(repo_path, file_path), true);
+        assert_eq!(
+            stage_addremoved(repo_path, file_path).unwrap(),
+            true
+        );
 
         assert_eq!(status_count(StatusType::WorkingDir), 0);
         assert_eq!(status_count(StatusType::Stage), 1);

--- a/src/app.rs
+++ b/src/app.rs
@@ -225,12 +225,10 @@ impl App {
                     {
                         flags.insert(NeedsUpdate::ALL);
                     }
-                } else if sync::reset_workdir_file(
+                } else if let Ok(()) = sync::reset_workdir_file(
                     CWD,
                     reset_item.path.as_str(),
-                )
-                .unwrap()
-                {
+                ) {
                     flags.insert(NeedsUpdate::ALL);
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,12 +217,10 @@ impl App {
         match ev {
             InternalEvent::ResetItem(reset_item) => {
                 if reset_item.is_folder {
-                    if sync::reset_workdir_folder(
+                    if let Ok(()) = sync::reset_workdir_folder(
                         CWD,
                         reset_item.path.as_str(),
-                    )
-                    .unwrap()
-                    {
+                    ) {
                         flags.insert(NeedsUpdate::ALL);
                     }
                 } else if let Ok(()) = sync::reset_workdir_file(

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,16 +217,20 @@ impl App {
         match ev {
             InternalEvent::ResetItem(reset_item) => {
                 if reset_item.is_folder {
-                    if let Ok(()) = sync::reset_workdir_folder(
+                    if sync::reset_workdir_folder(
                         CWD,
                         reset_item.path.as_str(),
-                    ) {
+                    )
+                    .is_ok()
+                    {
                         flags.insert(NeedsUpdate::ALL);
                     }
-                } else if let Ok(()) = sync::reset_workdir_file(
+                } else if sync::reset_workdir_file(
                     CWD,
                     reset_item.path.as_str(),
-                ) {
+                )
+                .is_ok()
+                {
                     flags.insert(NeedsUpdate::ALL);
                 }
             }
@@ -244,8 +248,8 @@ impl App {
                         {
                             flags.insert(NeedsUpdate::ALL);
                         }
-                    } else if let Ok(()) =
-                        sync::stage_hunk(CWD, path, hash)
+                    } else if sync::stage_hunk(CWD, path, hash)
+                        .is_ok()
                     {
                         flags.insert(NeedsUpdate::ALL);
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,13 +220,17 @@ impl App {
                     if sync::reset_workdir_folder(
                         CWD,
                         reset_item.path.as_str(),
-                    ) {
+                    )
+                    .unwrap()
+                    {
                         flags.insert(NeedsUpdate::ALL);
                     }
                 } else if sync::reset_workdir_file(
                     CWD,
                     reset_item.path.as_str(),
-                ) {
+                )
+                .unwrap()
+                {
                     flags.insert(NeedsUpdate::ALL);
                 }
             }
@@ -239,10 +243,14 @@ impl App {
                     self.status_tab.selected_path()
                 {
                     if is_stage {
-                        if sync::unstage_hunk(CWD, path, hash) {
+                        if sync::unstage_hunk(CWD, path, hash)
+                            .unwrap()
+                        {
                             flags.insert(NeedsUpdate::ALL);
                         }
-                    } else if sync::stage_hunk(CWD, path, hash) {
+                    } else if sync::stage_hunk(CWD, path, hash)
+                        .unwrap()
+                    {
                         flags.insert(NeedsUpdate::ALL);
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -248,8 +248,8 @@ impl App {
                         {
                             flags.insert(NeedsUpdate::ALL);
                         }
-                    } else if sync::stage_hunk(CWD, path, hash)
-                        .unwrap()
+                    } else if let Ok(()) =
+                        sync::stage_hunk(CWD, path, hash)
                     {
                         flags.insert(NeedsUpdate::ALL);
                     }

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -126,7 +126,8 @@ impl ChangesComponent {
             } else {
                 let path =
                     Path::new(tree_item.info.full_path.as_str());
-                return sync::reset_stage(CWD, path).unwrap();
+                sync::reset_stage(CWD, path).unwrap();
+                return true;
             }
         }
 

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -109,8 +109,10 @@ impl ChangesComponent {
                         return match status {
                             StatusItemType::Deleted => {
                                 sync::stage_addremoved(CWD, path)
+                                    .unwrap()
                             }
-                            _ => sync::stage_add_file(CWD, path),
+                            _ => sync::stage_add_file(CWD, path)
+                                .unwrap(),
                         };
                     }
                 } else {
@@ -118,12 +120,13 @@ impl ChangesComponent {
                     return sync::stage_add_all(
                         CWD,
                         tree_item.info.full_path.as_str(),
-                    );
+                    )
+                    .unwrap();
                 }
             } else {
                 let path =
                     Path::new(tree_item.info.full_path.as_str());
-                return sync::reset_stage(CWD, path);
+                return sync::reset_stage(CWD, path).unwrap();
             }
         }
 

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -135,7 +135,9 @@ impl CommitComponent {
         }
 
         sync::commit(CWD, &self.msg).unwrap();
-        if let HookResult::NotOk(e) = sync::hooks_post_commit(CWD) {
+        if let HookResult::NotOk(e) =
+            sync::hooks_post_commit(CWD).unwrap()
+        {
             error!("post-commit hook error: {}", e);
             self.queue.borrow_mut().push_back(
                 InternalEvent::ShowMsg(format!(

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -122,7 +122,7 @@ impl CommitComponent {
 
     fn commit(&mut self) {
         if let HookResult::NotOk(e) =
-            sync::hooks_commit_msg(CWD, &mut self.msg)
+            sync::hooks_commit_msg(CWD, &mut self.msg).unwrap()
         {
             error!("commit-msg hook error: {}", e);
             self.queue.borrow_mut().push_back(

--- a/src/tabs/revlog/mod.rs
+++ b/src/tabs/revlog/mod.rs
@@ -80,7 +80,8 @@ impl Revlog {
 
     ///
     pub fn update(&mut self) {
-        self.selection_max = self.git_log.count().saturating_sub(1);
+        self.selection_max =
+            self.git_log.count().unwrap().saturating_sub(1);
 
         if self.items.needs_data(self.selection, self.selection_max) {
             self.fetch_commits();
@@ -96,7 +97,7 @@ impl Revlog {
 
         let commits = sync::get_commits_info(
             CWD,
-            &self.git_log.get_slice(want_min, SLICE_SIZE),
+            &self.git_log.get_slice(want_min, SLICE_SIZE).unwrap(),
         );
 
         if let Ok(commits) = commits {
@@ -343,7 +344,7 @@ impl Component for Revlog {
 
         if !self.first_open_done {
             self.first_open_done = true;
-            self.git_log.fetch();
+            self.git_log.fetch().unwrap();
         }
     }
 }

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -183,7 +183,7 @@ impl Status {
 
     ///
     pub fn update(&mut self) {
-        self.git_diff.refresh();
+        self.git_diff.refresh().unwrap();
         self.git_status.fetch(current_tick().unwrap()).unwrap();
     }
 
@@ -226,7 +226,8 @@ impl Status {
                 }
             } else {
                 // we dont show the right diff right now, so we need to request
-                if let Some(diff) = self.git_diff.request(diff_params)
+                if let Some(diff) =
+                    self.git_diff.request(diff_params).unwrap()
                 {
                     self.diff.update(path, is_stage, diff);
                 } else {

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -184,7 +184,7 @@ impl Status {
     ///
     pub fn update(&mut self) {
         self.git_diff.refresh();
-        self.git_status.fetch(current_tick());
+        self.git_status.fetch(current_tick().unwrap()).unwrap();
     }
 
     ///
@@ -202,7 +202,7 @@ impl Status {
     }
 
     fn update_status(&mut self) {
-        let status = self.git_status.last();
+        let status = self.git_status.last().unwrap();
         self.index.update(&status.stage);
         self.index_wd.update(&status.work_dir);
 
@@ -217,7 +217,9 @@ impl Status {
             if self.diff.current() == (path.clone(), is_stage) {
                 // we are already showing a diff of the right file
                 // maybe the diff changed (outside file change)
-                if let Some((params, last)) = self.git_diff.last() {
+                if let Some((params, last)) =
+                    self.git_diff.last().unwrap()
+                {
                     if params == diff_params {
                         self.diff.update(path, is_stage, last);
                     }

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -184,7 +184,7 @@ impl Status {
     ///
     pub fn update(&mut self) {
         self.git_diff.refresh().unwrap();
-        self.git_status.fetch(current_tick().unwrap()).unwrap();
+        self.git_status.fetch(current_tick()).unwrap();
     }
 
     ///


### PR DESCRIPTION
This pull request tries to replace `unwrap()` calls in asyncgit with error handling via a custom error type defined in `error.rs`. changes has been split into separate commits.

* Added a new error type in `error.rs` file (dependent on `thiserror` crate)
* Added a `Result<T>` type alias for `Result<T,Error>`
* Removed all `unwrap()` calls from `asyncgit` lib except a few in callbacks that I don't know how to deal with for the moment.

I have not touched `unwrap()` inside tests as I am not sure yet if we want to remove them too. I assume they are alright in tests. I will continue to change other files when I get feedback about the code. 
