### PR TITLE
Add CD action to update Homebrew formula

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-  
+
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       run: |
         rustup target add x86_64-unknown-linux-musl
         sudo apt-get -qq install musl-tools
-      
+
     - name: Build Release Mac
       if: matrix.os == 'macos-latest'
       run: make release-mac
@@ -71,9 +71,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Bump Brew
+    - name: Bump extrawurst/homebrew-tap formula
       if: matrix.os == 'macos-latest'
-      env: 
+      env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.BREW_TOKEN }}
       run: |
         brew tap extrawurst/tap
@@ -81,3 +81,11 @@ jobs:
         --sha256=${{ steps.shasum.outputs.sha }} \
         --url="https://github.com/extrawurst/gitui/releases/download/${{ steps.get_version.outputs.version }}/gitui-mac.tar.gz" \
         extrawurst/tap/gitui
+
+    - name: Bump homebrew-core formula
+      uses: mislav/bump-homebrew-formula-action@v1
+      if: "matrix.os == 'macos-latest' && !contains(github.ref, '-')" # skip prereleases
+      env:
+        COMMITTER_TOKEN: ${{ secrets.BREW_TOKEN }}
+      with:
+        formula-name: gitui


### PR DESCRIPTION
Uses https://github.com/mislav/bump-homebrew-formula-action for updating Homebrew core formula.