### PR TITLE
Added XCB dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Binaries available for:
 
 - Latest `rust` and `cargo`
   - See [Install Rust](https://www.rust-lang.org/tools/install)
+- xcb
+  - Ubuntu: `sudo apt install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev`
 
 ### Cargo Install
 


### PR DESCRIPTION
I tried installing gitui through cargo on my new ubuntu machine and ran into some dependencies it was missing.
I figured I'd add them to the README as I couldn't find any information on it yet

This only works for ubuntu, I don't know what other linux distros would need (arch, fedora, etc). If anyone wants to look that up I'll add them to the PR

[Rendered](https://github.com/VictorKoenders/gitui/blob/ab6e5190ff0cc0e867b43a4dffceacf628e7cefc/README.md#build)