### PR TITLE
Add support for GPG signing commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install gpgme
 
+    - name: Install GnuPG on Windows
+      if: matrix.os == 'windows-latest'
+      run: |
+        $path = [Environment]::GetEnvironmentVariable("path", "machine")
+        $newPath = ($path.Split(';') | Where-Object { $_ -eq 'C:\ProgramData\chocolatey\bin' }) -join ';'
+        [Environment]::SetEnvironmentVariable("path", $newPath, "machine")
+        choco install gpg4win
+        refreshenv
+
     - name: Build Debug
       run: |
         rustc --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
         profile: minimal
         components: clippy
 
+    - name: Install GnuPG on Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get -qq install libgpg-error-dev libgpgme11-dev
+
+    - name: Install GnuPG on MacOS
+      if: matrix.os == 'macos-latest'
+      run: brew install gpgme
+
     - name: Build Debug
       run: |
         rustc --version
@@ -57,6 +65,9 @@ jobs:
         toolchain: stable
         profile: minimal
         target: x86_64-unknown-linux-musl
+
+    - name: Install GnuPG
+      run: sudo apt-get -qq install libgpg-error-dev libgpgme11-dev
 
     - name: Setup MUSL
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,8 @@ version = "0.9.0"
 dependencies = [
  "crossbeam-channel",
  "git2",
+ "gpg-error",
+ "gpgme",
  "invalidstring",
  "log",
  "rayon-core",
@@ -220,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +322,22 @@ checksum = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "cstr-argument"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd4e8067c20c7c3a4dea759ef91d4b18418ddb5bd8837ef6e2f2f93ca7ccbb"
+dependencies = [
+ "cfg-if",
+ "memchr",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "debugid"
@@ -433,6 +460,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "gpg-error"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eafd8f60a0e9112caa9057f9a5fca2c3b17a9b6f3c035e79c35af9b94905137"
+dependencies = [
+ "libgpg-error-sys",
+]
+
+[[package]]
+name = "gpgme"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528b8b981855eb0c74696a408919b1bf5dbe7f4cd99261bb1b47097d9bf3478f"
+dependencies = [
+ "bitflags",
+ "conv",
+ "cstr-argument",
+ "gpg-error",
+ "gpgme-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "static_assertions",
+]
+
+[[package]]
+name = "gpgme-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b293be40a67cf00d4cdbefc8bc87c10d2b9581fcb9ac226084c53a556f2e31f"
+dependencies = [
+ "libc",
+ "libgpg-error-sys",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +597,15 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libgpg-error-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1088124ffd50d800fa4daa9854a1ce6fbaa4b9cc953ee571c6b3cc27e5928f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -726,6 +798,12 @@ name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+
+[[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "parking_lot"
@@ -1051,6 +1129,12 @@ name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -18,6 +18,8 @@ rayon-core = "1.7"
 crossbeam-channel = "0.4"
 log = "0.4"
 thiserror = "1.0"
+gpg-error = "0.5.1"
+gpgme = "0.9.2"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
 
     #[error("git error:{0}")]
     Git(#[from] git2::Error),
+
+    #[error("gpg error:#{0}")]
+    Gpg(#[from] gpg_error::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
# Overview

This PR is an initial stab at resolving #97. This is a recreation of #218, which I accidentally created without marking as a draft PR and I was unable to set it back so I decided to close it.

With these changes, I was able to create this PR's commits signed with `gitui`:
![Screen Shot 2020-07-29 at 5 51 07 PM](https://user-images.githubusercontent.com/616290/88862488-0c669280-d1c6-11ea-8437-94a069ec34a7.png)

## Details

Unfortunately, `libgit2` appears to not provide an interface for creating signed commits as friendly as standard commit creation so there is a lot of code added. The GPG signing must be done manually which brings in dependencies for `gpgme`. Unlike standard commit creation, there is not an option to automatically update `HEAD` so it must be done manually when after creating a signed commit. When dealing with a newly initialized repo, this means the default branch has to be created as well! There is no official documentation creating signed commits with `libgit2`, so credit goes to https://github.com/rust-lang/git2-rs/issues/507 for figuring it out.

I am not sure how test suite should handle this new functionality. The main conditional is currently determined by the user's git config option, so on my computer it will always use the GPG signing. We could add extra tests and manage whether GPG signing should be on for each one or try to run the entire suite with GPG signing on and off. The main commit tests are working, but locally I am getting ~4-6 failures each time. Here is a sample run:
```
...

failures:

---- sync::commit_details::tests::test_msg_invalid_utf8 stdout ----
thread 'sync::commit_details::tests::test_msg_invalid_utf8' panicked at 'Buffer was not valid UTF-8', asyncgit/src/sync/commit.rs:83:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- sync::commits_info::tests::test_invalid_utf8 stdout ----
thread 'sync::commits_info::tests::test_invalid_utf8' panicked at 'Buffer was not valid UTF-8', asyncgit/src/sync/commit.rs:83:13

---- sync::commit::tests::test_tag stdout ----
Error: Gpg(Error { source: Some("gcrypt"), code: 32854, description: "Cannot allocate memory" })
thread 'sync::commit::tests::test_tag' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /Users/grantbdev/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/macros.rs:16:9

---- sync::commits_info::tests::test_log stdout ----
thread 'sync::commits_info::tests::test_log' panicked at 'called `Result::unwrap()` on an `Err` value: Gpg(Error { source: Some("Pinentry"), code: 32854, description: "Cannot allocate memory" })', asyncgit/src/sync/commits_info.rs:137:18

---- sync::stash::tests::test_stash_without_2nd_parent stdout ----
Error: Gpg(Error { source: Some("Pinentry"), code: 32854, description: "Cannot allocate memory" })
thread 'sync::stash::tests::test_stash_without_2nd_parent' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /Users/grantbdev/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/macros.rs:16:9

...

test result: FAILED. 48 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out
```

The invalid UTF-8 failures seem to happen every time. There is a point in the GPG commit logic that will panic if the message contains invalid UTF-8 and I guess that differs from the standard commit logic? I'm not sure how that should be resolved other than having different expectations with and without the GPG signing feature.

The rest are random tests failing each run, pointing to gcrypt or Pinentry and saying it couldn't allocate memory. This appears to only happen when the tests are run in parallel by default. `cargo test -- --test-threads=1` will eliminate the random failures.