### PR TITLE
Allow user to set theme with flag

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -3,11 +3,13 @@
 default on light terminal:
 ![](assets/light-theme.png)
 
-to change the colors of the program you have to modify `theme.ron` file
+to change the colors of the default theme you have to modify `theme.ron` file
 [Ron format](https://github.com/ron-rs/ron) located at config path. The path differs depending on the operating system:
 
 * `$HOME/Library/Application Support/gitui/theme.ron` (mac)
 * `$XDG_CONFIG_HOME/gitui/theme.ron` (linux using XDG)
 * `$HOME/.config/gitui/theme.ron` (linux)
+
+Alternatively you may make a theme in the same directory mentioned above with and select with the `-t` flag followed by the name of the file in the directory. E.g. If you are on linux calling `gitui -t arc.ron` wil use `$XDG_CONFIG_HOME/gitui/arc.ron` or `$HOME/.config/gitui/arc.ron`
 
 Valid colors can be found in tui-rs' [Color](https://docs.rs/tui/0.12.0/tui/style/enum.Color.html) struct. note that rgb colors might not be supported in every terminal.

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ use crossbeam_channel::Sender;
 use crossterm::event::{Event, KeyEvent};
 use std::{
     cell::{Cell, RefCell},
-    path::Path,
+    path::{Path, PathBuf},
     rc::Rc,
 };
 use tui::{
@@ -70,10 +70,11 @@ impl App {
     pub fn new(
         sender: &Sender<AsyncNotification>,
         input: Input,
+        theme_path: PathBuf,
     ) -> Self {
         let queue = Queue::default();
 
-        let theme = Rc::new(Theme::init());
+        let theme = Rc::new(Theme::init(theme_path));
         let key_config = Rc::new(KeyConfig::init());
 
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,12 @@ pub enum QueueEvent {
     InputEvent(InputEvent),
 }
 
+struct CliArgs {
+    theme: PathBuf,
+}
+
 fn main() -> Result<()> {
-    process_cmdline()?;
+    let cliargs = process_cmdline()?;
 
     let _profiler = Profiler::new();
 
@@ -100,7 +104,7 @@ fn main() -> Result<()> {
     let ticker = tick(TICK_INTERVAL);
     let spinner_ticker = tick(SPINNER_INTERVAL);
 
-    let mut app = App::new(&tx_git, input);
+    let mut app = App::new(&tx_git, input, cliargs.theme);
 
     let mut spinner = Spinner::default();
     let mut first_update = true;
@@ -261,7 +265,7 @@ fn setup_logging() -> Result<()> {
     Ok(())
 }
 
-fn process_cmdline() -> Result<()> {
+fn process_cmdline() -> Result<CliArgs> {
     let app = ClapApp::new(crate_name!())
         .author(crate_authors!())
         .version(crate_version!())
@@ -301,12 +305,14 @@ fn process_cmdline() -> Result<()> {
     let arg_theme =
         arg_matches.value_of("theme").unwrap_or("theme.ron");
     if get_app_config_path()?.join(arg_theme).is_file() {
-        env::set_var("GITUI_THEME", arg_theme)
+        Ok(CliArgs {
+            theme: get_app_config_path()?.join(arg_theme),
+        })
     } else {
-        env::set_var("GITUI_THEME", "theme.ron")
+        Ok(CliArgs {
+            theme: get_app_config_path()?.join("theme.ron"),
+        })
     }
-
-    Ok(())
 }
 
 fn set_panic_handlers() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,14 @@ fn process_cmdline() -> Result<()> {
         .version(crate_version!())
         .about(crate_description!())
         .arg(
+            Arg::with_name("theme")
+                .help("Set the color theme (defaults to theme.ron")
+                .short("t")
+                .long("theme")
+                .value_name("THEME")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("logging")
                 .help("Stores logging output into a cache directory")
                 .short("l")
@@ -289,6 +297,13 @@ fn process_cmdline() -> Result<()> {
         let directory =
             arg_matches.value_of("directory").unwrap_or(".");
         env::set_current_dir(directory)?;
+    }
+    let arg_theme =
+        arg_matches.value_of("theme").unwrap_or("theme.ron");
+    if get_app_config_path()?.join(arg_theme).is_file() {
+        env::set_var("GITUI_THEME", arg_theme)
+    } else {
+        env::set_var("GITUI_THEME", "theme.ron")
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn process_cmdline() -> Result<()> {
         .about(crate_description!())
         .arg(
             Arg::with_name("theme")
-                .help("Set the color theme (defaults to theme.ron")
+                .help("Set the color theme (defaults to theme.ron)")
                 .short("t")
                 .long("theme")
                 .value_name("THEME")

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -7,6 +7,7 @@ use ron::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    env,
     fs::File,
     io::{Read, Write},
     path::PathBuf,
@@ -238,9 +239,18 @@ impl Theme {
         Ok(())
     }
 
+    /// Check for GITUI_THEME if it exists use it, otherwise use theme.ron
     fn get_theme_file() -> Result<PathBuf> {
         let app_home = get_app_config_path()?;
-        Ok(app_home.join("theme.ron"))
+
+        Ok(if let Some(env) = env::var_os("GITUI_THEME") {
+            match env.to_str() {
+                Some(x) => app_home.join(x),
+                None => app_home.join("theme.ron"),
+            }
+        } else {
+            app_home.join("theme.ron")
+        })
     }
 
     fn read_file(theme_file: PathBuf) -> Result<Self> {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -259,10 +259,9 @@ impl Theme {
         Ok(from_bytes(&buffer)?)
     }
 
-    fn init_internal() -> Result<Self> {
-        let file = Self::get_theme_file()?;
-        if file.exists() {
-            Ok(Self::read_file(file)?)
+    fn init_internal(theme: PathBuf) -> Result<Self> {
+        if theme.exists() {
+            Ok(Self::read_file(theme)?)
         } else {
             let def = Self::default();
             if def.save().is_err() {
@@ -272,8 +271,8 @@ impl Theme {
         }
     }
 
-    pub fn init() -> Self {
-        Self::init_internal().unwrap_or_default()
+    pub fn init(theme_path: PathBuf) -> Self {
+        Self::init_internal(theme_path).unwrap_or_default()
     }
 }
 

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -239,17 +239,16 @@ impl Theme {
         Ok(())
     }
 
-    /// Check for GITUI_THEME if it exists use it, otherwise use theme.ron
+    /// Check for `GITUI_THEME` if it exists use it, otherwise use theme.ron
     fn get_theme_file() -> Result<PathBuf> {
         let app_home = get_app_config_path()?;
 
-        Ok(if let Some(env) = env::var_os("GITUI_THEME") {
-            match env.to_str() {
+        Ok(match env::var_os("GITUI_THEME") {
+            Some(env) => match env.to_str() {
                 Some(x) => app_home.join(x),
                 None => app_home.join("theme.ron"),
-            }
-        } else {
-            app_home.join("theme.ron")
+            },
+            None => app_home.join("theme.ron"),
         })
     }
 


### PR DESCRIPTION
### This pull request allows user to set gitui theme by passing a flag (-t,  --theme). Address [Issue 480](https://github.com/extrawurst/gitui/issues/480)

The argument it takes is files a file relative to the app_config directory, meaning if the (linux) user passes `-t example.ron` to gitui then the theme located at `~/.config/gitui/example.ron` will be used. If `~/.config/gitui/example.ron` doesn't exist then `theme.ron` will be used.

This works by setting environment variable `GITUI_THEME` while processing command line arguments and reading it in function get_theme_file.