### PR TITLE
fix crash when no remote called 'origin' present (#486)

### DIFF
--- a/asyncgit/src/sync/branch.rs
+++ b/asyncgit/src/sync/branch.rs
@@ -1,5 +1,6 @@
 //!
 
+use super::{remotes::get_first_remote_in_repo, utils::bytes2string};
 use crate::{
     error::{Error, Result},
     sync::{utils, CommitId},
@@ -7,8 +8,6 @@ use crate::{
 use git2::{BranchType, Repository};
 use scopetime::scope_time;
 use utils::get_head_repo;
-
-use super::utils::bytes2string;
 
 /// returns the branch-name head is currently pointing to
 /// this might be expensive, see `cached::BranchName`
@@ -98,8 +97,8 @@ pub(crate) fn branch_set_upstream(
         repo.find_branch(branch_name, BranchType::Local)?;
 
     if branch.upstream().is_err() {
-        //TODO: what about other remote names
-        let upstream_name = format!("origin/{}", branch_name);
+        let remote = get_first_remote_in_repo(repo)?;
+        let upstream_name = format!("{}/{}", remote, branch_name);
         branch.set_upstream(Some(upstream_name.as_str()))?;
     }
 

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -41,8 +41,8 @@ pub use hunks::{reset_hunk, stage_hunk, unstage_hunk};
 pub use ignore::add_to_ignore;
 pub use logwalker::LogWalker;
 pub use remotes::{
-    fetch_origin, get_remotes, push, ProgressNotification,
-    DEFAULT_REMOTE_NAME,
+    fetch_origin, get_first_remote, get_remotes, push,
+    ProgressNotification,
 };
 pub use reset::{reset_stage, reset_workdir};
 pub use stash::{get_stashes, stash_apply, stash_drop, stash_save};


### PR DESCRIPTION
this will pick up the first remote we can find. maybe its a better strategy to fail always when no `origin` is present and we have another way to push to a specific remote, or even pull up a popup when wanting to push and no `origin` is defined to choose the remote to use.

closes #486 