### PR TITLE
keep uncommitted msg around.

### DIFF
--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -112,9 +112,11 @@ impl Component for CommitComponent {
     }
 
     fn show(&mut self) -> Result<()> {
+        if self.amend.is_some() {
+            self.input.clear();
+        }
         self.amend = None;
 
-        self.input.clear();
         self.input
             .set_title(strings::commit_title(&self.key_config));
         self.input.show()?;


### PR DESCRIPTION
when adding *amend* this got broken because in that case we want to clear out the msg when it was not confirmed.

closes #530