### PR TITLE
fixed an issue with tab reverse on windows.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,8 @@ impl App {
                     self.toggle_tabs(false)?;
                     NeedsUpdate::COMMANDS
                 }
-                keys::TAB_TOGGLE_REVERSE => {
+                keys::TAB_TOGGLE_REVERSE
+                | keys::TAB_TOGGLE_REVERSE_WINDOWS => {
                     self.toggle_tabs(true)?;
                     NeedsUpdate::COMMANDS
                 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -20,6 +20,7 @@ pub const TAB_3: KeyEvent = no_mod(KeyCode::Char('3'));
 pub const TAB_4: KeyEvent = no_mod(KeyCode::Char('4'));
 pub const TAB_TOGGLE: KeyEvent = no_mod(KeyCode::Tab);
 pub const TAB_TOGGLE_REVERSE: KeyEvent = no_mod(KeyCode::BackTab);
+pub const TAB_TOGGLE_REVERSE_WINDOWS: KeyEvent = with_mod(KeyCode::BackTab, KeyModifiers::SHIFT);
 pub const FOCUS_WORKDIR: KeyEvent = no_mod(KeyCode::Char('w'));
 pub const FOCUS_STAGE: KeyEvent = no_mod(KeyCode::Char('s'));
 pub const FOCUS_RIGHT: KeyEvent = no_mod(KeyCode::Right);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -20,7 +20,8 @@ pub const TAB_3: KeyEvent = no_mod(KeyCode::Char('3'));
 pub const TAB_4: KeyEvent = no_mod(KeyCode::Char('4'));
 pub const TAB_TOGGLE: KeyEvent = no_mod(KeyCode::Tab);
 pub const TAB_TOGGLE_REVERSE: KeyEvent = no_mod(KeyCode::BackTab);
-pub const TAB_TOGGLE_REVERSE_WINDOWS: KeyEvent = with_mod(KeyCode::BackTab, KeyModifiers::SHIFT);
+pub const TAB_TOGGLE_REVERSE_WINDOWS: KeyEvent =
+    with_mod(KeyCode::BackTab, KeyModifiers::SHIFT);
 pub const FOCUS_WORKDIR: KeyEvent = no_mod(KeyCode::Char('w'));
 pub const FOCUS_STAGE: KeyEvent = no_mod(KeyCode::Char('s'));
 pub const FOCUS_RIGHT: KeyEvent = no_mod(KeyCode::Right);


### PR DESCRIPTION
This PR fixes a small but annoying bug on windows that prevents `SHIFT + TAB` to select the tabs in revers order. The bug is caused by the difference in interpretation of modifiers either in `crossterm` or lower levels. 

for non windows platforms the `SHIFT + TAB` key generates `KeyCode::BackTab` without any modifiers while on windows the same produces `KeyCode::BackTab` + Shift modifier. 

I am not sure the issue should be addressed in `gitui` but here is the fix.

