### PR TITLE
Adjusted hook tests to work on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
     #   run: |
     #     choco install wsl-ubuntu-1804
 
+    - name: Windows Setup
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install git
+
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       run: |
         echo "::add-path::C:\Program Files\Git\bin"
         echo $Env:Path
+        Get-Command bash
+
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
-        echo "::set-env name=Path::C:\Program Files\Git\bin;$Path"
+        echo "::set-env name=Path::C:\Program Files\Git\bin;${{ env.PATH }}"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
 
     - name: Windows Setup
       if: matrix.os == 'windows-latest'
-      env:
+      run: |
         # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
-        Path: "C:\Program Files\Git\bin;${{ env.Path }}"
+        echo "::set-env name=Path::"C:\Program Files\Git\bin;${{ env.Path }}"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ jobs:
 
     - name: Windows Setup
       if: matrix.os == 'windows-latest'
-      run: |
-        choco install git
+      env:
+        # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
+        Path: "C:\Program Files\Git\bin;${{ env.Path }}"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
         echo "::add-path::C:\Program Files\Git\bin"
+        echo ${{ env.Path }}
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,6 @@ jobs:
     #   run: |
     #     choco install wsl-ubuntu-1804
 
-    - name: Windows Setup
-      if: matrix.os == 'windows-latest'
-      # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
-      run: |
-        echo $Env:Path
-        Get-Command bash
-
-
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
-        echo "::set-env name=Path::C:\Program Files\Git\bin;${{ env.PATH }}"
+        echo "::add-path::C:\Program Files\Git\bin"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
-        echo "::set-env name=Path::C:\Program Files\Git\bin;${{ env.Path }}"
+        echo "::set-env name=Path::C:\Program Files\Git\bin;$Path"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       if: matrix.os == 'windows-latest'
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
-        echo "::add-path::C:\Program Files\Git\bin"
         echo $Env:Path
         Get-Command bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
 
     - name: Windows Setup
       if: matrix.os == 'windows-latest'
+      # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
-        # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
-        echo "::set-env name=Path::"C:\Program Files\Git\bin;${{ env.Path }}"
+        echo "::set-env name=Path::C:\Program Files\Git\bin;${{ env.Path }}"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       # https://codeblog.jonskeet.uk/2019/10/12/using-git-bash-from-appveyor/
       run: |
         echo "::add-path::C:\Program Files\Git\bin"
-        echo ${{ env.Path }}
+        echo $Env:Path
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -105,6 +105,7 @@ fn run_hook(
     let output = Command::new("bash")
         .args(bash_args)
         .current_dir(path)
+        .env("DUMMYENV", "FixPathHandlingOnWindows") // This call forces Command to handle the Path environment correctly on windows, the specific env set here does not matter
         .output();
 
     let output = output.expect("general hook error");

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -183,8 +183,7 @@ mod tests {
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        let hook = b"
-#!/bin/sh
+        let hook = b"#!/bin/sh
 exit 0
         ";
 
@@ -204,8 +203,7 @@ exit 0
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        let hook = b"
-#!/bin/sh
+        let hook = b"#!/bin/sh
 echo 'msg' > $1
 echo 'rejected'
 exit 1
@@ -230,8 +228,7 @@ exit 1
         let root = repo.path().parent().unwrap();
         // let repo_path = root.as_os_str().to_str().unwrap();
 
-        let hook = b"
-#!/bin/sh
+        let hook = b"#!/bin/sh
 echo 'msg' > $1
 echo 'rejected'
 exit 1
@@ -261,8 +258,7 @@ exit 1
         let root = repo.path().parent().unwrap();
         let repo_path = root.as_os_str().to_str().unwrap();
 
-        let hook = b"
-#!/bin/sh
+        let hook = b"#!/bin/sh
 echo 'msg' > $1
 exit 0
         ";
@@ -281,8 +277,7 @@ exit 0
         let (_td, repo) = repo_init().unwrap();
         let root = repo.path().parent().unwrap();
 
-        let hook = b"
-#!/bin/sh
+        let hook = b"#!/bin/sh
 echo 'rejected'
 exit 1
         ";


### PR DESCRIPTION
This PR fixes #235.
The extra newline at the beginning of the hook caused the following error on windows:
`error: cannot spawn .git/hooks/commit-msg: No such file or directory`