### PR TITLE
Add command for tagging commit

### DIFF
--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -18,7 +18,7 @@ pub mod utils;
 
 pub(crate) use branch::get_branch_name;
 
-pub use commit::{amend, commit};
+pub use commit::{amend, commit, tag};
 pub use commit_details::{get_commit_details, CommitDetails};
 pub use commit_files::get_commit_files;
 pub use commits_info::{get_commits_info, CommitId, CommitInfo};

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
         event_pump, CommandBlocking, CommandInfo, CommitComponent,
         Component, DrawableComponent, ExternalEditorComponent,
         HelpComponent, InspectCommitComponent, MsgComponent,
-        ResetComponent, StashMsgComponent,
+        ResetComponent, StashMsgComponent, TagCommitComponent,
     },
     input::{Input, InputEvent, InputState},
     keys,
@@ -40,6 +40,7 @@ pub struct App {
     stashmsg_popup: StashMsgComponent,
     inspect_commit_popup: InspectCommitComponent,
     external_editor_popup: ExternalEditorComponent,
+    tag_commit_popup: TagCommitComponent,
     cmdbar: RefCell<CommandBar>,
     tab: usize,
     revlog: Revlog,
@@ -83,6 +84,10 @@ impl App {
                 theme.clone(),
             ),
             external_editor_popup: ExternalEditorComponent::new(
+                theme.clone(),
+            ),
+            tag_commit_popup: TagCommitComponent::new(
+                queue.clone(),
                 theme.clone(),
             ),
             do_quit: false,
@@ -296,6 +301,7 @@ impl App {
             stashmsg_popup,
             inspect_commit_popup,
             external_editor_popup,
+            tag_commit_popup,
             help,
             revlog,
             status_tab,
@@ -419,6 +425,9 @@ impl App {
                 self.stashmsg_popup.options(opts);
                 self.stashmsg_popup.show()?
             }
+            InternalEvent::TagCommit(id) => {
+                self.tag_commit_popup.open(id)?;
+            }
             InternalEvent::TabSwitch => self.set_tab(0)?,
             InternalEvent::InspectCommit(id, tags) => {
                 self.inspect_commit_popup.open(id, tags)?;
@@ -484,6 +493,7 @@ impl App {
             || self.stashmsg_popup.is_visible()
             || self.inspect_commit_popup.is_visible()
             || self.external_editor_popup.is_visible()
+            || self.tag_commit_popup.is_visible()
     }
 
     fn draw_popups<B: Backend>(
@@ -508,6 +518,7 @@ impl App {
         self.msg.draw(f, size)?;
         self.inspect_commit_popup.draw(f, size)?;
         self.external_editor_popup.draw(f, size)?;
+        self.tag_commit_popup.draw(f, size)?;
 
         Ok(())
     }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -11,6 +11,7 @@ mod inspect_commit;
 mod msg;
 mod reset;
 mod stashmsg;
+mod tag_commit;
 mod textinput;
 mod utils;
 
@@ -30,6 +31,8 @@ pub use inspect_commit::InspectCommitComponent;
 pub use msg::MsgComponent;
 pub use reset::ResetComponent;
 pub use stashmsg::StashMsgComponent;
+pub use tag_commit::TagCommitComponent;
+pub use textinput::TextInputComponent;
 pub use utils::filetree::FileTreeItemKind;
 
 use crate::ui::style::Theme;

--- a/src/components/tag_commit.rs
+++ b/src/components/tag_commit.rs
@@ -1,0 +1,134 @@
+use super::{
+    textinput::TextInputComponent, visibility_blocking,
+    CommandBlocking, CommandInfo, Component, DrawableComponent,
+};
+use crate::{
+    queue::{InternalEvent, NeedsUpdate, Queue},
+    strings::{self, commands},
+    ui::style::SharedTheme,
+};
+use anyhow::Result;
+use asyncgit::{
+    sync::{self, CommitId},
+    CWD,
+};
+use crossterm::event::{Event, KeyCode};
+use tui::{backend::Backend, layout::Rect, Frame};
+
+pub struct TagCommitComponent {
+    input: TextInputComponent,
+    commit_id: Option<CommitId>,
+    queue: Queue,
+}
+
+impl DrawableComponent for TagCommitComponent {
+    fn draw<B: Backend>(
+        &self,
+        f: &mut Frame<B>,
+        rect: Rect,
+    ) -> Result<()> {
+        self.input.draw(f, rect)?;
+
+        Ok(())
+    }
+}
+
+impl Component for TagCommitComponent {
+    fn commands(
+        &self,
+        out: &mut Vec<CommandInfo>,
+        force_all: bool,
+    ) -> CommandBlocking {
+        if self.is_visible() || force_all {
+            self.input.commands(out, force_all);
+
+            out.push(CommandInfo::new(
+                commands::TAG_COMMIT_CONFIRM_MSG,
+                true,
+                true,
+            ));
+        }
+
+        visibility_blocking(self)
+    }
+
+    fn event(&mut self, ev: Event) -> Result<bool> {
+        if self.is_visible() {
+            if self.input.event(ev)? {
+                return Ok(true);
+            }
+
+            if let Event::Key(e) = ev {
+                if let KeyCode::Enter = e.code {
+                    self.tag()
+                }
+
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn is_visible(&self) -> bool {
+        self.input.is_visible()
+    }
+
+    fn hide(&mut self) {
+        self.input.hide()
+    }
+
+    fn show(&mut self) -> Result<()> {
+        self.input.show()?;
+
+        Ok(())
+    }
+}
+
+impl TagCommitComponent {
+    ///
+    pub fn new(queue: Queue, theme: SharedTheme) -> Self {
+        Self {
+            queue,
+            input: TextInputComponent::new(
+                theme,
+                strings::TAG_COMMIT_POPUP_TITLE,
+                strings::TAG_COMMIT_POPUP_MSG,
+            ),
+            commit_id: None,
+        }
+    }
+
+    ///
+    pub fn open(&mut self, id: CommitId) -> Result<()> {
+        self.commit_id = Some(id);
+        self.show()?;
+
+        Ok(())
+    }
+
+    ///
+    pub fn tag(&mut self) {
+        if let Some(commit_id) = self.commit_id {
+            match sync::tag(CWD, &commit_id, self.input.get_text()) {
+                Ok(_) => {
+                    self.input.clear();
+                    self.hide();
+
+                    self.queue.borrow_mut().push_back(
+                        InternalEvent::Update(NeedsUpdate::ALL),
+                    );
+                }
+                Err(e) => {
+                    self.hide();
+                    log::error!("e: {}", e,);
+                    self.queue.borrow_mut().push_back(
+                        InternalEvent::ShowErrorMsg(format!(
+                            "tag error:\n{}",
+                            e,
+                        )),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -66,5 +66,6 @@ pub const STASH_DROP: KeyEvent =
     with_mod(KeyCode::Char('D'), KeyModifiers::SHIFT);
 pub const CMD_BAR_TOGGLE: KeyEvent = no_mod(KeyCode::Char('.'));
 pub const LOG_COMMIT_DETAILS: KeyEvent = no_mod(KeyCode::Enter);
+pub const LOG_TAG_COMMIT: KeyEvent = no_mod(KeyCode::Char('t'));
 pub const COMMIT_AMEND: KeyEvent =
     with_mod(KeyCode::Char('a'), KeyModifiers::CONTROL);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -49,6 +49,8 @@ pub enum InternalEvent {
     ///
     InspectCommit(CommitId, Option<CommitTags>),
     ///
+    TagCommit(CommitId),
+    ///
     OpenExternalEditor(Option<String>),
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -27,6 +27,10 @@ pub static CONFIRM_MSG_STASHDROP: &str = "confirm stash drop?";
 pub static CONFIRM_MSG_RESETHUNK: &str = "confirm reset hunk?";
 
 pub static LOG_TITLE: &str = "Commit";
+
+pub static TAG_COMMIT_POPUP_TITLE: &str = "Tag";
+pub static TAG_COMMIT_POPUP_MSG: &str = "type tag";
+
 pub static STASHLIST_TITLE: &str = "Stashes";
 
 pub static HELP_TITLE: &str = "Help: all commands";
@@ -295,4 +299,10 @@ pub mod commands {
         "inspect selected commit in detail",
         CMD_GROUP_LOG,
     );
+    ///
+    pub static LOG_TAG_COMMIT: CommandText =
+        CommandText::new("Tag [t]", "tag commit", CMD_GROUP_LOG);
+    ///
+    pub static TAG_COMMIT_CONFIRM_MSG: CommandText =
+        CommandText::new("Tag [enter]", "tag commit", CMD_GROUP_LOG);
 }

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -207,6 +207,19 @@ impl Component for Revlog {
                         return Ok(true);
                     }
 
+                    Event::Key(keys::LOG_TAG_COMMIT) => {
+                        return if let Some(id) =
+                            self.selected_commit()
+                        {
+                            self.queue.borrow_mut().push_back(
+                                InternalEvent::TagCommit(id),
+                            );
+                            Ok(true)
+                        } else {
+                            Ok(false)
+                        };
+                    }
+
                     Event::Key(keys::FOCUS_RIGHT)
                         if self.commit_details.is_visible() =>
                     {
@@ -255,6 +268,12 @@ impl Component for Revlog {
             true,
             (self.visible && self.commit_details.is_visible())
                 || force_all,
+        ));
+
+        out.push(CommandInfo::new(
+            commands::LOG_TAG_COMMIT,
+            true,
+            self.visible || force_all,
         ));
 
         visibility_blocking(self)


### PR DESCRIPTION
Opened as a draft for getting early feedback.

Open questions:

- [x] Do you want to validate the tag before calling `repo.tag` or do you want
  to rely on git refusing invalid tags?
- [x] Should the dialog have just a single line?

Will close #103.
