### PR TITLE
Use helper binary for clipboard access (#262)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
         profile: minimal
         components: clippy
 
-    - name: Install dependencies for clipboard access
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get -qq install libxcb-shape0-dev libxcb-xfixes0-dev
-
     - name: Build Debug
       run: |
         rustc --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "bytemuck"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,28 +175,6 @@ dependencies = [
  "bitflags",
  "textwrap 0.11.0",
  "unicode-width",
-]
-
-[[package]]
-name = "clipboard"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
-dependencies = [
- "clipboard-win",
- "objc",
- "objc-foundation",
- "objc_id",
- "x11-clipboard",
-]
-
-[[package]]
-name = "clipboard-win"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -448,7 +420,6 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
- "clipboard",
  "crossbeam-channel",
  "crossterm 0.18.0",
  "dirs",
@@ -560,9 +531,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.72"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libgit2-sys"
@@ -629,15 +600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -784,35 +746,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -1403,22 +1336,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x11-clipboard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
-dependencies = [
- "xcb",
-]
-
-[[package]]
-name = "xcb"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
-dependencies = [
- "libc",
- "log",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ serde = "1.0"
 anyhow = "1.0.33"
 unicode-width = "0.1"
 textwrap = "0.12"
-clipboard = { version = "0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 pprof = { version = "0.3", features = ["flamegraph"], optional = true }
@@ -49,7 +48,7 @@ pprof = { version = "0.3", features = ["flamegraph"], optional = true }
 maintenance = { status = "actively-developed" }
 
 [features]
-default=["clipboard"]
+default=[]
 timing=["scopetime/enabled"]
 
 [workspace]

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ release-linux-musl: build-linux-musl-release
 	tar -C ./target/x86_64-unknown-linux-musl/release/ -czvf ./release/gitui-linux-musl.tar.gz ./gitui
 
 build-linux-musl-debug:
-	cargo build --target=x86_64-unknown-linux-musl --no-default-features
+	cargo build --target=x86_64-unknown-linux-musl
 
 build-linux-musl-release:
-	cargo build --release --target=x86_64-unknown-linux-musl --no-default-features
+	cargo build --release --target=x86_64-unknown-linux-musl
 
 test-linux-musl:
-	cargo test --workspace --target=x86_64-unknown-linux-musl --no-default-features
+	cargo test --workspace --target=x86_64-unknown-linux-musl
 
 test:
 	cargo test --workspace

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -269,7 +269,7 @@ impl DiffComponent {
                 self,
                 "copy to clipboard error:",
                 crate::clipboard::copy_string(
-                    lines_to_copy.join("\n")
+                    &lines_to_copy.join("\n")
                 )
             );
         }
@@ -611,13 +611,11 @@ impl Component for DiffComponent {
             self.focused,
         ));
 
-        if crate::clipboard::is_supported() {
-            out.push(CommandInfo::new(
-                strings::commands::copy(&self.key_config),
-                true,
-                self.focused,
-            ));
-        }
+        out.push(CommandInfo::new(
+            strings::commands::copy(&self.key_config),
+            true,
+            self.focused,
+        ));
 
         out.push(
             CommandInfo::new(
@@ -697,9 +695,7 @@ impl Component for DiffComponent {
                         }
                     }
                     Ok(true)
-                } else if e == self.key_config.copy
-                    && crate::clipboard::is_supported()
-                {
+                } else if e == self.key_config.copy {
                     self.copy_selection()?;
                     Ok(true)
                 } else {


### PR DESCRIPTION
Use `clip` on Windows, `pbcopy` on MacOX, `xclip` on Linux.

Remove dependency on `clipboard`.

Closes #262.
