### PR TITLE
Remove hardcoded white color from selected tab (#719)

### DIFF
--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -92,9 +92,7 @@ impl Theme {
 
     pub fn tab(&self, selected: bool) -> Style {
         if selected {
-            self.text(true, false)
-                .fg(Color::White)
-                .add_modifier(Modifier::UNDERLINED)
+            self.text(true, false).add_modifier(Modifier::UNDERLINED)
         } else {
             self.text(false, false)
         }


### PR DESCRIPTION
Screenshots:

![fixed-light](https://user-images.githubusercontent.com/327943/119130431-382d6000-ba06-11eb-9e4c-e9c37dd3bba4.png)
![fixed-dark](https://user-images.githubusercontent.com/327943/119130442-3b285080-ba06-11eb-96ce-d4fd340abfa6.png)

See #719 for "before" screenshots and additional context.
