### PR TITLE
Fix left key in tree broken

### DIFF
--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -186,24 +186,17 @@ impl FileTreeItems {
     }
 
     ///
-    pub(crate) fn find_parent_index(
-        &self,
-        path: &str,
-        index: usize,
-    ) -> usize {
-        if let Some(parent_path) = Path::new(path).parent() {
-            let parent_path =
-                parent_path.to_str().expect("invalid path");
-            for i in (0..=index).rev() {
-                let item = &self.items[i];
-                let item_path = &item.info.full_path;
-                if item_path == parent_path {
-                    return i;
-                }
+    pub(crate) fn find_parent_index(&self, index: usize) -> usize {
+        let item_indent = &self.items[index].info.indent;
+        let mut parent_index = index;
+        while item_indent <= &self.items[parent_index].info.indent {
+            if parent_index == 0 {
+                return 0;
             }
+            parent_index -= 1;
         }
 
-        0
+        parent_index
     }
 
     fn push_dirs<'a>(
@@ -435,9 +428,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            res.find_parent_index(&String::from("a/b/c"), 3),
-            1
-        );
+        assert_eq!(res.find_parent_index(3), 1);
     }
 }

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -185,6 +185,27 @@ impl FileTreeItems {
         self.file_count
     }
 
+    ///
+    pub(crate) fn find_parent_index(
+        &self,
+        path: &str,
+        index: usize,
+    ) -> usize {
+        if let Some(parent_path) = Path::new(path).parent() {
+            let parent_path =
+                parent_path.to_str().expect("invalid path");
+            for i in (0..=index).rev() {
+                let item = &self.items[i];
+                let item_path = &item.info.full_path;
+                if item_path == parent_path {
+                    return i;
+                }
+            }
+        }
+
+        0
+    }
+
     fn push_dirs<'a>(
         item_path: &'a Path,
         nodes: &mut Vec<FileTreeItem>,
@@ -396,5 +417,27 @@ mod tests {
         assert_eq!(res.multiple_items_at_path(0), false);
         assert_eq!(res.multiple_items_at_path(1), false);
         assert_eq!(res.multiple_items_at_path(2), true);
+    }
+
+    #[test]
+    fn test_find_parent() {
+        //0 a/
+        //1   b/
+        //2     c
+        //3     d
+
+        let res = FileTreeItems::new(
+            &string_vec_to_status(&[
+                "a/b/c", //
+                "a/b/d", //
+            ]),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            res.find_parent_index(&String::from("a/b/c"), 3),
+            1
+        );
     }
 }

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -324,7 +324,14 @@ impl StatusTree {
             || matches!(item_kind,FileTreeItemKind::Path(PathCollapsed(collapsed))
         if collapsed)
         {
-            self.selection_updown(current_selection, true)
+            let mut cur_parent =
+                self.tree.find_parent_index(current_selection);
+            while !self.available_selections.contains(&cur_parent)
+                && cur_parent != 0
+            {
+                cur_parent = self.tree.find_parent_index(cur_parent);
+            }
+            SelectionChange::new(cur_parent, false)
         } else if matches!(item_kind,  FileTreeItemKind::Path(PathCollapsed(collapsed))
         if !collapsed)
         {
@@ -889,11 +896,8 @@ mod tests {
 
         assert!(res.move_selection(MoveSelection::Left)); // folds 7
         assert_eq!(res.selection, Some(7));
-        assert!(res.move_selection(MoveSelection::Left)); // move to 4
-        assert_eq!(res.selection, Some(4));
-        assert!(res.move_selection(MoveSelection::Left)); // move to 1
-        assert_eq!(res.selection, Some(1));
-        assert!(res.move_selection(MoveSelection::Left)); // move to 0
+
+        assert!(res.move_selection(MoveSelection::Left)); // jump to 0
         assert_eq!(res.selection, Some(0));
     }
 }


### PR DESCRIPTION
Fixes #291

Pressing left now causes the selection to jump to the parent rather than just moving up one.