### PR TITLE
change temporary commit msg file path

### DIFF
--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -67,8 +67,8 @@ pub use state::{repo_state, RepoState};
 pub use tags::{get_tags, CommitTags, Tags};
 pub use tree::{tree_file_content, tree_files, TreeFile};
 pub use utils::{
-    get_head, get_head_tuple, is_bare_repo, is_repo, stage_add_all,
-    stage_add_file, stage_addremoved, Head,
+    get_head, get_head_tuple, is_bare_repo, is_repo, repo_dir,
+    stage_add_all, stage_add_file, stage_addremoved, Head,
 };
 
 #[cfg(test)]

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -4,7 +4,11 @@ use super::CommitId;
 use crate::error::{Error, Result};
 use git2::{IndexAddOption, Repository, RepositoryOpenFlags};
 use scopetime::scope_time;
-use std::{fs::File, io::Write, path::Path};
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 ///
 #[derive(PartialEq, Debug, Clone)]
@@ -54,6 +58,12 @@ pub(crate) fn repo(repo_path: &str) -> Result<Repository> {
 ///
 pub(crate) fn work_dir(repo: &Repository) -> Result<&Path> {
     repo.workdir().ok_or(Error::NoWorkDir)
+}
+
+/// path to .git folder
+pub fn repo_dir(repo_path: &str) -> Result<PathBuf> {
+    let repo = repo(repo_path)?;
+    Ok(repo.path().to_owned())
 }
 
 ///


### PR DESCRIPTION
we now use `.git/COMMIT_EDITMSG` for vim to recognise

closes #518