### PR TITLE
Add async wrapper to blame

### DIFF
--- a/asyncgit/src/blame.rs
+++ b/asyncgit/src/blame.rs
@@ -1,0 +1,182 @@
+use crate::{
+    error::Result,
+    hash,
+    sync::{self, BlameAt, FileBlame},
+    AsyncNotification, CWD,
+};
+use crossbeam_channel::Sender;
+use std::{
+    hash::Hash,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
+
+///
+#[derive(Hash, Clone, PartialEq)]
+pub struct BlameParams {
+    /// path to the file to blame
+    pub file_path: String,
+}
+
+struct Request<R, A>(R, Option<A>);
+
+#[derive(Default, Clone)]
+struct LastResult<P, R> {
+    params: P,
+    hash: u64,
+    result: R,
+}
+
+///
+pub struct AsyncBlame {
+    current: Arc<Mutex<Request<u64, FileBlame>>>,
+    last: Arc<Mutex<Option<LastResult<BlameParams, FileBlame>>>>,
+    sender: Sender<AsyncNotification>,
+    pending: Arc<AtomicUsize>,
+}
+
+impl AsyncBlame {
+    ///
+    pub fn new(sender: &Sender<AsyncNotification>) -> Self {
+        Self {
+            current: Arc::new(Mutex::new(Request(0, None))),
+            last: Arc::new(Mutex::new(None)),
+            sender: sender.clone(),
+            pending: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    ///
+    pub fn last(
+        &mut self,
+    ) -> Result<Option<(BlameParams, FileBlame)>> {
+        let last = self.last.lock()?;
+
+        Ok(last.clone().map(|last_result| {
+            (last_result.params, last_result.result)
+        }))
+    }
+
+    ///
+    pub fn refresh(&mut self) -> Result<()> {
+        if let Ok(Some(param)) = self.get_last_param() {
+            self.clear_current()?;
+            self.request(param)?;
+        }
+        Ok(())
+    }
+
+    ///
+    pub fn is_pending(&self) -> bool {
+        self.pending.load(Ordering::Relaxed) > 0
+    }
+
+    ///
+    pub fn request(
+        &mut self,
+        params: BlameParams,
+    ) -> Result<Option<FileBlame>> {
+        log::trace!("request");
+
+        let hash = hash(&params);
+
+        {
+            let mut current = self.current.lock()?;
+
+            if current.0 == hash {
+                return Ok(current.1.clone());
+            }
+
+            current.0 = hash;
+            current.1 = None;
+        }
+
+        let arc_current = Arc::clone(&self.current);
+        let arc_last = Arc::clone(&self.last);
+        let sender = self.sender.clone();
+        let arc_pending = Arc::clone(&self.pending);
+
+        self.pending.fetch_add(1, Ordering::Relaxed);
+
+        rayon_core::spawn(move || {
+            let notify = Self::get_blame_helper(
+                params,
+                &arc_last,
+                &arc_current,
+                hash,
+            );
+
+            let notify = match notify {
+                Err(err) => {
+                    log::error!("get_blame_helper error: {}", err);
+                    true
+                }
+                Ok(notify) => notify,
+            };
+
+            arc_pending.fetch_sub(1, Ordering::Relaxed);
+
+            sender
+                .send(if notify {
+                    AsyncNotification::Blame
+                } else {
+                    AsyncNotification::FinishUnchanged
+                })
+                .expect("error sending blame");
+        });
+
+        Ok(None)
+    }
+
+    fn get_blame_helper(
+        params: BlameParams,
+        arc_last: &Arc<
+            Mutex<Option<LastResult<BlameParams, FileBlame>>>,
+        >,
+        arc_current: &Arc<Mutex<Request<u64, FileBlame>>>,
+        hash: u64,
+    ) -> Result<bool> {
+        let file_blame = sync::blame::blame_file(
+            CWD,
+            &params.file_path,
+            &BlameAt::Head,
+        )?;
+
+        let mut notify = false;
+        {
+            let mut current = arc_current.lock()?;
+            if current.0 == hash {
+                current.1 = Some(file_blame.clone());
+                notify = true;
+            }
+        }
+
+        {
+            let mut last = arc_last.lock()?;
+            *last = Some(LastResult {
+                result: file_blame,
+                hash,
+                params,
+            });
+        }
+
+        Ok(notify)
+    }
+
+    fn get_last_param(&self) -> Result<Option<BlameParams>> {
+        Ok(self
+            .last
+            .lock()?
+            .clone()
+            .map(|last_result| last_result.params))
+    }
+
+    fn clear_current(&mut self) -> Result<()> {
+        let mut current = self.current.lock()?;
+        current.0 = 0;
+        current.1 = None;
+        Ok(())
+    }
+}

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -20,6 +20,7 @@
 //TODO: get this in someday since expect still leads us to crashes sometimes
 // #![deny(clippy::expect_used)]
 
+mod blame;
 pub mod cached;
 mod commit_files;
 mod diff;
@@ -35,6 +36,7 @@ pub mod sync;
 mod tags;
 
 pub use crate::{
+    blame::{AsyncBlame, BlameParams},
     commit_files::AsyncCommitFiles,
     diff::{AsyncDiff, DiffParams, DiffType},
     fetch::{AsyncFetch, FetchRequest},
@@ -75,6 +77,8 @@ pub enum AsyncNotification {
     PushTags,
     ///
     Fetch,
+    ///
+    Blame,
 }
 
 /// current working directory `./`

--- a/src/app.rs
+++ b/src/app.rs
@@ -96,6 +96,7 @@ impl App {
             ),
             blame_file_popup: BlameFileComponent::new(
                 &queue,
+                sender,
                 &strings::blame_title(&key_config),
                 theme.clone(),
                 key_config.clone(),
@@ -322,6 +323,7 @@ impl App {
         self.status_tab.update_git(ev)?;
         self.stashing_tab.update_git(ev)?;
         self.revlog.update_git(ev)?;
+        self.blame_file_popup.update_git(ev)?;
         self.inspect_commit_popup.update_git(ev)?;
         self.push_popup.update_git(ev)?;
         self.push_tags_popup.update_git(ev)?;
@@ -344,6 +346,7 @@ impl App {
         self.status_tab.anything_pending()
             || self.revlog.any_work_pending()
             || self.stashing_tab.anything_pending()
+            || self.blame_file_popup.any_work_pending()
             || self.inspect_commit_popup.any_work_pending()
             || self.input.is_state_changing()
             || self.push_popup.any_work_pending()


### PR DESCRIPTION
- Rename `self.path` to `self.file_path` in `BlameFileComponent`.
- Take into account that `draw_scrollbar` subtracts the area’s height
  before calculating the scrollbar’s position.

The implementation closely mirrors the one in `asyncgit/src/blame.rs`. Let me
know if I understood the async part correctly.

I tested the implementation locally in my `gitui` repository, and I did not
encounter any issues, but I also did not spend a large amount of time on
testing. If you think the implementation looks good, I will test it on a few
more repositories.

This closes #661.
