### PR TITLE
Switch focus when working directory or stage becomes empty

### DIFF
--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -46,6 +46,7 @@ pub struct Status {
     git_status_workdir: AsyncStatus,
     git_status_stage: AsyncStatus,
     queue: Queue,
+    git_action_executed: bool,
 }
 
 impl DrawableComponent for Status {
@@ -130,6 +131,7 @@ impl Status {
             git_diff: AsyncDiff::new(sender.clone()),
             git_status_workdir: AsyncStatus::new(sender.clone()),
             git_status_stage: AsyncStatus::new(sender.clone()),
+            git_action_executed: false,
         }
     }
 
@@ -231,13 +233,28 @@ impl Status {
     }
 
     fn update_status(&mut self) -> Result<()> {
-        let status = self.git_status_stage.last()?;
-        self.index.set_items(&status.items)?;
+        let stage_status = self.git_status_stage.last()?;
+        self.index.set_items(&stage_status.items)?;
 
-        let status = self.git_status_workdir.last()?;
-        self.index_wd.set_items(&status.items)?;
+        let workdir_status = self.git_status_workdir.last()?;
+        self.index_wd.set_items(&workdir_status.items)?;
 
         self.update_diff()?;
+
+        if self.git_action_executed {
+            self.git_action_executed = false;
+
+            if self.focus == Focus::WorkDir
+                && workdir_status.items.is_empty()
+                && !stage_status.items.is_empty()
+            {
+                self.switch_focus(Focus::Stage)?;
+            } else if self.focus == Focus::Stage
+                && stage_status.items.is_empty()
+            {
+                self.switch_focus(Focus::WorkDir)?;
+            }
+        }
 
         Ok(())
     }
@@ -371,6 +388,7 @@ impl Component for Status {
     fn event(&mut self, ev: crossterm::event::Event) -> Result<bool> {
         if self.visible {
             if event_pump(ev, self.components_mut().as_mut_slice())? {
+                self.git_action_executed = true;
                 return Ok(true);
             }
 


### PR DESCRIPTION
If the focus is on the working directory and it becomes empty (no files are listed) by either staging the last file or using the _Stage all_ command, the focus will be moved to the stage automatically. It works the same for when the stage becomes empty, by moving the focus to the working directory.

If the focus is on the diff area, the focus will not be moved when either the working directory or the stage becomes empty.

Fixes #215 