### PR TITLE
Fold folders up into parent if alone in directory

### DIFF
--- a/src/components/filetree.rs
+++ b/src/components/filetree.rs
@@ -251,13 +251,11 @@ impl FileTreeComponent {
                     && tree_items[idx_temp + 1].info.indent
                         < tree_items[idx_temp + 2].info.indent
                 {
-                    // fold up the folder/file
-                    // because there is only one in the directory
+                    // fold up the folder/file because there is only one in the directory
                     idx_temp += 1;
                     should_skip_over += 1;
 
-                    // check if there is another folder or file at the
-                    // same level, if there is, don't fold up
+                    // check if there is another folder or file at the same level, if there is, don't fold up
                     let mut idx_temp_inner;
                     if idx_temp + 2 < tree_items.len() {
                         idx_temp_inner = idx_temp + 1;
@@ -276,13 +274,11 @@ impl FileTreeComponent {
                     if tree_items[idx_temp_inner].info.indent
                         == tree_items[idx_temp].info.indent
                     {
-                        // there is another folder or file at the same level,
-                        // so don't fold up, it should be on its own line
+                        // there is another folder or file at the same level, so don't fold up, it should be on its own line
                         should_skip_over -= 1;
                         break;
                     } else {
-                        // There is only one item at this level
-                        // (i.e only one folder in the folder),
+                        // There is only one item at this level (i.e only one folder in the folder),
                         // so do fold up
                         let vec_draw_text_info_len =
                             vec_draw_text_info.len();

--- a/src/components/filetree.rs
+++ b/src/components/filetree.rs
@@ -251,30 +251,13 @@ impl FileTreeComponent {
                     && tree_items[idx_temp + 1].info.indent
                         < tree_items[idx_temp + 2].info.indent
                 {
-                    // fold up the folder/file because there is only one in the directory
+                    // fold up the folder/file
                     idx_temp += 1;
                     should_skip_over += 1;
-
-                    // check if there is another folder or file at the same level, if there is, don't fold up
-                    let mut idx_temp_inner;
-                    if idx_temp + 2 < tree_items.len() {
-                        idx_temp_inner = idx_temp + 1;
-                        while tree_items[idx_temp].info.indent
-                            < tree_items[idx_temp_inner].info.indent
-                        {
-                            idx_temp_inner += 1;
-                            if idx_temp_inner == tree_items.len() - 1
-                            {
-                                break;
-                            }
-                        }
-                    } else {
-                        idx_temp_inner = idx_temp;
-                    }
-                    if tree_items[idx_temp_inner].info.indent
-                        == tree_items[idx_temp].info.indent
+                    // check if there is another folder or file at the same level
+                    if self.tree.tree.multiple_items_at_path(idx_temp)
                     {
-                        // there is another folder or file at the same level, so don't fold up, it should be on its own line
+                        // don't fold up
                         should_skip_over -= 1;
                         break;
                     } else {

--- a/src/components/filetree.rs
+++ b/src/components/filetree.rs
@@ -244,34 +244,30 @@ impl FileTreeComponent {
             });
 
             let mut idx_temp = index;
-            if index < (tree_items.len().saturating_sub(2)) {
-                while idx_temp < (tree_items.len().saturating_sub(2))
-                    && tree_items[idx_temp].info.indent
-                        < tree_items[idx_temp + 1].info.indent
-                    && tree_items[idx_temp + 1].info.indent
-                        < tree_items[idx_temp + 2].info.indent
-                {
-                    // fold up the folder/file
-                    idx_temp += 1;
-                    should_skip_over += 1;
-                    // check if there is another folder or file at the same level
-                    if self.tree.tree.multiple_items_at_path(idx_temp)
-                    {
-                        // don't fold up
-                        should_skip_over -= 1;
-                        break;
-                    } else {
-                        // There is only one item at this level (i.e only one folder in the folder),
-                        // so do fold up
-                        let vec_draw_text_info_len =
-                            vec_draw_text_info.len();
-                        vec_draw_text_info
-                            [vec_draw_text_info_len - 1]
-                            .name += &(String::from("/")
-                            + &tree_items[idx_temp].info.path);
-                        if index_above_select {
-                            selection_offset += 1;
-                        }
+            while idx_temp < (tree_items.len().saturating_sub(2))
+                && tree_items[idx_temp].info.indent
+                    < tree_items[idx_temp + 1].info.indent
+                && tree_items[idx_temp + 1].info.indent
+                    < tree_items[idx_temp + 2].info.indent
+            {
+                // fold up the folder/file
+                idx_temp += 1;
+                should_skip_over += 1;
+                // check if there is another folder or file at the same level
+                if self.tree.tree.multiple_items_at_path(idx_temp) {
+                    // don't fold up
+                    should_skip_over -= 1;
+                    break;
+                } else {
+                    // There is only one item at this level (i.e only one folder in the folder),
+                    // so do fold up
+                    let vec_draw_text_info_len =
+                        vec_draw_text_info.len();
+                    vec_draw_text_info[vec_draw_text_info_len - 1]
+                        .name += &(String::from("/")
+                        + &tree_items[idx_temp].info.path);
+                    if index_above_select {
+                        selection_offset += 1;
                     }
                 }
             }

--- a/src/components/filetree.rs
+++ b/src/components/filetree.rs
@@ -244,23 +244,31 @@ impl FileTreeComponent {
             });
 
             let mut idx_temp = index;
-            while idx_temp < (tree_items.len().saturating_sub(2))
+
+            while idx_temp < tree_items.len().saturating_sub(2)
                 && tree_items[idx_temp].info.indent
                     < tree_items[idx_temp + 1].info.indent
-                && tree_items[idx_temp + 1].info.indent
-                    < tree_items[idx_temp + 2].info.indent
             {
                 // fold up the folder/file
                 idx_temp += 1;
                 should_skip_over += 1;
-                // check if there is another folder or file at the same level
+
+                // don't fold files up
+                if let FileTreeItemKind::File(_) =
+                    &tree_items[idx_temp].kind
+                {
+                    should_skip_over -= 1;
+                    break;
+                }
+
+                // don't fold up if more than one folder in folder
                 if self.tree.tree.multiple_items_at_path(idx_temp) {
-                    // don't fold up
                     should_skip_over -= 1;
                     break;
                 } else {
                     // There is only one item at this level (i.e only one folder in the folder),
                     // so do fold up
+
                     let vec_draw_text_info_len =
                         vec_draw_text_info.len();
                     vec_draw_text_info[vec_draw_text_info_len - 1]

--- a/src/components/filetree.rs
+++ b/src/components/filetree.rs
@@ -145,7 +145,7 @@ impl FileTreeComponent {
         }
     }
 
-    fn item_to_text_simple<'b>(
+    fn item_to_text<'b>(
         string: &str,
         indent: usize,
         visible: bool,
@@ -351,7 +351,7 @@ impl DrawableComponent for FileTreeComponent {
                 .iter()
                 .enumerate()
                 .filter_map(|(index, draw_text_info)| {
-                    Self::item_to_text_simple(
+                    Self::item_to_text(
                         &draw_text_info.name,
                         draw_text_info.indent as usize,
                         draw_text_info.visible,

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -376,28 +376,6 @@ mod tests {
     }
 
     #[test]
-    fn test_find_parent() {
-        //0 a/
-        //1   b/
-        //2     c
-        //3     d
-
-        let res = FileTreeItems::new(
-            &string_vec_to_status(&[
-                "a/b/c", //
-                "a/b/d", //
-            ]),
-            &BTreeSet::new(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            res.find_parent_index(&String::from("a/b/c"), 3),
-            1
-        );
-    }
-
-    #[test]
     fn test_multiple_items_at_path() {
         //0 a/
         //1   b/

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -185,27 +185,6 @@ impl FileTreeItems {
         self.file_count
     }
 
-    ///
-    pub(crate) fn find_parent_index(
-        &self,
-        path: &str,
-        index: usize,
-    ) -> usize {
-        if let Some(parent_path) = Path::new(path).parent() {
-            let parent_path =
-                parent_path.to_str().expect("invalid path");
-            for i in (0..=index).rev() {
-                let item = &self.items[i];
-                let item_path = &item.info.full_path;
-                if item_path == parent_path {
-                    return i;
-                }
-            }
-        }
-
-        0
-    }
-
     fn push_dirs<'a>(
         item_path: &'a Path,
         nodes: &mut Vec<FileTreeItem>,
@@ -248,13 +227,8 @@ impl FileTreeItems {
             return false;
         }
 
-        if tree_items[idx_temp_inner].info.indent
+        tree_items[idx_temp_inner].info.indent
             == tree_items[index].info.indent
-        {
-            true
-        } else {
-            false
-        }
     }
 }
 

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -232,6 +232,32 @@ impl FileTreeItems {
 
         Ok(())
     }
+
+    pub fn multiple_items_at_path(&self, index: usize) -> bool {
+        let tree_items = self.items();
+        let mut idx_temp_inner;
+        if index + 2 < tree_items.len() {
+            idx_temp_inner = index + 1;
+            while tree_items[index].info.indent
+                < tree_items[idx_temp_inner].info.indent
+            {
+                idx_temp_inner += 1;
+                if idx_temp_inner == tree_items.len() - 1 {
+                    break;
+                }
+            }
+        } else {
+            idx_temp_inner = index;
+        }
+
+        if tree_items[idx_temp_inner].info.indent
+            == tree_items[index].info.indent
+        {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl IndexMut<usize> for FileTreeItems {

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -238,16 +238,14 @@ impl FileTreeItems {
         let mut idx_temp_inner;
         if index + 2 < tree_items.len() {
             idx_temp_inner = index + 1;
-            while tree_items[index].info.indent
-                < tree_items[idx_temp_inner].info.indent
+            while idx_temp_inner < tree_items.len().saturating_sub(1)
+                && tree_items[index].info.indent
+                    < tree_items[idx_temp_inner].info.indent
             {
                 idx_temp_inner += 1;
-                if idx_temp_inner == tree_items.len() - 1 {
-                    break;
-                }
             }
         } else {
-            idx_temp_inner = index;
+            return false;
         }
 
         if tree_items[idx_temp_inner].info.indent

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -422,4 +422,27 @@ mod tests {
             1
         );
     }
+
+    #[test]
+    fn test_multiple_items_at_path() {
+        //0 a/
+        //1   b/
+        //2     c/
+        //3       d
+        //4     e/
+        //5       f
+
+        let res = FileTreeItems::new(
+            &string_vec_to_status(&[
+                "a/b/c/d", //
+                "a/b/e/f", //
+            ]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(res.multiple_items_at_path(0), false);
+        assert_eq!(res.multiple_items_at_path(1), false);
+        assert_eq!(res.multiple_items_at_path(2), true);
+    }
 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -235,11 +235,9 @@ impl StatusTree {
                 } else {
                     // Find the closest to the index, usually this shouldn't happen
                     if current_index == 0 {
-                        // This should never happen,  if it does, this means there
-                        // was no first index in available_selections
-                        // which means there are elements in available_selections
-                        // but none are at 0, which does not make sense
-                        panic!("Something is wrong, unable to find which item is selected in the status tree.  There are items in the statustree but none are at index 0.  Restarting the application should fix this.");
+                        // This should never happen
+                        current_index_in_available_selections = 0;
+                        break;
                     }
                     cur_index_find -= 1;
                 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -203,7 +203,10 @@ impl StatusTree {
     ) -> SelectionChange {
         let mut current_index_in_available_selections;
         let mut cur_index_find = current_index;
-        if self.available_selections.len() > 0 {
+        if self.available_selections.is_empty() {
+            // Go to top
+            current_index_in_available_selections = 0;
+        } else {
             loop {
                 if let Some(pos) = self
                     .available_selections
@@ -222,9 +225,6 @@ impl StatusTree {
                     cur_index_find -= 1;
                 }
             }
-        } else {
-            // Go to top
-            current_index_in_available_selections = 0;
         }
 
         let mut new_index;
@@ -238,24 +238,19 @@ impl StatusTree {
                         .saturating_sub(1);
                 self.available_selections
                     [current_index_in_available_selections]
+            } else if current_index_in_available_selections
+                .saturating_add(1)
+                <= self.available_selections.len().saturating_sub(1)
+            {
+                current_index_in_available_selections =
+                    current_index_in_available_selections
+                        .saturating_add(1);
+                self.available_selections
+                    [current_index_in_available_selections]
             } else {
-                if current_index_in_available_selections
-                    .saturating_add(1)
-                    <= self
-                        .available_selections
-                        .len()
-                        .saturating_sub(1)
-                {
-                    current_index_in_available_selections =
-                        current_index_in_available_selections
-                            .saturating_add(1);
-                    self.available_selections
-                        [current_index_in_available_selections]
-                } else {
-                    // can't move down anymore
-                    new_index = current_index;
-                    break;
-                }
+                // can't move down anymore
+                new_index = current_index;
+                break;
             };
 
             if self.is_visible_index(new_index) {
@@ -329,7 +324,7 @@ impl StatusTree {
             || matches!(item_kind,FileTreeItemKind::Path(PathCollapsed(collapsed))
         if collapsed)
         {
-            return self.selection_updown(current_selection, true);
+            self.selection_updown(current_selection, true)
         } else if matches!(item_kind,  FileTreeItemKind::Path(PathCollapsed(collapsed))
         if !collapsed)
         {

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -329,11 +329,7 @@ impl StatusTree {
             || matches!(item_kind,FileTreeItemKind::Path(PathCollapsed(collapsed))
         if collapsed)
         {
-            SelectionChange::new(
-                self.tree
-                    .find_parent_index(&item_path, current_selection),
-                false,
-            )
+            return self.selection_updown(current_selection, true);
         } else if matches!(item_kind,  FileTreeItemKind::Path(PathCollapsed(collapsed))
         if !collapsed)
         {

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -120,7 +120,6 @@ impl StatusTree {
                         == tree_items[idx_temp].info.indent
                     {
                         // there is another folder or file at the same level, so don't fold up
-                        // don't skip over this one, it should be on its own line
                         should_skip_over -= 1;
                         break;
                     } else {

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -86,22 +86,20 @@ impl StatusTree {
             }
             let mut idx_temp = index;
             vec_available_selections.push(index);
-            if index < (tree_items.len().saturating_sub(2)) {
-                while idx_temp < (tree_items.len().saturating_sub(2))
-                    && tree_items[idx_temp].info.indent
-                        < tree_items[idx_temp + 1].info.indent
-                    && tree_items[idx_temp + 1].info.indent
-                        < tree_items[idx_temp + 2].info.indent
-                {
-                    // fold up the folder/file
-                    idx_temp += 1;
-                    should_skip_over += 1;
+            while idx_temp < (tree_items.len().saturating_sub(2))
+                && tree_items[idx_temp].info.indent
+                    < tree_items[idx_temp + 1].info.indent
+                && tree_items[idx_temp + 1].info.indent
+                    < tree_items[idx_temp + 2].info.indent
+            {
+                // fold up the folder/file
+                idx_temp += 1;
+                should_skip_over += 1;
 
-                    if self.tree.multiple_items_at_path(idx_temp) {
-                        // don't fold up
-                        should_skip_over -= 1;
-                        break;
-                    }
+                if self.tree.multiple_items_at_path(idx_temp) {
+                    // don't fold up
+                    should_skip_over -= 1;
+                    break;
                 }
             }
         }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -70,11 +70,10 @@ impl StatusTree {
         Ok(())
     }
 
-    /// Return which indices can be selected taking into account that
+    /// Return which indices can be selected, taking into account that
     /// some folders may be folded up into their parent
     ///
-    /// It should be impossible to select a folder
-    /// which has been folded into its parent
+    /// It should be impossible to select a folder which has been folded into its parent
     fn setup_available_selections(&self) -> Vec<usize> {
         // use the same algorithm as in filetree build_vec_text_for_drawing function
         let mut should_skip_over: usize = 0;
@@ -95,36 +94,13 @@ impl StatusTree {
                         < tree_items[idx_temp + 2].info.indent
                 {
                     // fold up the folder/file
-                    // because there is only one in the directory
                     idx_temp += 1;
                     should_skip_over += 1;
 
-                    // check if there is another folder or file at the
-                    // same level, if there is, don't fold up
-                    let mut idx_temp_inner;
-                    if idx_temp + 2 < tree_items.len() {
-                        idx_temp_inner = idx_temp + 1;
-                        while tree_items[idx_temp].info.indent
-                            < tree_items[idx_temp_inner].info.indent
-                        {
-                            idx_temp_inner += 1;
-                            if idx_temp_inner == tree_items.len() - 1
-                            {
-                                break;
-                            }
-                        }
-                    } else {
-                        idx_temp_inner = idx_temp;
-                    }
-                    if tree_items[idx_temp_inner].info.indent
-                        == tree_items[idx_temp].info.indent
-                    {
-                        // there is another folder or file at the same level, so don't fold up
+                    if self.tree.multiple_items_at_path(idx_temp) {
+                        // don't fold up
                         should_skip_over -= 1;
                         break;
-                    } else {
-                        // There is only one item at this level (in the folder)
-                        // so do fold up if this were a file or folder
                     }
                 }
             }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -791,8 +791,7 @@ mod tests {
 
         let mut res = StatusTree::default();
         res.update(&items).unwrap();
-
-        assert!(res.move_selection(MoveSelection::Down));
+        res.selection = Some(1);
 
         assert!(res.move_selection(MoveSelection::Down));
         assert_eq!(res.selection, Some(3));
@@ -808,5 +807,29 @@ mod tests {
 
         assert!(res.move_selection(MoveSelection::Down));
         assert_eq!(res.selection, Some(9));
+    }
+
+    #[test]
+    fn test_folders_fold_up_if_alone_in_directory_2() {
+        let items = string_vec_to_status(&["a/b/c/d/e/f/g/h"]);
+
+        //0 a/
+        //1   b/
+        //2     c/
+        //3       d/
+        //4         e/
+        //5           f/
+        //6             g/
+        //7               h
+
+        //0 a/b/c/d/e/f/g/
+        //7               h
+
+        let mut res = StatusTree::default();
+        res.update(&items).unwrap();
+        res.selection = Some(1);
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(7));
     }
 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -778,7 +778,8 @@ mod tests {
         //8     i/
         //9       j
 
-        //0 a/b/c/
+        //0 a/
+        //1   b/c/
         //3       d
         //4   e/f/
         //6       g
@@ -787,7 +788,10 @@ mod tests {
 
         let mut res = StatusTree::default();
         res.update(&items).unwrap();
-        res.selection = Some(1);
+        res.selection = Some(0);
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(1));
 
         assert!(res.move_selection(MoveSelection::Down));
         assert_eq!(res.selection, Some(3));
@@ -823,9 +827,78 @@ mod tests {
 
         let mut res = StatusTree::default();
         res.update(&items).unwrap();
-        res.selection = Some(1);
+        res.selection = Some(0);
 
         assert!(res.move_selection(MoveSelection::Down));
         assert_eq!(res.selection, Some(7));
+    }
+
+    #[test]
+    fn test_folders_fold_up_down_with_selection_left_right() {
+        let items = string_vec_to_status(&[
+            "a/b/c/d", //
+            "a/e/f/g", //
+            "a/h/i/j", //
+        ]);
+
+        //0 a/
+        //1   b/
+        //2     c/
+        //3       d
+        //4   e/
+        //5     f/
+        //6       g
+        //7   h/
+        //8     i/
+        //9       j
+
+        //0 a/
+        //1   b/c/
+        //3       d
+        //4   e/f/
+        //6       g
+        //7   h/i/
+        //9       j
+
+        let mut res = StatusTree::default();
+        res.update(&items).unwrap();
+        res.selection = Some(0);
+
+        assert!(res.move_selection(MoveSelection::Left));
+        assert_eq!(res.selection, Some(0));
+
+        // These should do nothing
+        res.move_selection(MoveSelection::Left);
+        res.move_selection(MoveSelection::Left);
+        assert_eq!(res.selection, Some(0));
+        //
+        assert!(res.move_selection(MoveSelection::Right)); // unfold 0
+        assert_eq!(res.selection, Some(0));
+
+        assert!(res.move_selection(MoveSelection::Right)); // move to 1
+        assert_eq!(res.selection, Some(1));
+
+        assert!(res.move_selection(MoveSelection::Left)); // fold 1
+        assert!(res.move_selection(MoveSelection::Down)); // move to 4
+        assert_eq!(res.selection, Some(4));
+
+        assert!(res.move_selection(MoveSelection::Left)); // fold 4
+        assert!(res.move_selection(MoveSelection::Down)); // move to 7
+        assert_eq!(res.selection, Some(7));
+
+        assert!(res.move_selection(MoveSelection::Right)); // move to 9
+        assert_eq!(res.selection, Some(9));
+
+        assert!(res.move_selection(MoveSelection::Left)); // move to 7
+        assert_eq!(res.selection, Some(7));
+
+        assert!(res.move_selection(MoveSelection::Left)); // folds 7
+        assert_eq!(res.selection, Some(7));
+        assert!(res.move_selection(MoveSelection::Left)); // move to 4
+        assert_eq!(res.selection, Some(4));
+        assert!(res.move_selection(MoveSelection::Left)); // move to 1
+        assert_eq!(res.selection, Some(1));
+        assert!(res.move_selection(MoveSelection::Left)); // move to 0
+        assert_eq!(res.selection, Some(0));
     }
 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -251,8 +251,6 @@ impl StatusTree {
                 }
             };
 
-            // Find a visible index, then break
-            // there must be at least 1
             if self.is_visible_index(new_index) {
                 break;
             }
@@ -756,5 +754,52 @@ mod tests {
         assert!(res.move_selection(MoveSelection::Down));
 
         assert_eq!(res.selection, Some(3));
+    }
+
+    #[test]
+    fn test_folders_fold_up_if_alone_in_directory() {
+        let items = string_vec_to_status(&[
+            "a/b/c/d", //
+            "a/e/f/g", //
+            "a/h/i/j", //
+        ]);
+
+        //0 a/
+        //1   b/
+        //2     c/
+        //3       d
+        //4   e/
+        //5     f/
+        //6       g
+        //7   h/
+        //8     i/
+        //9       j
+
+        //0 a/b/c/
+        //3       d
+        //4   e/f/
+        //6       g
+        //7   h/i/
+        //9       j
+
+        let mut res = StatusTree::default();
+        res.update(&items).unwrap();
+
+        assert!(res.move_selection(MoveSelection::Down));
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(3));
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(4));
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(6));
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(7));
+
+        assert!(res.move_selection(MoveSelection::Down));
+        assert_eq!(res.selection, Some(9));
     }
 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -86,18 +86,25 @@ impl StatusTree {
             }
             let mut idx_temp = index;
             vec_available_selections.push(index);
-            while idx_temp < (tree_items.len().saturating_sub(2))
+
+            while idx_temp < tree_items.len().saturating_sub(2)
                 && tree_items[idx_temp].info.indent
                     < tree_items[idx_temp + 1].info.indent
-                && tree_items[idx_temp + 1].info.indent
-                    < tree_items[idx_temp + 2].info.indent
             {
                 // fold up the folder/file
                 idx_temp += 1;
                 should_skip_over += 1;
 
+                // don't fold files up
+                if let FileTreeItemKind::File(_) =
+                    &tree_items[idx_temp].kind
+                {
+                    should_skip_over -= 1;
+                    break;
+                }
+
+                // don't fold up if more than one folder in folder
                 if self.tree.multiple_items_at_path(idx_temp) {
-                    // don't fold up
                     should_skip_over -= 1;
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ fn setup_logging() -> Result<()> {
     path.push("gitui.log");
 
     let _ = WriteLogger::init(
-        LevelFilter::Trace,
+        LevelFilter::Info,
         Config::default(),
         File::create(path)?,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ fn setup_logging() -> Result<()> {
     path.push("gitui.log");
 
     let _ = WriteLogger::init(
-        LevelFilter::Info,
+        LevelFilter::Trace,
         Config::default(),
         File::create(path)?,
     );


### PR DESCRIPTION
Closes #192.
Folds folders up into their parent if they are the only item it their directory.  For example:
Before:
![before_screenshot](https://user-images.githubusercontent.com/52405405/94304143-eb70b280-ff66-11ea-97a9-38238da85f20.png)
After:
![after_screenshot](https://user-images.githubusercontent.com/52405405/94304160-f297c080-ff66-11ea-951a-0cadbd2c5e6f.png)