### PR TITLE
chore: Add LICENSE file into the sub-crates

### DIFF
--- a/asyncgit/LICENSE.md
+++ b/asyncgit/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/scopetime/LICENSE.md
+++ b/scopetime/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
Those are released separately on crates.io and they do not contain
LICENSE file now that is required when packaging them in Linux
distributions.

Signed-off-by: Igor Raits <i.gnatenko.brain@gmail.com>