### PR TITLE
Fix build

### DIFF
--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -97,7 +97,7 @@ impl CommitList {
     }
 
     ///
-    pub const fn tags(&self) -> Option<&Tags> {
+    pub fn tags(&self) -> Option<&Tags> {
         self.tags.as_ref()
     }
 


### PR DESCRIPTION
On ubuntu 18.04 LTS, there is a build error:

```
error: `std::option::Option::<T>::as_ref` is not yet stable as a const fn
   --> src/components/commitlist.rs:101:9
    |
101 |         self.tags.as_ref()
    |         ^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

This patch is fix that.