### PR TITLE
use '<space>\u{200b}' for a '<space>' so tui doesn't remove it

### DIFF
--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -142,7 +142,7 @@ impl TextInputComponent {
             .next_char_position()
             // if the cursor is at the end of the msg
             // a whitespace is used to underline
-            .map_or(" ".to_owned(), |pos| {
+            .map_or(" \u{200b}".to_owned(), |pos| {
                 self.get_msg(self.cursor_position..pos)
             });
 

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(txt.len(), 2);
         assert_eq!(get_text(&txt[0]), Some("a"));
         assert_eq!(get_style(&txt[0]), Some(&not_underlined));
-        assert_eq!(get_text(&txt[1]), Some(" "));
+        assert_eq!(get_text(&txt[1]), Some(" \u{200b}"));
         assert_eq!(get_style(&txt[1]), Some(&underlined));
     }
 


### PR DESCRIPTION
This causes the ending space to be preserved in the text block so it shows as underlined, this can be removed once https://github.com/fdehau/tui-rs/issues/404 is resolved.