### PR TITLE
README: Add Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,21 @@ Over the last 2 years my go-to GUI tool for this was [fork](https://git-fork.com
 
 For the time being this product is considered alpha and **not** production ready.
 
-## release binaries
+## Fedora
 
-see [releases](https://github.com/extrawurst/gitui/releases)
+```sh
+sudo dnf install gitui
+```
 
 ## homebrew (macos)
 
 ```
 brew install extrawurst/tap/gitui
 ```
+
+## release binaries
+
+see [releases](https://github.com/extrawurst/gitui/releases)
 
 ## install from source
 


### PR DESCRIPTION
P.S> It will be available only in F32+ and should be pushed there within a few days: https://bodhi.fedoraproject.org/updates/FEDORA-2020-d3770ba5a9