### PR TITLE
Add branch name in Status and ChangesComponent cleanup

### DIFF
--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -52,10 +52,7 @@ impl ChangesComponent {
 
     pub fn update(&mut self) -> Result<()> {
         if self.is_working_dir {
-            self.files.set_title(format!(
-                    "{}",
-                    &self.title, 
-                    ))
+            self.files.set_title(format!("{}", &self.title,))
         }
         Ok(())
     }

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -11,7 +11,7 @@ use crate::{
     ui::style::SharedTheme,
 };
 use anyhow::Result;
-use asyncgit::{cached, sync, StatusItem, StatusItemType, CWD};
+use asyncgit::{sync, StatusItem, StatusItemType, CWD};
 use crossterm::event::Event;
 use std::path::Path;
 use tui::{backend::Backend, layout::Rect, Frame};
@@ -22,7 +22,6 @@ pub struct ChangesComponent {
     files: FileTreeComponent,
     is_working_dir: bool,
     queue: Queue,
-    branch_name: cached::BranchName,
     key_config: SharedKeyConfig,
 }
 
@@ -47,26 +46,18 @@ impl ChangesComponent {
             ),
             is_working_dir,
             queue,
-            branch_name: cached::BranchName::new(CWD),
             key_config,
         }
     }
 
     pub fn update(&mut self) -> Result<()> {
         if self.is_working_dir {
-            if let Ok(branch_name) = self.branch_name.lookup() {
-                self.files.set_title(format!(
-                    "{} - {{{}}}",
-                    &self.title, branch_name,
-                ))
-            }
+            self.files.set_title(format!(
+                    "{}",
+                    &self.title, 
+                    ))
         }
         Ok(())
-    }
-
-    ///
-    pub fn branch_name(&self) -> Option<String> {
-        self.branch_name.last()
     }
 
     ///

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -18,7 +18,6 @@ use tui::{backend::Backend, layout::Rect, Frame};
 
 ///
 pub struct ChangesComponent {
-    title: String,
     files: FileTreeComponent,
     is_working_dir: bool,
     queue: Queue,
@@ -36,7 +35,6 @@ impl ChangesComponent {
         key_config: SharedKeyConfig,
     ) -> Self {
         Self {
-            title: title.into(),
             files: FileTreeComponent::new(
                 title,
                 focus,
@@ -48,13 +46,6 @@ impl ChangesComponent {
             queue,
             key_config,
         }
-    }
-
-    pub fn update(&mut self) -> Result<()> {
-        if self.is_working_dir {
-            self.files.set_title(format!("{}", &self.title,))
-        }
-        Ok(())
     }
 
     ///

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -259,7 +259,6 @@ impl Status {
             self.git_status_stage
                 .fetch(StatusParams::new(StatusType::Stage, true))?;
 
-            self.index_wd.update()?;
             self.check_branch_state();
         }
 

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -162,11 +162,12 @@ impl Status {
     ) {
         if let Some(branch_name) = self.git_branch_name.last() {
             let w = Paragraph::new(format!(
-                    "\u{2191}{} \u{2193}{} {{{}}}",
-                    self.git_branch_state.ahead, self.git_branch_state.behind,
-                    branch_name
-                    ))
-                .alignment(Alignment::Right);
+                "\u{2191}{} \u{2193}{} {{{}}}",
+                self.git_branch_state.ahead,
+                self.git_branch_state.behind,
+                branch_name
+            ))
+            .alignment(Alignment::Right);
 
             let mut rect = if self.index_wd.focused() {
                 let mut rect = chunks[0];
@@ -178,8 +179,9 @@ impl Status {
 
             rect.x += 1;
             rect.width = rect.width.saturating_sub(2);
-            rect.height =
-                rect.height.saturating_sub(rect.height.saturating_sub(1));
+            rect.height = rect
+                .height
+                .saturating_sub(rect.height.saturating_sub(1));
 
             f.render_widget(w, rect);
         }


### PR DESCRIPTION
This fixes #365.

Still not sure if lookup in `update` function is done correctly:
```rust
self.git_branch_name.lookup().map(Some).unwrap_or(None)
```
Other than that I think everything is okay now :)