### PR TITLE
Add ability to select multiple commits in commit log

### DIFF
--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -269,7 +269,7 @@ impl CommitList {
         let selection = self.relative_selection();
 
         let mut txt: Vec<Spans> = Vec::with_capacity(height);
-        //self.scroll_top.get() ==
+
         for (idx, e) in self
             .items
             .iter()

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -374,14 +374,14 @@ impl Component for CommitList {
                 self.move_selection(ScrollType::Up)?
             } else if k == self.key_config.move_down {
                 self.move_selection(ScrollType::Down)?
-            } else if k == self.key_config.shift_up
-                || k == self.key_config.home
-            {
+            } else if k == self.key_config.shift_up {
                 self.move_selection(ScrollType::ShiftUp)?
-            } else if k == self.key_config.shift_down
-                || k == self.key_config.end
-            {
+            } else if k == self.key_config.shift_down {
                 self.move_selection(ScrollType::ShiftDown)?
+            } else if k == self.key_config.home {
+                self.move_selection(ScrollType::Home)?
+            } else if k == self.key_config.end {
+                self.move_selection(ScrollType::End)?
             } else if k == self.key_config.page_up {
                 self.move_selection(ScrollType::PageUp)?
             } else if k == self.key_config.page_down {

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -198,7 +198,6 @@ impl DiffComponent {
                 ScrollType::Up => {
                     self.selection.get_top().saturating_sub(1)
                 }
-                ScrollType::Home => 0,
                 ScrollType::End => max,
                 ScrollType::PageDown => {
                     self.selection.get_bottom().saturating_add(
@@ -212,6 +211,7 @@ impl DiffComponent {
                             as usize,
                     )
                 }
+                ScrollType::Home | _ => 0,
             };
 
             let new_start = cmp::min(max, new_start);

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -113,6 +113,8 @@ pub enum ScrollType {
     End,
     PageUp,
     PageDown,
+    ShiftUp,
+    ShiftDown,
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Adds the ability to select multiple commits.  After this, squashing commits should be able to be implemented, but that should be a different PR.
To select multiple commits, use SHIFT+ARROW, so shift-down would select the current commit and the commit below.

![Screenshot_20201105_235336](https://user-images.githubusercontent.com/52405405/98309291-03097500-1fc2-11eb-8ed7-df1362268c92.png)