### PR TITLE
fix: push gauge blinks

### DIFF
--- a/src/components/push.rs
+++ b/src/components/push.rs
@@ -155,10 +155,10 @@ impl DrawableComponent for PushComponent {
                             .border_type(BorderType::Thick)
                             .border_style(self.theme.block(true)),
                     )
-                    .style(
+                    .gauge_style(
                         Style::default()
-                            .fg(Color::White)
-                            .bg(Color::Black), // .modifier(Modifier::ITALIC),
+                            .fg(Color::Reset)
+                            .bg(Color::Reset), // .modifier(Modifier::ITALIC),
                     )
                     .percent(u16::from(progress)),
                 area,


### PR DESCRIPTION
Fix #328 

I think the problem comes from a bug in tui-rs (https://github.com/fdehau/tui-rs/issues/400).

Anyway, we can bypass this bug with this fix.

Is this ok for you ?
![gitui-gauge-fix-2020-10-16_02 00 08](https://user-images.githubusercontent.com/2017216/96198074-1346ab00-0f54-11eb-90bb-6203bf84ed0b.gif)
