### PR TITLE
revert clipboard feature on linux to fix static linux binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
     - name: Build Debug
       run: |
         cargo build --target=x86_64-unknown-linux-musl
+        ls -lisa ./target/x86_64-unknown-linux-musl/debug
+        ldd ./target/x86_64-unknown-linux-musl/debug/gitui
         ./target/x86_64-unknown-linux-musl/debug/gitui --version
     - name: Build Release
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,11 @@ jobs:
         sudo apt-get -qq install musl-tools
     - name: Build Debug
       run: |
-        cargo build --target=x86_64-unknown-linux-musl
-        ls -lisa ./target/x86_64-unknown-linux-musl/debug
-        ldd ./target/x86_64-unknown-linux-musl/debug/gitui
+        make build-linux-musl-debug
         ./target/x86_64-unknown-linux-musl/debug/gitui --version
     - name: Build Release
       run: |
-        cargo build --release --target=x86_64-unknown-linux-musl
-        ldd ./target/x86_64-unknown-linux-musl/release/gitui
+        make build-linux-musl-release
         ./target/x86_64-unknown-linux-musl/release/gitui --version
 
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,14 @@ jobs:
       run: |
         sudo apt-get -qq install musl-tools
     - name: Build Debug
-      run: cargo build --target=x86_64-unknown-linux-musl
+      run: |
+        cargo build --target=x86_64-unknown-linux-musl
+        ./target/x86_64-unknown-linux-musl/debug/gitui --version
     - name: Build Release
       run: |
         cargo build --release --target=x86_64-unknown-linux-musl
+        ldd ./target/x86_64-unknown-linux-musl/release/gitui
+        ./target/x86_64-unknown-linux-musl/release/gitui --version
 
   rustfmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2020-09-01
+
+### Fixed
+- static linux binaries broke due to new clipboard feature which is disabled on linux for now ([#259](https://github.com/extrawurst/gitui/issues/259))
+
 ## [0.10.0] - 2020-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "gitui"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "asyncgit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0"
 anyhow = "1.0.32"
 unicode-width = "0.1"
 textwrap = "0.12"
-clipboard = "0.5"
+clipboard = { version = "0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 pprof = { version = "0.3", features = ["flamegraph"], optional = true }
@@ -49,7 +49,7 @@ pprof = { version = "0.3", features = ["flamegraph"], optional = true }
 maintenance = { status = "actively-developed" }
 
 [features]
-default=[]
+default=["clipboard"]
 timing=["scopetime/enabled"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitui"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Stephan Dilly <dilly.stephan@gmail.com>"]
 description = "blazing fast terminal-ui for git"
 edition = "2018"

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,16 @@ release-win: build-release
 	mkdir -p release
 	tar -C ./target/release/ -czvf ./release/gitui-win.tar.gz ./gitui.exe
 
-release-linux-musl: 
-	cargo build --release --target=x86_64-unknown-linux-musl
+release-linux-musl: build-linux-musl-release
 	strip target/x86_64-unknown-linux-musl/release/gitui
 	mkdir -p release
 	tar -C ./target/x86_64-unknown-linux-musl/release/ -czvf ./release/gitui-linux-musl.tar.gz ./gitui
+
+build-linux-musl-debug:
+	cargo build --target=x86_64-unknown-linux-musl --no-default-features
+
+build-linux-musl-release:
+	cargo build --release --target=x86_64-unknown-linux-musl --no-default-features
 
 test:
 	cargo test --workspace

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -18,3 +18,13 @@ pub fn copy_string(string: String) -> Result<()> {
 pub fn copy_string(_string: String) -> Result<()> {
     Ok(())
 }
+
+#[cfg(feature = "clipboard")]
+pub fn is_supported() -> bool {
+    true
+}
+
+#[cfg(not(feature = "clipboard"))]
+pub fn is_supported() -> bool {
+    false
+}

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+#[cfg(feature = "clipboard")]
+use clipboard::{ClipboardContext, ClipboardProvider};
+
+#[cfg(feature = "clipboard")]
+pub fn copy_string(string: String) -> Result<()> {
+    use anyhow::anyhow;
+
+    let mut ctx: ClipboardContext = ClipboardProvider::new()
+        .map_err(|_| anyhow!("failed to get access to clipboard"))?;
+    ctx.set_contents(string)
+        .map_err(|_| anyhow!("failed to set clipboard contents"))?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "clipboard"))]
+pub fn copy_string(_string: String) -> Result<()> {
+    Ok(())
+}

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -604,11 +604,13 @@ impl Component for DiffComponent {
             self.focused,
         ));
 
-        out.push(CommandInfo::new(
-            strings::commands::copy(&self.key_config),
-            true,
-            self.focused,
-        ));
+        if crate::clipboard::is_supported() {
+            out.push(CommandInfo::new(
+                strings::commands::copy(&self.key_config),
+                true,
+                self.focused,
+            ));
+        }
 
         out.push(
             CommandInfo::new(
@@ -688,7 +690,9 @@ impl Component for DiffComponent {
                         }
                     }
                     Ok(true)
-                } else if e == self.key_config.copy {
+                } else if e == self.key_config.copy
+                    && crate::clipboard::is_supported()
+                {
                     self.copy_selection()?;
                     Ok(true)
                 } else {

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -8,8 +8,10 @@ use crate::{
     strings, try_or_popup,
     ui::{self, calc_scroll_top, style::SharedTheme},
 };
+use anyhow::Result;
 use asyncgit::{hash, sync, DiffLine, DiffLineType, FileDiff, CWD};
 use bytesize::ByteSize;
+#[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
 use crossterm::event::Event;
 use std::{borrow::Cow, cell::Cell, cmp, path::Path};
@@ -20,8 +22,6 @@ use tui::{
     widgets::{Block, Borders, Paragraph, Text},
     Frame,
 };
-
-use anyhow::{anyhow, Result};
 
 #[derive(Default)]
 struct Current {
@@ -244,7 +244,10 @@ impl DiffComponent {
         Ok(())
     }
 
+    #[cfg(feature = "clipboard")]
     fn copy_string(string: String) -> Result<()> {
+        use anyhow::anyhow;
+
         let mut ctx: ClipboardContext = ClipboardProvider::new()
             .map_err(|_| {
                 anyhow!("failed to get access to clipboard")
@@ -253,6 +256,11 @@ impl DiffComponent {
             anyhow!("failed to set clipboard contents")
         })?;
 
+        Ok(())
+    }
+
+    #[cfg(not(feature = "clipboard"))]
+    fn copy_string(_string: String) -> Result<()> {
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 #![warn(clippy::missing_const_for_fn)]
 
 mod app;
+mod clipboard;
 mod cmdbar;
 mod components;
 mod input;


### PR DESCRIPTION
this reverts the new dependency on clipboard and x11 in turn so that static linux binaries can be build again. 
we need to look into a different solution later.

closes #259