### PR TITLE
Fix scrollbar in commit msg

### DIFF
--- a/src/components/commit_details/details.rs
+++ b/src/components/commit_details/details.rs
@@ -355,14 +355,18 @@ impl DrawableComponent for DetailsComponent {
         );
 
         if self.focused {
-            ui::draw_scrollbar(
-                f,
-                chunks[1],
-                &self.theme,
-                self.get_number_of_lines(width as usize)
-                    .saturating_sub(height as usize),
-                self.scroll_top.get(),
-            )
+            if self.get_number_of_lines(width as usize)
+                > height as usize
+            {
+                ui::draw_scrollbar(
+                    f,
+                    chunks[1],
+                    &self.theme,
+                    self.get_number_of_lines(width as usize)
+                        .saturating_sub(height as usize),
+                    self.scroll_top.get(),
+                )
+            }
         }
 
         Ok(())

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -45,10 +45,6 @@ impl Widget for Scrollbar {
             return;
         }
 
-        if area.height > self.max {
-            return;
-        }
-
         for y in area.top()..area.bottom() {
             buf.set_string(right, y, THICK_VERTICAL, self.style_bar);
         }


### PR DESCRIPTION
Fixes #350

Well I know that may not be the perfect solution, but a better fix itself would have to be inside `scrollbar.rs` anyway. This has to do with the way of how position of scrollbar is calculated, and changing `max` parameter of `draw_scrollbar` function would change nothing as either the scrollbar would never reach the end, or there would be a lot of empty lines.

This functionality would display scrollbar by default (which, regardless of this fix, is also the case with diff) and a simple check can prevent it from rendering. 

What do you think?