### PR TITLE
Implement git hook support on windows- closes 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - introduced proper changelog
-- hook support on windows 
+- hook support on windows ([#14](https://github.com/extrawurst/gitui/issues/14))
 
 ### Changed
 - show longer commit messages in log view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - introduced proper changelog
+- hook support on windows 
 
 ### Changed
 - show longer commit messages in log view

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,6 @@ version = "0.2.3"
 dependencies = [
  "crossbeam-channel",
  "git2",
- "is_executable",
  "log",
  "rayon-core",
  "scopetime",
@@ -333,15 +332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "is_executable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577"
-dependencies = [
- "winapi 0.3.8",
 ]
 
 [[package]]

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -15,7 +15,6 @@ git2 = { version = "0.13.5", default-features = false }
 rayon-core = "1.7"
 crossbeam-channel = "0.4"
 log = "0.4"
-is_executable = "0.1"
 scopetime = { path = "../scopetime", version = "0.1" }
 thiserror = "1.0"
 

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -17,5 +17,7 @@ crossbeam-channel = "0.4"
 log = "0.4"
 is_executable = "0.1"
 scopetime = { path = "../scopetime", version = "0.1" }
-tempfile = "3.1"
 thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3.1"

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -232,12 +232,15 @@ fn is_executable(_: PathBuf) -> bool {
 /// `/mnt/c/Users/Guest` so that scripts on windows file system can be used from bash.
 fn map_windows_path_for_bash(path: &str) -> String {
     let mut chars = path.chars();
-    match (chars.next(), chars.next(), chars.as_str()) {
+    let mapped = match (chars.next(), chars.next(), chars.as_str()) {
         (Some(drive), Some(':'), rest) => format!(
             "/mnt/{}{}",
             drive.to_lowercase(),
             rest.replace('\\', "/")
         ),
         _ => path.to_string(),
-    }
+    };
+
+    print!("mapped windows path {:?} to {:?}", path, mapped);
+    mapped
 }

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -212,8 +212,14 @@ exit 0
 
 #[cfg(not(windows))]
 fn is_executable(path: PathBuf) -> bool {
-    use is_executable::IsExecutable;
-    path.is_executable()
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = match path.metadata() {
+        Ok(metadata) => metadata,
+        Err(_) => return false,
+    };
+
+    let permissions = metadata.permissions();
+    permissions.mode() & 0o111 != 0
 }
 
 #[cfg(windows)]

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -234,7 +234,7 @@ fn map_windows_path_for_bash(path: &str) -> String {
     let mut chars = path.chars();
     match (chars.next(), chars.next(), chars.as_str()) {
         (Some(drive), Some(':'), rest) => format!(
-            "/mnt/{}/{}",
+            "/mnt/{}{}",
             drive.to_lowercase(),
             rest.replace('\\', "/")
         ),

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -95,8 +95,8 @@ fn run_hook(
     if output.status.success() {
         HookResult::Ok
     } else {
-        let err = String::from_utf8(output.stderr).unwrap();
-        let out = String::from_utf8(output.stdout).unwrap();
+        let err = String::from_utf8_lossy(&output.stderr);
+        let out = String::from_utf8_lossy(&output.stdout);
         let formatted = format!("{}{}", out, err);
 
         HookResult::NotOk(formatted)


### PR DESCRIPTION
This PR modifies the hook support to enable hook management on windows platform. in order for the code to work on windows I have made sure:
1. we don't try to chmod script files on windows (not needed / not supported)
2. we don't verify if scripts are executable on windows.
3. we use relative path for temp files to prevent path mapping issues for bash on windows.
