### PR TITLE
Multi line

### DIFF
--- a/src/components/cred.rs
+++ b/src/components/cred.rs
@@ -4,7 +4,7 @@ use tui::{backend::Backend, layout::Rect, Frame};
 
 use asyncgit::sync::cred::BasicAuthCredential;
 
-use crate::components::TextInputComponent;
+use crate::components::{InputType, TextInputComponent};
 use crate::{
     components::{
         visibility_blocking, CommandBlocking, CommandInfo, Component,
@@ -37,13 +37,15 @@ impl CredComponent {
                 key_config.clone(),
                 &strings::username_popup_title(&key_config),
                 &strings::username_popup_msg(&key_config),
-            ),
+            )
+            .with_input_type(InputType::Singleline),
             input_password: TextInputComponent::new(
                 theme,
                 key_config.clone(),
                 &strings::password_popup_title(&key_config),
                 &strings::password_popup_msg(&key_config),
-            ),
+            )
+            .with_input_type(InputType::Password),
             key_config,
             cred: BasicAuthCredential::new(None, None),
         }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -207,11 +207,11 @@ fn dialog_paragraph<'a>(
 
 fn popup_paragraph<'a>(
     title: &'a str,
-    content: Vec<Span<'a>>,
+    content: Vec<Spans<'a>>,
     theme: &Theme,
     focused: bool,
 ) -> Paragraph<'a> {
-    Paragraph::new(Spans::from(content))
+    Paragraph::new(content)
         .block(
             Block::default()
                 .title(Span::styled(title, theme.title(focused)))

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -41,7 +41,7 @@ pub use reset::ResetComponent;
 pub use select_branch::SelectBranchComponent;
 pub use stashmsg::StashMsgComponent;
 pub use tag_commit::TagCommitComponent;
-pub use textinput::TextInputComponent;
+pub use textinput::{InputType, TextInputComponent};
 pub use utils::filetree::FileTreeItemKind;
 
 use crate::ui::style::Theme;

--- a/src/components/reset.rs
+++ b/src/components/reset.rs
@@ -11,7 +11,8 @@ use anyhow::Result;
 use crossterm::event::Event;
 use std::borrow::Cow;
 use tui::{
-    backend::Backend, layout::Rect, text::Span, widgets::Clear, Frame,
+    backend::Backend, layout::Rect, text::Span, text::Spans,
+    widgets::Clear, Frame,
 };
 use ui::style::SharedTheme;
 
@@ -33,10 +34,10 @@ impl DrawableComponent for ResetComponent {
         if self.visible {
             let (title, msg) = self.get_text();
 
-            let txt = vec![Span::styled(
+            let txt = vec![Spans::from(Span::styled(
                 Cow::from(msg),
                 self.theme.text_danger(),
-            )];
+            ))];
 
             let area = ui::centered_rect(30, 20, f.size());
             f.render_widget(Clear, area);

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -427,8 +427,6 @@ mod tests {
         assert_eq!(txt.len(), 2);
         assert_eq!(get_text(&l1_spans[0]), Some("a"));
         assert_eq!(get_text(&l1_spans[1]), Some("_"));
-        //assert_eq!(get_style(&l1_spans[1]), Some(&underlined));
-        //assert_eq!(get_text(&txt[2]), Some("\n"));
         assert_eq!(get_text(&l2_spans[0]), Some("b"));
     }
 

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -138,11 +138,14 @@ impl TextInputComponent {
             ));
         }
 
+        // this code with _ for the trailing cursor character needs to be revised once tui fixes
+        // it should be NBSP => const NBSP: &str = "\u{00a0}";
+        // ...
         let cursor_str = self
             .next_char_position()
             // if the cursor is at the end of the msg
             // a whitespace is used to underline
-            .map_or(" ".to_owned(), |pos| {
+            .map_or("_".to_owned(), |pos| {
                 self.get_msg(self.cursor_position..pos)
             });
 
@@ -155,10 +158,15 @@ impl TextInputComponent {
             ));
         }
 
-        txt.push(Span::styled(
-            cursor_str,
-            style.add_modifier(Modifier::UNDERLINED),
-        ));
+        // ... and this conditional underline needs to be removed
+        if cursor_str == "_" {
+            txt.push(Span::styled(cursor_str, style));
+        } else {
+            txt.push(Span::styled(
+                cursor_str,
+                style.add_modifier(Modifier::UNDERLINED),
+            ));
+        }
 
         // The final portion of the text is added if there are
         // still remaining characters.
@@ -364,7 +372,8 @@ mod tests {
             "",
         );
         let theme = SharedTheme::default();
-        let underlined = theme
+        // retained for when tui trailing NBSP bug fixed
+        let _underlined = theme
             .text(true, false)
             .add_modifier(Modifier::UNDERLINED);
 
@@ -378,8 +387,8 @@ mod tests {
         assert_eq!(txt.len(), 2);
         assert_eq!(get_text(&txt[0]), Some("a"));
         assert_eq!(get_style(&txt[0]), Some(&not_underlined));
-        assert_eq!(get_text(&txt[1]), Some(" "));
-        assert_eq!(get_style(&txt[1]), Some(&underlined));
+        assert_eq!(get_text(&txt[1]), Some("_"));
+        assert_eq!(get_style(&txt[1]), Some(&not_underlined));
     }
 
     #[test]


### PR DESCRIPTION
This is the bare minimum (as requested) of changes to fix this bug https://github.com/extrawurst/gitui/issues/405

 - You can still edit the first line when you return from the external editor.
 -  If you backspace out the whole first line then the second line moves up tp become the first line. I can prevent that if you like.
 -  There is no way to see more lines than will fit in the dialog box

Its my understanding that this is what others wanted.

Note - the display of the hard unicode CR character is gone because I wasnt sure what to do with it. The current code only shows it on the current line (which can only be the first one), should it be shown on every line? In what place? Should it be added if it would make the line overflow the screen width
