### PR TITLE
Add missing colon to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Context (please complete the following information):**
  - OS/Distro + Version: [e.g. `macOS 10.15.5`]
- - GitUI Version [e.g. `0.5`]
+ - GitUI Version: [e.g. `0.5`]
  - Rust version: [e.g `1.44`]
 
 **Additional context**


### PR DESCRIPTION
While submitting an issue I noticed a simple error in the format.