### PR TITLE
Fix commit_amend in vim style key config

### DIFF
--- a/assets/vim_style_key_config.ron
+++ b/assets/vim_style_key_config.ron
@@ -64,7 +64,7 @@
 
     cmd_bar_toggle: ( code: Char('.'), modifiers: ( bits: 0,),),
     log_tag_commit: ( code: Char('t'), modifiers: ( bits: 0,),),
-    commit_amend: ( code: Char('A'), modifiers: ( bits: 1,),),
+    commit_amend: ( code: Char('a'), modifiers: ( bits: 2,),),
     copy: ( code: Char('y'), modifiers: ( bits: 0,),),
     create_branch: ( code: Char('c'), modifiers: ( bits: 0,),),
     rename_branch: ( code: Char('r'), modifiers: ( bits: 0,),),


### PR DESCRIPTION
The same problem as with uppercase <kbd>E</kbd> for opening editor – <kbd>Shift</kbd> cannot be used as modifier in commit-message editing floating window. Use <kbd>Ctrl</kbd> + <kbd>A</kbd> instead.