### PR TITLE
Move config directory

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -4,7 +4,11 @@ default on light terminal:
 ![](assets/light-theme.png)
 
 to change the colors of the program you have to modify `theme.ron` file
-[Ron format](https://github.com/ron-rs/ron) located at config path (same as [log path](README.md#diagnostics)).
+[Ron format](https://github.com/ron-rs/ron) located at config path. The path differs depending on the operating system:
+
+* `$HOME/Library/Preferences/gitui/theme.ron` (mac)
+* `$XDG_CONFIG_HOME/gitui/theme.ron` (linux using XDG)
+* `$HOME/.config/gitui/theme.ron` (linux)
 
 Valid colors can be found in [ColorDef](./src/ui/style.rs#ColorDef) struct. note that rgb colors might not be supported 
 in every terminal.


### PR DESCRIPTION
This changes the config directory from the `dirs::cache_dir` to `dirs::config_dir`. It does however keep the cache directory as the default logging directory, as it seems a better fit.

It also adds a function, `migrate_config`, which is called at startup to move directory entries inside the "old" config directory to the "new" one (but it skips moving log files). The intention is that this function can be removed after a few releases when the likelihood of someone upgrading from 0.6.0 or earlier is fairly small.

Fixes #98