### PR TITLE
feat: dynamic branch popup size

### DIFF
--- a/src/components/select_branch.rs
+++ b/src/components/select_branch.rs
@@ -45,13 +45,19 @@ impl DrawableComponent for SelectBranchComponent {
         // Render a scrolllist of branches inside a box
 
         if self.visible {
-            const SIZE: (u16, u16) = (50, 20);
-            let scroll_threshold = SIZE.1 / 3;
+            const PERCENT_SIZE: (u16, u16) = (60, 25);
+            const MIN_SIZE: (u16, u16) = (50, 20);
+
+            let area = ui::centered_rect(
+                PERCENT_SIZE.0,
+                PERCENT_SIZE.1,
+                f.size(),
+            );
+            let area = ui::rect_min(MIN_SIZE.0, MIN_SIZE.1, area);
+
+            let scroll_threshold = area.height / 3;
             let scroll =
                 self.selection.saturating_sub(scroll_threshold);
-
-            let area =
-                ui::centered_rect_absolute(SIZE.0, SIZE.1, f.size());
 
             f.render_widget(Clear, area);
             f.render_widget(
@@ -275,15 +281,17 @@ impl SelectBranchComponent {
         theme: &SharedTheme,
         width_available: u16,
     ) -> Result<Text> {
-        const BRANCH_NAME_LENGTH: usize = 15;
         const COMMIT_HASH_LENGTH: usize = 8;
         const IS_HEAD_STAR_LENGTH: usize = 3; // "*  "
         const THREE_DOTS_LENGTH: usize = 3; // "..."
 
+        // branch name = 30% of area size
+        let branch_name_length: usize =
+            width_available as usize * 30 / 100;
         // commit message takes up the remaining width
         let commit_message_length: usize = (width_available as usize)
             .saturating_sub(COMMIT_HASH_LENGTH)
-            .saturating_sub(BRANCH_NAME_LENGTH)
+            .saturating_sub(branch_name_length)
             .saturating_sub(IS_HEAD_STAR_LENGTH)
             .saturating_sub(THREE_DOTS_LENGTH);
         let mut txt = Vec::new();
@@ -301,9 +309,9 @@ impl SelectBranchComponent {
             }
 
             let mut branch_name = displaybranch.name.clone();
-            if branch_name.len() > BRANCH_NAME_LENGTH {
+            if branch_name.len() > branch_name_length {
                 branch_name.truncate(
-                    BRANCH_NAME_LENGTH
+                    branch_name_length
                         .saturating_sub(THREE_DOTS_LENGTH),
                 );
                 branch_name += "...";
@@ -322,7 +330,7 @@ impl SelectBranchComponent {
                         format!(
                             ">{:w$} ",
                             branch_name,
-                            w = BRANCH_NAME_LENGTH
+                            w = branch_name_length
                         ),
                         theme.commit_author(true),
                     ),
@@ -348,7 +356,7 @@ impl SelectBranchComponent {
                         format!(
                             " {:w$} ",
                             branch_name,
-                            w = BRANCH_NAME_LENGTH
+                            w = branch_name_length
                         ),
                         theme.commit_author(false),
                     ),


### PR DESCRIPTION
Fix #346.

I have used a dynamic size (width=60%, height=25%) and I have kept a minimum size for small screen (original size).

Finally, branch name size is now 30% of popup size.

![gitui-window-size](https://user-images.githubusercontent.com/2017216/96649434-61332880-1331-11eb-8e5f-48fa1fe7888f.gif)

This is very interesting to work on a rust project like this :smiley: 