### PR TITLE
fix(StatusTab): cleanup status tab

### DIFF
--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -639,12 +639,6 @@ impl Component for DiffComponent {
             self.focused,
         ));
 
-        out.push(CommandInfo::new(
-            strings::commands::copy(&self.key_config),
-            true,
-            self.focused,
-        ));
-
         out.push(
             CommandInfo::new(
                 strings::commands::diff_home_end(&self.key_config),
@@ -679,6 +673,12 @@ impl Component for DiffComponent {
                 self.focused && !self.is_stage(),
             ));
         }
+
+        out.push(CommandInfo::new(
+            strings::commands::copy(&self.key_config),
+            true,
+            self.focused,
+        ));
 
         CommandBlocking::PassingOn
     }

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -461,36 +461,34 @@ impl Component for Status {
                 force_all,
                 self.components().as_slice(),
             );
-
-            out.push(CommandInfo::new(
-                strings::commands::open_branch_select_popup(
-                    &self.key_config,
-                ),
-                true,
-                true,
-            ));
-
             out.push(CommandInfo::new(
                 strings::commands::status_push(&self.key_config),
                 self.can_push(),
-                true,
+                self.can_push(),
             ));
             out.push(CommandInfo::new(
                 strings::commands::status_force_push(
                     &self.key_config,
                 ),
                 self.can_push(),
-                true,
-            ));
-            out.push(CommandInfo::new(
-                strings::commands::status_pull(&self.key_config),
-                true,
-                true,
+                self.can_push(),
             ));
         }
 
         {
             let focus_on_diff = self.focus == Focus::Diff;
+            out.push(CommandInfo::new(
+                strings::commands::status_pull(&self.key_config),
+                !focus_on_diff,
+                !focus_on_diff,
+            ));
+            out.push(CommandInfo::new(
+                strings::commands::open_branch_select_popup(
+                    &self.key_config,
+                ),
+                !focus_on_diff,
+                !focus_on_diff,
+            ));
             out.push(CommandInfo::new(
                 strings::commands::edit_item(&self.key_config),
                 if focus_on_diff {


### PR DESCRIPTION
- Moved `copy` to back
- `pull` and `branches` not shown or available when diff has focus
- `psuh` and `force push` only available when something can be pushed

Fixes #572