### PR TITLE
Handled crash when git2 fails to obtain username from URL

### DIFF
--- a/asyncgit/src/sync/remotes.rs
+++ b/asyncgit/src/sync/remotes.rs
@@ -1,13 +1,13 @@
 //!
 
+use super::CommitId;
 use crate::{error::Result, sync::utils};
 use crossbeam_channel::Sender;
 use git2::{
-    Cred, FetchOptions, PackBuilderStage, PushOptions,
-    RemoteCallbacks, Error as GitError
+    Cred, Error as GitError, FetchOptions, PackBuilderStage,
+    PushOptions, RemoteCallbacks,
 };
 use scopetime::scope_time;
-use super::CommitId;
 ///
 #[derive(Debug, Clone)]
 pub enum ProgressNotification {
@@ -56,7 +56,7 @@ pub fn get_remotes(repo_path: &str) -> Result<Vec<String>> {
     let repo = utils::repo(repo_path)?;
     let remotes = repo.remotes()?;
     let remotes: Vec<String> =
-      remotes.iter().filter_map(|s| s).map(String::from).collect();
+        remotes.iter().filter_map(|s| s).map(String::from).collect();
 
     Ok(remotes)
 }
@@ -71,7 +71,7 @@ pub fn fetch_origin(repo_path: &str, branch: &str) -> Result<usize> {
     let mut options = FetchOptions::new();
     options.remote_callbacks(match remote_callbacks(None) {
         Ok(callback) => callback,
-        Err(e) => return Err(e)
+        Err(e) => return Err(e),
     });
 
     remote.fetch(&[branch], Some(&mut options), None)?;
@@ -93,10 +93,12 @@ pub fn push(
 
     let mut options = PushOptions::new();
 
-    options.remote_callbacks(match remote_callbacks(Some(progress_sender)) {
-        Ok(callbacks) => callbacks,
-        Err(e) => return Err(e)
-    });
+    options.remote_callbacks(
+        match remote_callbacks(Some(progress_sender)) {
+            Ok(callbacks) => callbacks,
+            Err(e) => return Err(e),
+        },
+    );
     options.packbuilder_parallelism(0);
 
     remote.push(&[branch], Some(&mut options))?;
@@ -172,12 +174,10 @@ fn remote_callbacks<'a>(
         );
 
         match username_from_url {
-            Some(username) => {
-                Cred::ssh_key_from_agent(
-                    username,
-                )
-            },
-            None => Err(GitError::from_str(" Couldn't extract username from url."))
+            Some(username) => Cred::ssh_key_from_agent(username),
+            None => Err(GitError::from_str(
+                " Couldn't extract username from url.",
+            )),
         }
     });
 

--- a/asyncgit/src/sync/remotes.rs
+++ b/asyncgit/src/sync/remotes.rs
@@ -4,12 +4,10 @@ use crate::{error::Result, sync::utils};
 use crossbeam_channel::Sender;
 use git2::{
     Cred, FetchOptions, PackBuilderStage, PushOptions,
-    RemoteCallbacks,
+    RemoteCallbacks, Error as GitError
 };
 use scopetime::scope_time;
-
 use super::CommitId;
-
 ///
 #[derive(Debug, Clone)]
 pub enum ProgressNotification {
@@ -58,7 +56,7 @@ pub fn get_remotes(repo_path: &str) -> Result<Vec<String>> {
     let repo = utils::repo(repo_path)?;
     let remotes = repo.remotes()?;
     let remotes: Vec<String> =
-        remotes.iter().filter_map(|s| s).map(String::from).collect();
+      remotes.iter().filter_map(|s| s).map(String::from).collect();
 
     Ok(remotes)
 }
@@ -71,7 +69,10 @@ pub fn fetch_origin(repo_path: &str, branch: &str) -> Result<usize> {
     let mut remote = repo.find_remote("origin")?;
 
     let mut options = FetchOptions::new();
-    options.remote_callbacks(remote_callbacks(None));
+    options.remote_callbacks(match remote_callbacks(None) {
+        Ok(callback) => callback,
+        Err(e) => return Err(e)
+    });
 
     remote.fetch(&[branch], Some(&mut options), None)?;
 
@@ -92,7 +93,10 @@ pub fn push(
 
     let mut options = PushOptions::new();
 
-    options.remote_callbacks(remote_callbacks(Some(progress_sender)));
+    options.remote_callbacks(match remote_callbacks(Some(progress_sender)) {
+        Ok(callbacks) => callbacks,
+        Err(e) => return Err(e)
+    });
     options.packbuilder_parallelism(0);
 
     remote.push(&[branch], Some(&mut options))?;
@@ -102,7 +106,7 @@ pub fn push(
 
 fn remote_callbacks<'a>(
     sender: Option<Sender<ProgressNotification>>,
-) -> RemoteCallbacks<'a> {
+) -> Result<RemoteCallbacks<'a>> {
     let mut callbacks = RemoteCallbacks::new();
     let sender_clone = sender.clone();
     callbacks.push_transfer_progress(move |current, total, bytes| {
@@ -167,12 +171,17 @@ fn remote_callbacks<'a>(
             allowed_types
         );
 
-        Cred::ssh_key_from_agent(
-            username_from_url.expect("username not found"),
-        )
+        match username_from_url {
+            Some(username) => {
+                Cred::ssh_key_from_agent(
+                    username,
+                )
+            },
+            None => Err(GitError::from_str(" Couldn't extract username from url."))
+        }
     });
 
-    callbacks
+    Ok(callbacks)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I modified `remote_callbacks( )` to return a `Result<RemoteCallbacks<'a>>` with an error in case the `credentials` callback fails, I also matched every occurrence of the `remote_callbacks( )` function to handle the possible scenarios.

An error is now correctly displayed when this occurs.
![Screenshot_20201004_131058](https://user-images.githubusercontent.com/22224438/95026010-116f1480-0643-11eb-8857-de756471dce6.png)

Linked to [#304](https://github.com/extrawurst/gitui/issues/304)
