### PR TITLE
Add branch names to rev log

### DIFF
--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -12,7 +12,7 @@ use crate::{
 use anyhow::Result;
 use asyncgit::{
     cached,
-    sync::{self, CommitId},
+    sync::{self, get_branches_info, CommitId},
     AsyncLog, AsyncNotification, AsyncTags, FetchStatus, CWD,
 };
 use crossbeam_channel::Sender;
@@ -95,6 +95,12 @@ impl Revlog {
 
             self.list.set_branch(
                 self.branch_name.lookup().map(Some).unwrap_or(None),
+            );
+
+            self.list.set_local_branch_list(
+                get_branches_info(CWD, true)
+                    .map(Some)
+                    .unwrap_or(None),
             );
 
             if self.commit_details.is_visible() {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -48,6 +48,8 @@ pub struct Theme {
     #[serde(with = "Color")]
     commit_author: Color,
     #[serde(with = "Color")]
+    commit_local_branch: Color,
+    #[serde(with = "Color")]
     danger_fg: Color,
     #[serde(with = "Color")]
     push_gauge_bg: Color,
@@ -88,6 +90,17 @@ impl Theme {
         } else {
             branch
         }
+    }
+
+    pub fn branch_in_log(&self, selected: bool) -> Style {
+        Style::default()
+            .fg(self.commit_local_branch)
+            .add_modifier(Modifier::BOLD)
+            .bg(if selected {
+                self.selection_bg
+            } else {
+                Color::Reset
+            })
     }
 
     pub fn tab(&self, selected: bool) -> Style {
@@ -320,6 +333,7 @@ impl Default for Theme {
             commit_hash: Color::Magenta,
             commit_time: Color::LightCyan,
             commit_author: Color::Green,
+            commit_local_branch: Color::LightGreen,
             danger_fg: Color::Red,
             push_gauge_bg: Color::Blue,
             push_gauge_fg: Color::Reset,


### PR DESCRIPTION
Feature suggestion: add local branch names to the revlog. Personally I miss this feature a lot, I use it daily on the command line when working in a team that consists of more people than me :D
![feature_branchnames](https://user-images.githubusercontent.com/6555002/118403998-5fd0a100-b671-11eb-8510-4256f0c9a4ee.png)
