### PR TITLE
fix for utf8 encoded arrows in 'help command' window

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -90,7 +90,7 @@ pub mod commands {
     );
     ///
     pub static DIFF_HOME_END: CommandText = CommandText::new(
-        "Jump up/down [home,end,\u{11014}up,\u{2191}down]",
+        "Jump up/down [home,end,\u{2191} up,\u{2193} down]",
         "scroll to top or bottom of diff",
         CMD_GROUP_DIFF,
     );


### PR DESCRIPTION
Hi,
first of all, I really like this project.

The 'arrow up' was displayed incorrectly in the 'help command window'. (see: attached screenshot)
Working on a relatively clean Ubuntu 20.04.  

![jumpupdown](https://user-images.githubusercontent.com/10914103/85123701-01b0f900-b229-11ea-90bc-1d91cc0f051a.png)
