### PR TITLE
Allow adding newlines in commit message with alt+enter

### DIFF
--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -340,6 +340,7 @@ impl Component for TextInputComponent {
 
                 let is_ctrl =
                     e.modifiers.contains(KeyModifiers::CONTROL);
+                let is_alt = e.modifiers.contains(KeyModifiers::ALT);
 
                 match e.code {
                     KeyCode::Char(c) if !is_ctrl => {
@@ -371,6 +372,14 @@ impl Component for TextInputComponent {
                     }
                     KeyCode::End => {
                         self.cursor_position = self.msg.len();
+                        return Ok(true);
+                    }
+                    KeyCode::Enter if is_alt => {
+                        // Alt+enter inserts newline.
+                        // Note shift+enter is not supported:
+                        // https://github.com/crossterm-rs/crossterm/issues/400
+                        self.msg.insert(self.cursor_position, '\n');
+                        self.incr_cursor();
                         return Ok(true);
                     }
                     _ => (),


### PR DESCRIPTION
One thing I found added quite a bit of friction while using gitui was writing more than a single-line commit message. From writing a commit message to realizing "I need an extra few lines to explain better" currently requires doing:

1. From the commit window, press ctrl+e
2. `$EDITOR` is launched
3. Write commit message with newlines
4. Press save
5. Close editor window

Not complex, but.. definitely a little tedious

Instead I've added `alt+enter` as a shortcut to insert a literal newline in the commit message.

I think it would be more conventional to use `shift+enter` for this (e.g I've often found chat clients tend to use "shift+enter" to add newlines instead of sending message), however this doesn't seem possible in many terminal emulators according to https://github.com/crossterm-rs/crossterm/issues/400 - so I settled on alt+enter

Before polishing this up (adding note of this to the help text at button, test case, etc) - is this feature desirable?