### PR TITLE
Fix CommitMessage combine wrongly concatenating subject to body

### DIFF
--- a/asyncgit/src/sync/commit_details.rs
+++ b/asyncgit/src/sync/commit_details.rs
@@ -60,7 +60,7 @@ impl CommitMessage {
     ///
     pub fn combine(self) -> String {
         if let Some(body) = self.body {
-            format!("{}{}", self.subject, body)
+            format!("{}\n{}", self.subject, body)
         } else {
             self.subject
         }
@@ -155,6 +155,15 @@ mod tests {
 
         assert_eq!(msg.subject, String::from("foo"),);
         assert_eq!(msg.body, Some(String::from("bar\ntest")),);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_commit_message_combine() -> Result<()> {
+        let msg = CommitMessage::from("foo\nbar\r\ntest");
+
+        assert_eq!(msg.combine(), String::from("foo\nbar\ntest"));
 
         Ok(())
     }


### PR DESCRIPTION
`CommitMessage::combine` simply concatenates the `subject` string to the `body`. However, when the `CommigMessage` is created from a previous commit message (e.g., when amending a commit), the subject was in a different line than the rest of the commit message.

So, if your commit message was:
```
Line 1
Line 2
```

Commit amend within gitui will set the commit message to `Line1Line2`.

This PR fixes that by introducing a line break in the `format!` macro.