### PR TITLE
Do not mix number and letters here

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 # Benchmarks
 
-For a [RustBerlin meetup presentation](https://youtu.be/rpilJV-eIVw?t=5334) ([slides](https://github.com/extrawurst/gitui-presentation)) I compared `lazygit`,`tig` and `gitui` by parsing the entire Linux git repository (which contains over 900 thousand commits):
+For a [RustBerlin meetup presentation](https://youtu.be/rpilJV-eIVw?t=5334) ([slides](https://github.com/extrawurst/gitui-presentation)) I compared `lazygit`,`tig` and `gitui` by parsing the entire Linux git repository (which contains over 900,000 commits):
 
 |           | Time        | Memory (GB) | Binary (MB) | Freezes   | Crashes   |
 | --------- | ----------- | ----------- | ----------- | --------- | --------- |


### PR DESCRIPTION
Fixes the README to not use a mix of numbers and letters,
but either "Ninehundretthousand" or "900,000" here,
with this patch the latter.