### PR TITLE
Aborting on panic for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,4 @@ members=[
 lto = true
 opt-level = 'z'  # Optimize for size.
 codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
>Why might you choose to do this? By removing support for unwinding, **you'll get smaller binaries**.

https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/aborting-on-panic.html

![image](https://user-images.githubusercontent.com/67187266/97220371-49d9bc80-17c3-11eb-9ac6-6f9d9334b074.png)
(not sure why it is so much bigger than what the README stats (1.4MB))