### PR TITLE
Add cache to GithubActions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Restore cargo cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-cargo-crates
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+
     - name: Get version
       id: get_version
       run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,14 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Restore cargo cache
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-cargo-crates
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
-
     - name: Get version
       id: get_version
       run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         cache-name: cache-cargo-crates
       with:
         path: ~/.cargo
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.rust }}-${{ hashFiles('Cargo.lock') }}
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Restore cargo cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-cargo-crates
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Closes #409 

Adds the ability for Github Actions to cache the build process so it doesn't download or build anything if nothing is changed.