### PR TITLE
Cache ./cargo/bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          ~/.cargo/bin
           target
         key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}-${{ hashFiles('Cargo.lock') }}
 


### PR DESCRIPTION
Is there any reason we aren't caching this?  This is where rustup, rustc, cargo... is stored which are all downloaded at the start of the CI.