### PR TITLE
Multiline commit message

### DIFF
--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -236,6 +236,11 @@ impl Component for ChangesComponent {
                 some_selection,
                 self.focused(),
             ));
+            out.push(CommandInfo::new(
+                commands::COMMIT_OPEN_EDITOR,
+                !self.is_empty(),
+                self.focused() || force_all,
+            ));
             out.push(
                 CommandInfo::new(
                     commands::COMMIT_OPEN,
@@ -264,6 +269,15 @@ impl Component for ChangesComponent {
                         self.queue
                             .borrow_mut()
                             .push_back(InternalEvent::OpenCommit);
+                        Ok(true)
+                    }
+                    keys::OPEN_COMMIT_EDITOR
+                        if !self.is_working_dir
+                            && !self.is_empty() =>
+                    {
+                        self.queue
+                            .borrow_mut()
+                            .push_back(InternalEvent::SuspendPolling);
                         Ok(true)
                     }
                     keys::STATUS_STAGE_FILE => {

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -2,18 +2,24 @@ use super::{
     textinput::TextInputComponent, visibility_blocking,
     CommandBlocking, CommandInfo, Component, DrawableComponent,
 };
+use crate::strings::COMMIT_EDITOR_MSG;
 use crate::{
-    keys,
+    get_app_config_path, keys,
     queue::{InternalEvent, NeedsUpdate, Queue},
     strings,
     ui::style::SharedTheme,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use asyncgit::{
     sync::{self, CommitId},
     CWD,
 };
 use crossterm::event::Event;
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::Command;
 use strings::commands;
 use sync::HookResult;
 use tui::{backend::Backend, layout::Rect, Frame};
@@ -121,8 +127,65 @@ impl CommitComponent {
         }
     }
 
+    pub fn show_editor(&mut self) -> Result<()> {
+        const COMMIT_MSG_FILE_NAME: &str = "COMMITMSG_EDITOR";
+        let mut config_path: PathBuf = get_app_config_path()?;
+        config_path.push(COMMIT_MSG_FILE_NAME);
+
+        let mut file = File::create(&config_path)?;
+        file.write_all(COMMIT_EDITOR_MSG.as_bytes())?;
+        drop(file);
+
+        let mut editor = env::var("GIT_EDTIOR")
+            .ok()
+            .or_else(|| env::var("VISUAL").ok())
+            .or_else(|| env::var("EDITOR").ok())
+            .unwrap_or_else(|| String::from("vi"));
+        editor
+            .push_str(&format!(" {}", config_path.to_string_lossy()));
+
+        let mut editor = editor.split_whitespace();
+
+        let command = editor.next().ok_or_else(|| {
+            anyhow!("unable to read editor command")
+        })?;
+
+        Command::new(command)
+            .args(editor)
+            .status()
+            .map_err(|e| anyhow!("\"{}\": {}", command, e))?;
+
+        let mut message = String::new();
+
+        let mut file = File::open(&config_path)?;
+        file.read_to_string(&mut message)?;
+        drop(file);
+        std::fs::remove_file(&config_path)?;
+
+        let message: String = message
+            .lines()
+            .flat_map(|l| {
+                if l.starts_with('#') {
+                    vec![]
+                } else {
+                    vec![l, "\n"]
+                }
+            })
+            .collect();
+
+        if !message.chars().all(char::is_whitespace) {
+            return self.commit_msg(message);
+        }
+
+        Ok(())
+    }
+
     fn commit(&mut self) -> Result<()> {
-        let mut msg = self.input.get_text().clone();
+        self.commit_msg(self.input.get_text().clone())
+    }
+
+    fn commit_msg(&mut self, msg: String) -> Result<()> {
+        let mut msg = msg;
         if let HookResult::NotOk(e) =
             sync::hooks_commit_msg(CWD, &mut msg)?
         {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -32,6 +32,8 @@ pub const EXIT: KeyEvent =
 pub const EXIT_POPUP: KeyEvent = no_mod(KeyCode::Esc);
 pub const CLOSE_MSG: KeyEvent = no_mod(KeyCode::Enter);
 pub const OPEN_COMMIT: KeyEvent = no_mod(KeyCode::Char('c'));
+pub const OPEN_COMMIT_EDITOR: KeyEvent =
+    with_mod(KeyCode::Char('C'), KeyModifiers::SHIFT);
 pub const OPEN_HELP: KeyEvent = no_mod(KeyCode::Char('h'));
 pub const MOVE_LEFT: KeyEvent = no_mod(KeyCode::Left);
 pub const MOVE_RIGHT: KeyEvent = no_mod(KeyCode::Right);

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,8 +127,7 @@ fn main() -> Result<()> {
                 }
             }
 
-            //TODO: disable input polling while external editor open
-            input.set_polling(!app.any_work_pending());
+            input.set_polling(app.set_polling());
 
             if needs_draw {
                 draw(&mut terminal, &app)?;
@@ -164,6 +163,10 @@ fn draw<B: Backend>(
     terminal: &mut Terminal<B>,
     app: &App,
 ) -> io::Result<()> {
+    if app.requires_redraw() {
+        terminal.resize(terminal.size()?)?;
+    }
+
     terminal.draw(|mut f| {
         if let Err(e) = app.draw(&mut f) {
             log::error!("failed to draw: {:?}", e)

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -48,6 +48,8 @@ pub enum InternalEvent {
     TabSwitch,
     ///
     InspectCommit(CommitId),
+    ///
+    SuspendPolling,
 }
 
 ///

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -14,6 +14,10 @@ pub static MSG_TITLE_ERROR: &str = "Error";
 pub static COMMIT_TITLE: &str = "Commit";
 pub static COMMIT_TITLE_AMEND: &str = "Commit (Amend)";
 pub static COMMIT_MSG: &str = "type commit message..";
+pub static COMMIT_EDITOR_MSG: &str = r##"
+# Enter your commit message
+# Lines starting with '#' will be ignored
+# Empty commit message will abort the commit"##;
 pub static STASH_POPUP_TITLE: &str = "Stash";
 pub static STASH_POPUP_MSG: &str = "type name (optional)";
 pub static CONFIRM_TITLE_RESET: &str = "Reset";
@@ -147,6 +151,12 @@ pub mod commands {
     pub static COMMIT_OPEN: CommandText = CommandText::new(
         "Commit [c]",
         "open commit popup (available in non-empty stage)",
+        CMD_GROUP_COMMIT,
+    );
+    ///
+    pub static COMMIT_OPEN_EDITOR: CommandText = CommandText::new(
+        "Commit editor [C]",
+        "open commit editor (available in non-empty stage)",
         CMD_GROUP_COMMIT,
     );
     ///


### PR DESCRIPTION
This intends to implement a way to enter multi-line commit messages. Ref #46 

This adds support for opening a file in an external editor, writing the commit message and saving it to the file, and the use the entered message as the commit message. This works in much the same way git does by default.

This PR at, in it's current state is not ready for merging. There are a few issues which will need to be resolved first and I hope to get some feedback on how to solve these. They are as follows:

## gitui will capture key stroke events and prevent them from being passed on to the editor

> This is only an issue when the editor is opened inside the terminal (such as _vim_), and not as an external GUI application (such as _VS Code_).

The background thread spawned by gitui will continue to run and capture key strokes while the external editor is in use. I see mainly three ways of solving this:

1. Add a way to make the background thread skip polling. This is how it's currently solved, but it's not working completely. When launching the editor, the "poller" will run another time, poll for 2 seconds and then stop polling for as long as the editor is open. If you type inside of those 2 first seconds, the key stroke is going to be captured by gitui and will not be passed on to the editor.
1. Lower the polling duration from 2 seconds. It's not desirable, but it could work.
1. Add a way to kill the spawned thread when launching the editor and then spawning it again once the editor exits.

## gitui needs to redraw everything when returning from editor

Because both gitui and vim uses the _alternative screen_ feature, gitui will need to redraw it's whole UI when returning from the editor as the incremental updates tui usually does means some parts of the UI never gets set to it's correct state. If a part of gitui never changes, the "regular" shell underneath will "show through".

It seems the only way to make tui redraw the whole screen is to both clear the current screen, but also reset the stored previous buffer. Resetting all the stored buffers is something tui doesn't allow consumers to do (as far as I can see), except for one instance: `resize`. This function will reset all the internal buffers and force a redraw of the whole screen. `resize` is currently used to enforce a redraw. (Might be worth considering opening an issue upstream to enable forcing a complete redraw of the UI).

A big downside with current implementation of this is that it introduces a mutable static variable, which means it also introduces `unsafe` (the _forbid unsafe_ directive has been commented out). This might be worked around by using `lazy_static`, but I haven't investigated that in any way.

The reason for the mutable static is the introduction of a new channel, global to the app, which let's different parts of the app send command requests to the main loop. In this case it's a request for a full redraw of the UI, but this could be useful for other commands later (but with a better implementation of how to share the _sender_).

---

This PR is not based on a very recent commit because _master_ would not build on stable for me, so I kept it at 0.5.0-ish. I will rebase it at a later point.