### PR TITLE
Fix MacOS force push tests sometimes failing

### DIFF
--- a/asyncgit/src/sync/remotes.rs
+++ b/asyncgit/src/sync/remotes.rs
@@ -533,6 +533,8 @@ mod tests {
             true
         );
 
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
         assert_eq!(
             upstream
                 .find_commit((other_repo_commit_ids[0]).into())

--- a/asyncgit/src/sync/remotes.rs
+++ b/asyncgit/src/sync/remotes.rs
@@ -409,7 +409,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_force_push_rewrites_history() {
         use super::push;
         use std::fs::File;
@@ -536,7 +535,7 @@ mod tests {
 
         assert_eq!(
             upstream
-                .find_commit((commit_ids[0]).into())
+                .find_commit((other_repo_commit_ids[0]).into())
                 .unwrap()
                 .parents()
                 .next()


### PR DESCRIPTION
Closes #534 

Test this a few times before merging, it seems only the MacOS tests are effected.
Just opening this at the moment so the CI will run the test.  Will mark it ready for review when it's ready.