### PR TITLE
Improve blame view

### DIFF
--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     #[error("git: uncommitted changes")]
     UncommittedChanges,
 
+    #[error("git: can\u{2019}t run blame on a binary file")]
+    NoBlameOnBinaryFile,
+
     #[error("io error:{0}")]
     Io(#[from] std::io::Error),
 

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -25,7 +25,7 @@ pub mod status;
 mod tags;
 pub mod utils;
 
-pub use blame::{blame_file, BlameHunk, FileBlame};
+pub use blame::{blame_file, BlameAt, BlameHunk, FileBlame};
 pub use branch::{
     branch_compare_upstream, checkout_branch, config_is_pull_rebase,
     create_branch, delete_branch, get_branch_remote,

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,7 @@ impl App {
                 key_config.clone(),
             ),
             blame_file_popup: BlameFileComponent::new(
+                &queue,
                 &strings::blame_title(&key_config),
                 theme.clone(),
                 key_config.clone(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -104,7 +104,7 @@ impl Default for KeyConfig {
 			shift_up: KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::SHIFT},
 			shift_down: KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::SHIFT},
 			enter: KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::empty()},
-			blame: KeyEvent { code: KeyCode::Char('b'), modifiers: KeyModifiers::empty()},
+			blame: KeyEvent { code: KeyCode::Char('B'), modifiers: KeyModifiers::SHIFT},
 			edit_file: KeyEvent { code: KeyCode::Char('e'), modifiers: KeyModifiers::empty()},
 			status_stage_all: KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::empty()},
 			status_reset_item: KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT},

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -229,6 +229,19 @@ impl Theme {
         )
     }
 
+    pub fn commit_hash_in_blame(
+        &self,
+        is_blamed_commit: bool,
+    ) -> Style {
+        if is_blamed_commit {
+            Style::default()
+                .fg(self.commit_hash)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(self.commit_hash)
+        }
+    }
+
     pub fn push_gauge(&self) -> Style {
         Style::default()
             .fg(self.push_gauge_fg)

--- a/vim_style_key_config.ron
+++ b/vim_style_key_config.ron
@@ -45,7 +45,7 @@
     shift_down: ( code: Char('J'), modifiers: ( bits: 1,),),
 
     enter: ( code: Enter, modifiers: ( bits: 0,),),
-    blame: ( code: Char('b'), modifiers: ( bits: 0,),),
+    blame: ( code: Char('B'), modifiers: ( bits: 1,),),
 
     edit_file: ( code: Char('I'), modifiers: ( bits: 1,),),
 


### PR DESCRIPTION
- Set default shortcut to `B` instead of `b` because the latter would
  shadow `[b]ranches`.
- Add scrollbar.
- Show resolved commit id in title instead of `HEAD`.
- Make commit id bold if it is the commit id the file is blamed at.
- Don’t run blame on a binary file.
- Add shortcut for inspecting a commit in blame view.

This closes #656.
