### PR TITLE
ui: mod; calc_scroll_top, fix missing const fn lint

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub use scrolllist::draw_list;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
 /// return the scroll position (line) necessary to have the `selection` in view if it is not already
+#[allow(clippy::missing_const_for_fn)]
 pub fn calc_scroll_top(
     current_top: usize,
     height_in_lines: usize,


### PR DESCRIPTION
@extrawurst small linter fix, please test

```
warning: this could be a `const fn`
  --> src/ui/mod.rs:10:1
   |
10 | / pub fn calc_scroll_top(
11 | |     current_top: usize,
12 | |     height_in_lines: usize,
13 | |     selection: usize,
...  |
21 | |     }
22 | | }
   | |_^
   |
note: the lint level is defined here
  --> src/main.rs:10:9
   |
10 | #![warn(clippy::missing_const_for_fn)]
```