### PR TITLE
Add command to edit selected file in editor

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -48,6 +48,7 @@ pub const SHIFT_UP: KeyEvent =
 pub const SHIFT_DOWN: KeyEvent =
     with_mod(KeyCode::Down, KeyModifiers::SHIFT);
 pub const ENTER: KeyEvent = no_mod(KeyCode::Enter);
+pub const EDIT_FILE: KeyEvent = no_mod(KeyCode::Char('e'));
 pub const STATUS_STAGE_FILE: KeyEvent = no_mod(KeyCode::Enter);
 pub const STATUS_STAGE_ALL: KeyEvent = no_mod(KeyCode::Char('a'));
 pub const STATUS_RESET_FILE: KeyEvent =

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,12 +45,13 @@ use scopeguard::defer;
 use scopetime::scope_time;
 use simplelog::{Config, LevelFilter, WriteLogger};
 use spinner::Spinner;
+use std::process::Command;
 use std::{
     env, fs,
     fs::File,
     io::{self, Write},
     panic,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process,
     time::{Duration, Instant},
 };
@@ -239,6 +240,28 @@ fn migrate_config() -> Result<()> {
         config_path.push(entry.file_name());
         fs::rename(entry.path(), config_path)?;
     }
+
+    Ok(())
+}
+
+fn open_file_in_editor(path: &Path) -> Result<()> {
+    let mut editor = env::var("GIT_EDITOR")
+        .ok()
+        .or_else(|| env::var("VISUAL").ok())
+        .or_else(|| env::var("EDITOR").ok())
+        .unwrap_or_else(|| String::from("vi"));
+    editor.push_str(&format!(" {}", path.to_string_lossy()));
+
+    let mut editor = editor.split_whitespace();
+
+    let command = editor
+        .next()
+        .ok_or_else(|| anyhow!("unable to read editor command"))?;
+
+    Command::new(command)
+        .args(editor)
+        .status()
+        .map_err(|e| anyhow!("\"{}\": {}", command, e))?;
 
     Ok(())
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,6 +1,7 @@
 use crate::tabs::StashingOptions;
 use asyncgit::sync::CommitId;
 use bitflags::bitflags;
+use std::path::PathBuf;
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 bitflags! {
@@ -49,9 +50,7 @@ pub enum InternalEvent {
     ///
     InspectCommit(CommitId),
     ///
-    //TODO: make this a generic OpenExternalEditor to also use it for other places
-    //(see https://github.com/extrawurst/gitui/issues/166)
-    SuspendPolling,
+    OpenExternalEditor(Option<Box<PathBuf>>),
 }
 
 ///

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -172,6 +172,12 @@ pub mod commands {
         CMD_GROUP_COMMIT,
     );
     ///
+    pub static EDIT_ITEM: CommandText = CommandText::new(
+        "Edit Item [e]",
+        "edit the currently selected file in an external editor",
+        CMD_GROUP_CHANGES,
+    );
+    ///
     pub static STAGE_ITEM: CommandText = CommandText::new(
         "Stage Item [enter]",
         "stage currently selected file or entire path",


### PR DESCRIPTION
Pressing `e` while looking at a file in the _Status_ view will launch an external editor with the current file opened. The editor chosen is determined by the default logic introduced in #114.

An improvement to this in the future could be launching at the specific line at which the _Diff_ view is focused, but that seems to require a change in `FileDiff` which is a change bigger than this PR.

Fixes #166