### PR TITLE
Preserves same branch dialog behavior

### DIFF
--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -202,7 +202,6 @@ impl Component for BranchListComponent {
                     self.queue
                         .borrow_mut()
                         .push_back(InternalEvent::CreateBranch);
-                    self.hide();
                 } else if e == self.key_config.rename_branch
                     && self.valid_selection()
                 {


### PR DESCRIPTION
This change delivers same behavior to create branch and rename per [#679 ](https://github.com/extrawurst/gitui/issues/679)

It is my first and small contribution to the project, hope everything is okay.