### PR TITLE
Allow overriding selected_tab via theme

### DIFF
--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -92,7 +92,9 @@ impl Theme {
 
     pub fn tab(&self, selected: bool) -> Style {
         if selected {
-            self.text(true, false).add_modifier(Modifier::UNDERLINED)
+            self.text(true, false)
+                .fg(self.selected_tab)
+                .add_modifier(Modifier::UNDERLINED)
         } else {
             self.text(false, false)
         }
@@ -304,7 +306,7 @@ impl Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            selected_tab: Color::Yellow,
+            selected_tab: Color::Reset,
             command_fg: Color::White,
             selection_bg: Color::Blue,
             cmdbar_extra_lines_bg: Color::Blue,


### PR DESCRIPTION
See #722

I think this makes the most sense, because the yellow color hasn't been a thing since [v0.3.0](https://github.com/extrawurst/gitui/releases/tag/v0.3.0) (that release is a year and a day old today). But if you want that back as the default, I can make that adjustment.