### PR TITLE
Add multiple selection in diff view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         profile: minimal
         components: clippy
 
+    - name: Install dependencies for clipboard access
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get -qq install libxcb-shape0-dev libxcb-xfixes0-dev
+
     - name: Build Debug
       run: |
         rustc --version
@@ -53,6 +58,10 @@ jobs:
         toolchain: stable
         profile: minimal
         target: x86_64-unknown-linux-musl
+
+    - name: Install dependencies for clipboard access
+      run: |
+        sudo apt-get -qq install libxcb-shape0-dev libxcb-xfixes0-dev
 
     - name: Setup MUSL
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "bytemuck"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +179,28 @@ dependencies = [
  "bitflags",
  "textwrap 0.11.0",
  "unicode-width",
+]
+
+[[package]]
+name = "clipboard"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "x11-clipboard",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -410,6 +438,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "clipboard",
  "crossbeam-channel",
  "crossterm",
  "dirs",
@@ -577,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +758,35 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -1283,3 +1350,22 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "x11-clipboard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = "1.0"
 anyhow = "1.0.32"
 unicode-width = "0.1"
 textwrap = "0.12"
+clipboard = "0.5"
 
 [target.'cfg(not(windows))'.dependencies]
 pprof = { version = "0.3", features = ["flamegraph"], optional = true }

--- a/src/app.rs
+++ b/src/app.rs
@@ -515,8 +515,8 @@ impl App {
         self.stashmsg_popup.draw(f, size)?;
         self.reset.draw(f, size)?;
         self.help.draw(f, size)?;
-        self.msg.draw(f, size)?;
         self.inspect_commit_popup.draw(f, size)?;
+        self.msg.draw(f, size)?;
         self.external_editor_popup.draw(f, size)?;
         self.tag_commit_popup.draw(f, size)?;
 

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -7,7 +7,7 @@ use crate::{
     components::{CommandInfo, Component},
     keys,
     queue::{Action, InternalEvent, NeedsUpdate, Queue, ResetItem},
-    strings,
+    strings, try_or_popup,
     ui::style::SharedTheme,
 };
 use anyhow::Result;
@@ -16,22 +16,6 @@ use crossterm::event::Event;
 use std::path::Path;
 use strings::commands;
 use tui::{backend::Backend, layout::Rect, Frame};
-
-/// macro to simplify running code that might return Err.
-/// It will show a popup in that case
-#[macro_export]
-macro_rules! try_or_popup {
-    ($self:ident, $msg:literal, $e:expr) => {
-        if let Err(err) = $e {
-            $self.queue.borrow_mut().push_back(
-                InternalEvent::ShowErrorMsg(format!(
-                    "{}\n{}",
-                    $msg, err
-                )),
-            );
-        }
-    };
-}
 
 ///
 pub struct ChangesComponent {

--- a/src/components/inspect_commit.rs
+++ b/src/components/inspect_commit.rs
@@ -159,7 +159,7 @@ impl InspectCommitComponent {
                 sender,
                 theme.clone(),
             ),
-            diff: DiffComponent::new(None, theme),
+            diff: DiffComponent::new(queue.clone(), theme, true),
             commit_id: None,
             tags: None,
             git_diff: AsyncDiff::new(sender.clone()),

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -105,6 +105,12 @@ pub enum ScrollType {
     PageDown,
 }
 
+#[derive(Copy, Clone)]
+pub enum ExtendType {
+    Up,
+    Down,
+}
+
 ///
 #[derive(PartialEq)]
 pub enum CommandBlocking {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -106,7 +106,7 @@ pub enum ScrollType {
 }
 
 #[derive(Copy, Clone)]
-pub enum ExtendType {
+pub enum Direction {
     Up,
     Down,
 }

--- a/src/components/utils/mod.rs
+++ b/src/components/utils/mod.rs
@@ -4,6 +4,22 @@ pub mod filetree;
 pub mod logitems;
 pub mod statustree;
 
+/// macro to simplify running code that might return Err.
+/// It will show a popup in that case
+#[macro_export]
+macro_rules! try_or_popup {
+    ($self:ident, $msg:literal, $e:expr) => {
+        if let Err(err) = $e {
+            $self.queue.borrow_mut().push_back(
+                InternalEvent::ShowErrorMsg(format!(
+                    "{}\n{}",
+                    $msg, err
+                )),
+            );
+        }
+    };
+}
+
 /// helper func to convert unix time since epoch to formated time string in local timezone
 pub fn time_to_string(secs: i64, short: bool) -> String {
     let time = DateTime::<Local>::from(DateTime::<Utc>::from_utc(

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -50,6 +50,7 @@ pub const SHIFT_UP: KeyEvent =
 pub const SHIFT_DOWN: KeyEvent =
     with_mod(KeyCode::Down, KeyModifiers::SHIFT);
 pub const ENTER: KeyEvent = no_mod(KeyCode::Enter);
+pub const COPY: KeyEvent = no_mod(KeyCode::Char('y'));
 pub const EDIT_FILE: KeyEvent = no_mod(KeyCode::Char('e'));
 pub const STATUS_STAGE_FILE: KeyEvent = no_mod(KeyCode::Enter);
 pub const STATUS_STAGE_ALL: KeyEvent = no_mod(KeyCode::Char('a'));

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -105,6 +105,12 @@ pub mod commands {
         CMD_GROUP_GENERAL,
     );
     ///
+    pub static COPY: CommandText = CommandText::new(
+        "Copy [y]",
+        "copy selected lines to clipboard",
+        CMD_GROUP_DIFF,
+    );
+    ///
     pub static DIFF_HOME_END: CommandText = CommandText::new(
         "Jump up/down [home,end,\u{2191} up,\u{2193} down]",
         "scroll to top or bottom of diff",

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -127,7 +127,7 @@ impl Status {
                 queue.clone(),
                 theme.clone(),
             ),
-            diff: DiffComponent::new(Some(queue.clone()), theme),
+            diff: DiffComponent::new(queue.clone(), theme, false),
             git_diff: AsyncDiff::new(sender.clone()),
             git_status_workdir: AsyncStatus::new(sender.clone()),
             git_status_stage: AsyncStatus::new(sender.clone()),


### PR DESCRIPTION
This is a first attempt at implementing multiple selection in the diff view.
You can use `Shift+ArrowUp` as well as `Shift+ArrowDown` to extend the
selection.

Known issue: If the selection spans more than one hunk, only the hunk that
contains the selection’s start is selected. I don’t know a good way to address
that. Preventing the selection from spanning more than hunk seems like an
obvious choice, but then, of course, you could only copy lines out of one hunk
at a time.

Still left to do is the actual copying to clipboard, but that should be fairly
easy once the above issue is resolved.

Closes #229.
