### PR TITLE
Draw scrollbar for long commit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ![push](assets/push.gif)
 
+- scrollbar in long commit messages ([#308](https://github.com/extrawurst/gitui/issues/308))
+
 ### Changed
 - do not highlight selection in diff view when not focused ([#270](https://github.com/extrawurst/gitui/issues/270))
 - compact treeview [[@WizardOhio24](https://github.com/WizardOhio24)] ([#192](https://github.com/extrawurst/gitui/issues/192))

--- a/src/components/commit_details/details.rs
+++ b/src/components/commit_details/details.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     keys::SharedKeyConfig,
     strings::{self, order},
-    ui::style::SharedTheme,
+    ui::{self, style::SharedTheme},
 };
 use anyhow::Result;
 use asyncgit::{
@@ -355,6 +355,17 @@ impl DrawableComponent for DetailsComponent {
             ),
             chunks[1],
         );
+
+        if self.focused {
+            ui::draw_scrollbar(
+                f,
+                chunks[1],
+                &self.theme,
+                self.get_number_of_lines(width as usize)
+                    .saturating_sub(height as usize),
+                self.scroll_top.get(),
+            )
+        }
 
         Ok(())
     }

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -41,7 +41,7 @@ impl Widget for Scrollbar {
             vertical: 1,
         });
 
-        if area.height <= 4 {
+        if area.height < 4 {
             return;
         }
 


### PR DESCRIPTION
Closes #308 

Implements drawing a scrollbar when the commit message is too long. Also, I changed the minimum area height for the scrollbar to 4 so that the scrollbar would be drawn in the default terminal window (80x25):

![scrollbar_in_commit_msg](https://user-images.githubusercontent.com/8186312/95263974-49d74400-0837-11eb-8161-15f5f6574f02.gif)
