### PR TITLE
Give better error message for editor enviroment variable if variable is empty

### DIFF
--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -75,7 +75,7 @@ impl ExternalEditorComponent {
         let mut editor = editor.split_whitespace();
 
         let command = editor.next().ok_or_else(|| {
-            anyhow!("unable to read editor command")
+            anyhow!("Environment config variable for opening an editor is empty, check \"GIT_EDITOR\", \"VISUAL\" and \"EDITOR\" environment variables are not empty.")
         })?;
 
         let mut editor: Vec<&OsStr> =


### PR DESCRIPTION
This is link to a discussion in #419. 

This gives a better error message for opening an external editor.  This is also linked to #400, but is different because this gives a specific error message, saying the one of the environment variables must be empty.