### PR TITLE
Bump `dirs` version and add config migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,11 +323,10 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "2.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
 dependencies = [
- "cfg-if",
  "dirs-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ itertools = "0.9"
 rayon-core = "1.7"
 log = "0.4"
 simplelog = { version = "0.8", default-features = false }
-dirs = "2.0"
+dirs = "3.0"
 crossbeam-channel = "0.4"
 scopeguard = "1.1"
 bitflags = "1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,12 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // TODO: Remove this when upgrading from v0.8.x is unlikely
+    // Only run this migration on macOS, as it's the only platform where the config needs to be moved
+    if cfg!(target_os = "macos") {
+        migrate_config()?;
+    }
+
     setup_terminal()?;
     defer! {
         shutdown_terminal().expect("shutdown failed");
@@ -242,6 +248,29 @@ fn get_app_config_path() -> Result<PathBuf> {
     path.push("gitui");
     fs::create_dir_all(&path)?;
     Ok(path)
+}
+
+fn migrate_config() -> Result<()> {
+    let mut path = dirs::preference_dir().ok_or_else(|| {
+        anyhow!("failed to find os preference dir.")
+    })?;
+
+    path.push("gitui");
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let config_path = get_app_config_path()?;
+    let entries = path.read_dir()?.flatten();
+    for entry in entries {
+        let mut config_path = config_path.clone();
+        config_path.push(entry.file_name());
+        fs::rename(entry.path(), config_path)?;
+    }
+
+    let _ = fs::remove_dir(path);
+
+    Ok(())
 }
 
 fn setup_logging() -> Result<()> {


### PR DESCRIPTION
Bumps `dirs` to version 3.0 and add migration logic to move the config files to the new location. The migration only happens on _macOS_, as it's the only OS affected.

This also fixes a bug where file paths with spaces would not open correctly in external editors. As part of the fix, the code for launching the editor switches to using `OsStr` instead of `str` to prevent gitui from messing file paths up should they contain invalid UTF-8.

Fixes #175 
Closes #174 