### PR TITLE
Use theme for push gauge

### DIFF
--- a/src/components/push.rs
+++ b/src/components/push.rs
@@ -23,7 +23,6 @@ use crossterm::event::Event;
 use tui::{
     backend::Backend,
     layout::Rect,
-    style::{Color, Style},
     text::Span,
     widgets::{Block, BorderType, Borders, Clear, Gauge},
     Frame,
@@ -188,12 +187,7 @@ impl DrawableComponent for PushComponent {
                             .border_type(BorderType::Thick)
                             .border_style(self.theme.block(true)),
                     )
-                    .gauge_style(
-                        //TODO: use theme
-                        Style::default()
-                            .fg(Color::White)
-                            .bg(Color::Black),
-                    )
+                    .gauge_style(self.theme.push_gauge())
                     .percent(u16::from(progress)),
                 area,
             );

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -47,6 +47,10 @@ pub struct Theme {
     commit_author: Color,
     #[serde(with = "Color")]
     danger_fg: Color,
+    #[serde(with = "Color")]
+    push_gauge_bg: Color,
+    #[serde(with = "Color")]
+    push_gauge_fg: Color,
 }
 
 impl Theme {
@@ -220,6 +224,12 @@ impl Theme {
         )
     }
 
+    pub fn push_gauge(&self) -> Style {
+        Style::default()
+            .fg(self.push_gauge_fg)
+            .bg(self.push_gauge_bg)
+    }
+
     fn save(&self) -> Result<()> {
         let theme_file = Self::get_theme_file()?;
         let mut file = File::create(theme_file)?;
@@ -276,6 +286,8 @@ impl Default for Theme {
             commit_time: Color::LightCyan,
             commit_author: Color::Green,
             danger_fg: Color::Red,
+            push_gauge_bg: Color::White,
+            push_gauge_fg: Color::Red,
         }
     }
 }


### PR DESCRIPTION
Fixes #401 

This makes the push gauge red rather than black because explicit black looks odd on most terminals whereas red looks OK.