### PR TITLE
Remove ui::style::ColorDef in favor up tui::style::Color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "crossterm 0.17.7",
+ "serde",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ scopetime = { path = "./scopetime", version = "0.1" }
 asyncgit = { path = "./asyncgit", version = "0.10" }
 crossterm = { version = "0.18", features = [ "serde" ] }
 clap = { version = "2.33", default-features = false }
-tui = { version = "0.12", default-features = false, features = ['crossterm'] }
+tui = { version = "0.12", default-features = false, features = ['crossterm', 'serde'] }
 bytesize = { version = "1.0.1", default-features = false}
 itertools = "0.9"
 rayon-core = "1.9"

--- a/THEMES.md
+++ b/THEMES.md
@@ -1,4 +1,4 @@
-# Themes 
+# Themes
 
 default on light terminal:
 ![](assets/light-theme.png)
@@ -10,5 +10,4 @@ to change the colors of the program you have to modify `theme.ron` file
 * `$XDG_CONFIG_HOME/gitui/theme.ron` (linux using XDG)
 * `$HOME/.config/gitui/theme.ron` (linux)
 
-Valid colors can be found in [ColorDef](./src/ui/style.rs#ColorDef) struct. note that rgb colors might not be supported 
-in every terminal.
+Valid colors can be found in tui-rs' [Color](https://docs.rs/tui/0.12.0/tui/style/enum.Color.html) struct. note that rgb colors might not be supported in every terminal.

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -18,35 +18,34 @@ pub type SharedTheme = Rc<Theme>;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Theme {
-    #[serde(with = "ColorDef")]
     selected_tab: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     command_fg: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     selection_bg: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     cmdbar_extra_lines_bg: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     disabled_fg: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_line_add: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_line_delete: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_file_added: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_file_removed: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_file_moved: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     diff_file_modified: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     commit_hash: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     commit_time: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     commit_author: Color,
-    #[serde(with = "ColorDef")]
+    #[serde(with = "Color")]
     danger_fg: Color,
 }
 
@@ -265,30 +264,4 @@ impl Default for Theme {
             danger_fg: Color::Red,
         }
     }
-}
-
-/// we duplicate the Color definition from `tui` crate to implement Serde serialisation
-/// this enum can be removed once [tui-#292](https://github.com/fdehau/tui-rs/issues/292) is resolved
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
-#[serde(remote = "Color")]
-enum ColorDef {
-    Reset,
-    Black,
-    Red,
-    Green,
-    Yellow,
-    Blue,
-    Magenta,
-    Cyan,
-    Gray,
-    DarkGray,
-    LightRed,
-    LightGreen,
-    LightYellow,
-    LightBlue,
-    LightMagenta,
-    LightCyan,
-    White,
-    Rgb(u8, u8, u8),
-    Indexed(u8),
 }


### PR DESCRIPTION
As serialization support is landed in tui v0.10.0, we can remove the custom type. I also updated `THEME.md` to point to the documentation of the tui type.

Closes #149.

