### PR TITLE
Use default key config and theme when values are missing

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -418,7 +418,6 @@ mod tests {
         let expected_tab_status = KeyEvent { code: KeyCode::Char('6'), modifiers: KeyModifiers::SHIFT };
         assert_eq!(config.tab_status, expected_tab_status);
 
-        let expected_default_tab_log = KeyEvent { code: KeyCode::Char('2'), modifiers: KeyModifiers::empty() };
-        assert_eq!(config.tab_log, expected_default_tab_log);
+        assert_eq!(config.tab_log, KeyConfig::default_tab_log());
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,19 +1,20 @@
 //TODO: remove once fixed https://github.com/rust-lang/rust-clippy/issues/6818
 #![allow(clippy::use_self)]
 
-use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ron::{
-    self,
-    ser::{to_string_pretty, PrettyConfig},
-};
-use serde::{Deserialize, Serialize};
 use std::{
     fs::{self, File},
     io::{Read, Write},
     path::PathBuf,
     rc::Rc,
 };
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ron::{
+    self,
+    ser::{PrettyConfig, to_string_pretty},
+};
+use serde::{Deserialize, Serialize};
 
 use crate::args::get_app_config_path;
 
@@ -22,123 +23,237 @@ pub type SharedKeyConfig = Rc<KeyConfig>;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeyConfig {
     pub tab_status: KeyEvent,
+    #[serde(default = "KeyConfig::default_tab_log")]
     pub tab_log: KeyEvent,
+    #[serde(default = "KeyConfig::default_tab_stashing")]
     pub tab_stashing: KeyEvent,
+    #[serde(default = "KeyConfig::default_tab_stashes")]
     pub tab_stashes: KeyEvent,
+    #[serde(default = "KeyConfig::default_tab_toggle")]
     pub tab_toggle: KeyEvent,
+    #[serde(default = "KeyConfig::default_tab_toggle_reverse")]
     pub tab_toggle_reverse: KeyEvent,
+    #[serde(default = "KeyConfig::default_toggle_workarea")]
     pub toggle_workarea: KeyEvent,
+    #[serde(default = "KeyConfig::default_focus_right")]
     pub focus_right: KeyEvent,
+    #[serde(default = "KeyConfig::default_focus_left")]
     pub focus_left: KeyEvent,
+    #[serde(default = "KeyConfig::default_focus_above")]
     pub focus_above: KeyEvent,
+    #[serde(default = "KeyConfig::default_focus_below")]
     pub focus_below: KeyEvent,
+    #[serde(default = "KeyConfig::default_exit")]
     pub exit: KeyEvent,
+    #[serde(default = "KeyConfig::default_exit_popup")]
     pub exit_popup: KeyEvent,
+    #[serde(default = "KeyConfig::default_open_commit")]
     pub open_commit: KeyEvent,
+    #[serde(default = "KeyConfig::default_open_commit_editor")]
     pub open_commit_editor: KeyEvent,
+    #[serde(default = "KeyConfig::default_open_help")]
     pub open_help: KeyEvent,
+    #[serde(default = "KeyConfig::default_move_left")]
     pub move_left: KeyEvent,
+    #[serde(default = "KeyConfig::default_move_right")]
     pub move_right: KeyEvent,
+    #[serde(default = "KeyConfig::default_tree_collapse_recursive")]
     pub tree_collapse_recursive: KeyEvent,
+    #[serde(default = "KeyConfig::default_tree_expand_recursive")]
     pub tree_expand_recursive: KeyEvent,
+    #[serde(default = "KeyConfig::default_home")]
     pub home: KeyEvent,
+    #[serde(default = "KeyConfig::default_end")]
     pub end: KeyEvent,
+    #[serde(default = "KeyConfig::default_move_up")]
     pub move_up: KeyEvent,
+    #[serde(default = "KeyConfig::default_move_down")]
     pub move_down: KeyEvent,
+    #[serde(default = "KeyConfig::default_page_down")]
     pub page_down: KeyEvent,
+    #[serde(default = "KeyConfig::default_page_up")]
     pub page_up: KeyEvent,
+    #[serde(default = "KeyConfig::default_shift_up")]
     pub shift_up: KeyEvent,
+    #[serde(default = "KeyConfig::default_shift_down")]
     pub shift_down: KeyEvent,
+    #[serde(default = "KeyConfig::default_enter")]
     pub enter: KeyEvent,
+    #[serde(default = "KeyConfig::default_blame")]
     pub blame: KeyEvent,
+    #[serde(default = "KeyConfig::default_edit_file")]
     pub edit_file: KeyEvent,
+    #[serde(default = "KeyConfig::default_status_stage_all")]
     pub status_stage_all: KeyEvent,
+    #[serde(default = "KeyConfig::default_status_reset_item")]
     pub status_reset_item: KeyEvent,
+    #[serde(default = "KeyConfig::default_status_ignore_file")]
     pub status_ignore_file: KeyEvent,
+    #[serde(default = "KeyConfig::default_diff_stage_lines")]
     pub diff_stage_lines: KeyEvent,
+    #[serde(default = "KeyConfig::default_diff_reset_lines")]
     pub diff_reset_lines: KeyEvent,
+    #[serde(default = "KeyConfig::default_stashing_save")]
     pub stashing_save: KeyEvent,
+    #[serde(default = "KeyConfig::default_stashing_toggle_untracked")]
     pub stashing_toggle_untracked: KeyEvent,
+    #[serde(default = "KeyConfig::default_stashing_toggle_index")]
     pub stashing_toggle_index: KeyEvent,
+    #[serde(default = "KeyConfig::default_stash_apply")]
     pub stash_apply: KeyEvent,
+    #[serde(default = "KeyConfig::default_stash_open")]
     pub stash_open: KeyEvent,
+    #[serde(default = "KeyConfig::default_stash_drop")]
     pub stash_drop: KeyEvent,
+    #[serde(default = "KeyConfig::default_cmd_bar_toggle")]
     pub cmd_bar_toggle: KeyEvent,
+    #[serde(default = "KeyConfig::default_log_tag_commit")]
     pub log_tag_commit: KeyEvent,
+    #[serde(default = "KeyConfig::default_commit_amend")]
     pub commit_amend: KeyEvent,
+    #[serde(default = "KeyConfig::default_copy")]
     pub copy: KeyEvent,
+    #[serde(default = "KeyConfig::default_create_branch")]
     pub create_branch: KeyEvent,
+    #[serde(default = "KeyConfig::default_rename_branch")]
     pub rename_branch: KeyEvent,
+    #[serde(default = "KeyConfig::default_select_branch")]
     pub select_branch: KeyEvent,
+    #[serde(default = "KeyConfig::default_delete_branch")]
     pub delete_branch: KeyEvent,
+    #[serde(default = "KeyConfig::default_merge_branch")]
     pub merge_branch: KeyEvent,
+    #[serde(default = "KeyConfig::default_push")]
     pub push: KeyEvent,
+    #[serde(default = "KeyConfig::default_open_file_tree")]
     pub open_file_tree: KeyEvent,
+    #[serde(default = "KeyConfig::default_force_push")]
     pub force_push: KeyEvent,
+    #[serde(default = "KeyConfig::default_pull")]
     pub pull: KeyEvent,
+    #[serde(default = "KeyConfig::default_abort_merge")]
     pub abort_merge: KeyEvent,
+}
+
+impl KeyConfig {
+    fn default_tab_status() -> KeyEvent { KeyEvent { code: KeyCode::Char('1'), modifiers: KeyModifiers::empty() } }
+    fn default_tab_log() -> KeyEvent { KeyEvent { code: KeyCode::Char('2'), modifiers: KeyModifiers::empty() } }
+    fn default_tab_stashing() -> KeyEvent { KeyEvent { code: KeyCode::Char('3'), modifiers: KeyModifiers::empty() } }
+    fn default_tab_stashes() -> KeyEvent { KeyEvent { code: KeyCode::Char('4'), modifiers: KeyModifiers::empty() } }
+    fn default_tab_toggle() -> KeyEvent { KeyEvent { code: KeyCode::Tab, modifiers: KeyModifiers::empty() } }
+    fn default_tab_toggle_reverse() -> KeyEvent { KeyEvent { code: KeyCode::BackTab, modifiers: KeyModifiers::SHIFT } }
+    fn default_toggle_workarea() -> KeyEvent { KeyEvent { code: KeyCode::Char('w'), modifiers: KeyModifiers::empty() } }
+    fn default_focus_right() -> KeyEvent { KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty() } }
+    fn default_focus_left() -> KeyEvent { KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::empty() } }
+    fn default_focus_above() -> KeyEvent { KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::empty() } }
+    fn default_focus_below() -> KeyEvent { KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::empty() } }
+    fn default_exit() -> KeyEvent { KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL } }
+    fn default_exit_popup() -> KeyEvent { KeyEvent { code: KeyCode::Esc, modifiers: KeyModifiers::empty() } }
+    fn default_open_commit() -> KeyEvent { KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::empty() } }
+    fn default_open_commit_editor() -> KeyEvent { KeyEvent { code: KeyCode::Char('e'), modifiers: KeyModifiers::CONTROL } }
+    fn default_open_help() -> KeyEvent { KeyEvent { code: KeyCode::Char('h'), modifiers: KeyModifiers::empty() } }
+    fn default_move_left() -> KeyEvent { KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::empty() } }
+    fn default_move_right() -> KeyEvent { KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty() } }
+    fn default_tree_collapse_recursive() -> KeyEvent { KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::SHIFT } }
+    fn default_tree_expand_recursive() -> KeyEvent { KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::SHIFT } }
+    fn default_home() -> KeyEvent { KeyEvent { code: KeyCode::Home, modifiers: KeyModifiers::empty() } }
+    fn default_end() -> KeyEvent { KeyEvent { code: KeyCode::End, modifiers: KeyModifiers::empty() } }
+    fn default_move_up() -> KeyEvent { KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::empty() } }
+    fn default_move_down() -> KeyEvent { KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::empty() } }
+    fn default_page_down() -> KeyEvent { KeyEvent { code: KeyCode::PageDown, modifiers: KeyModifiers::empty() } }
+    fn default_page_up() -> KeyEvent { KeyEvent { code: KeyCode::PageUp, modifiers: KeyModifiers::empty() } }
+    fn default_shift_up() -> KeyEvent { KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::SHIFT } }
+    fn default_shift_down() -> KeyEvent { KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::SHIFT } }
+    fn default_enter() -> KeyEvent { KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::empty() } }
+    fn default_blame() -> KeyEvent { KeyEvent { code: KeyCode::Char('B'), modifiers: KeyModifiers::SHIFT } }
+    fn default_edit_file() -> KeyEvent { KeyEvent { code: KeyCode::Char('e'), modifiers: KeyModifiers::empty() } }
+    fn default_status_stage_all() -> KeyEvent { KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::empty() } }
+    fn default_status_reset_item() -> KeyEvent { KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT } }
+    fn default_diff_reset_lines() -> KeyEvent { KeyEvent { code: KeyCode::Char('d'), modifiers: KeyModifiers::empty() } }
+    fn default_status_ignore_file() -> KeyEvent { KeyEvent { code: KeyCode::Char('i'), modifiers: KeyModifiers::empty() } }
+    fn default_diff_stage_lines() -> KeyEvent { KeyEvent { code: KeyCode::Char('s'), modifiers: KeyModifiers::empty() } }
+    fn default_stashing_save() -> KeyEvent { KeyEvent { code: KeyCode::Char('s'), modifiers: KeyModifiers::empty() } }
+    fn default_stashing_toggle_untracked() -> KeyEvent { KeyEvent { code: KeyCode::Char('u'), modifiers: KeyModifiers::empty() } }
+    fn default_stashing_toggle_index() -> KeyEvent { KeyEvent { code: KeyCode::Char('i'), modifiers: KeyModifiers::empty() } }
+    fn default_stash_apply() -> KeyEvent { KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::empty() } }
+    fn default_stash_open() -> KeyEvent { KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty() } }
+    fn default_stash_drop() -> KeyEvent { KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT } }
+    fn default_cmd_bar_toggle() -> KeyEvent { KeyEvent { code: KeyCode::Char('.'), modifiers: KeyModifiers::empty() } }
+    fn default_log_tag_commit() -> KeyEvent { KeyEvent { code: KeyCode::Char('t'), modifiers: KeyModifiers::empty() } }
+    fn default_commit_amend() -> KeyEvent { KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::CONTROL } }
+    fn default_copy() -> KeyEvent { KeyEvent { code: KeyCode::Char('y'), modifiers: KeyModifiers::empty() } }
+    fn default_create_branch() -> KeyEvent { KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::empty() } }
+    fn default_rename_branch() -> KeyEvent { KeyEvent { code: KeyCode::Char('r'), modifiers: KeyModifiers::empty() } }
+    fn default_select_branch() -> KeyEvent { KeyEvent { code: KeyCode::Char('b'), modifiers: KeyModifiers::empty() } }
+    fn default_delete_branch() -> KeyEvent { KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT } }
+    fn default_merge_branch() -> KeyEvent { KeyEvent { code: KeyCode::Char('m'), modifiers: KeyModifiers::empty() } }
+    fn default_push() -> KeyEvent { KeyEvent { code: KeyCode::Char('p'), modifiers: KeyModifiers::empty() } }
+    fn default_force_push() -> KeyEvent { KeyEvent { code: KeyCode::Char('P'), modifiers: KeyModifiers::SHIFT } }
+    fn default_pull() -> KeyEvent { KeyEvent { code: KeyCode::Char('f'), modifiers: KeyModifiers::empty() } }
+    fn default_abort_merge() -> KeyEvent { KeyEvent { code: KeyCode::Char('M'), modifiers: KeyModifiers::SHIFT } }
+    fn default_open_file_tree() -> KeyEvent { KeyEvent { code: KeyCode::Char('F'), modifiers: KeyModifiers::SHIFT } }
 }
 
 #[rustfmt::skip]
 impl Default for KeyConfig {
     fn default() -> Self {
         Self {
-			tab_status: KeyEvent { code: KeyCode::Char('1'), modifiers: KeyModifiers::empty()},
-			tab_log: KeyEvent { code: KeyCode::Char('2'), modifiers: KeyModifiers::empty()},
-			tab_stashing: KeyEvent { code: KeyCode::Char('3'), modifiers: KeyModifiers::empty()},
-			tab_stashes: KeyEvent { code: KeyCode::Char('4'), modifiers: KeyModifiers::empty()},
-			tab_toggle: KeyEvent { code: KeyCode::Tab, modifiers: KeyModifiers::empty()},
-			tab_toggle_reverse: KeyEvent { code: KeyCode::BackTab, modifiers: KeyModifiers::SHIFT},
-            toggle_workarea: KeyEvent { code: KeyCode::Char('w'), modifiers: KeyModifiers::empty()},
-			focus_right: KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty()},
-			focus_left: KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::empty()},
-			focus_above: KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::empty()},
-			focus_below: KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::empty()},
-			exit: KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::CONTROL},
-			exit_popup: KeyEvent { code: KeyCode::Esc, modifiers: KeyModifiers::empty()},
-			open_commit: KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::empty()},
-			open_commit_editor: KeyEvent { code: KeyCode::Char('e'), modifiers:KeyModifiers::CONTROL},
-			open_help: KeyEvent { code: KeyCode::Char('h'), modifiers: KeyModifiers::empty()},
-			move_left: KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::empty()},
-			move_right: KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty()},
-            tree_collapse_recursive: KeyEvent { code: KeyCode::Left, modifiers: KeyModifiers::SHIFT},
-            tree_expand_recursive: KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::SHIFT},
-			home: KeyEvent { code: KeyCode::Home, modifiers: KeyModifiers::empty()},
-			end: KeyEvent { code: KeyCode::End, modifiers: KeyModifiers::empty()},
-			move_up: KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::empty()},
-			move_down: KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::empty()},
-			page_down: KeyEvent { code: KeyCode::PageDown, modifiers: KeyModifiers::empty()},
-			page_up: KeyEvent { code: KeyCode::PageUp, modifiers: KeyModifiers::empty()},
-			shift_up: KeyEvent { code: KeyCode::Up, modifiers: KeyModifiers::SHIFT},
-			shift_down: KeyEvent { code: KeyCode::Down, modifiers: KeyModifiers::SHIFT},
-			enter: KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::empty()},
-			blame: KeyEvent { code: KeyCode::Char('B'), modifiers: KeyModifiers::SHIFT},
-			edit_file: KeyEvent { code: KeyCode::Char('e'), modifiers: KeyModifiers::empty()},
-			status_stage_all: KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::empty()},
-			status_reset_item: KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT},
-            diff_reset_lines: KeyEvent { code: KeyCode::Char('d'), modifiers: KeyModifiers::empty()},
-			status_ignore_file: KeyEvent { code: KeyCode::Char('i'), modifiers: KeyModifiers::empty()},
-            diff_stage_lines: KeyEvent { code: KeyCode::Char('s'), modifiers: KeyModifiers::empty()},
-			stashing_save: KeyEvent { code: KeyCode::Char('s'), modifiers: KeyModifiers::empty()},
-			stashing_toggle_untracked: KeyEvent { code: KeyCode::Char('u'), modifiers: KeyModifiers::empty()},
-			stashing_toggle_index: KeyEvent { code: KeyCode::Char('i'), modifiers: KeyModifiers::empty()},
-			stash_apply: KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::empty()},
-			stash_open: KeyEvent { code: KeyCode::Right, modifiers: KeyModifiers::empty()},
-			stash_drop: KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT},
-			cmd_bar_toggle: KeyEvent { code: KeyCode::Char('.'), modifiers: KeyModifiers::empty()},
-			log_tag_commit: KeyEvent { code: KeyCode::Char('t'), modifiers: KeyModifiers::empty()},
-			commit_amend: KeyEvent { code: KeyCode::Char('a'), modifiers: KeyModifiers::CONTROL},
-            copy: KeyEvent { code: KeyCode::Char('y'), modifiers: KeyModifiers::empty()},
-            create_branch: KeyEvent { code: KeyCode::Char('c'), modifiers: KeyModifiers::empty()},
-            rename_branch: KeyEvent { code: KeyCode::Char('r'), modifiers: KeyModifiers::empty()},
-            select_branch: KeyEvent { code: KeyCode::Char('b'), modifiers: KeyModifiers::empty()},
-            delete_branch: KeyEvent { code: KeyCode::Char('D'), modifiers: KeyModifiers::SHIFT},
-            merge_branch: KeyEvent { code: KeyCode::Char('m'), modifiers: KeyModifiers::empty()},
-            push: KeyEvent { code: KeyCode::Char('p'), modifiers: KeyModifiers::empty()},
-            force_push: KeyEvent { code: KeyCode::Char('P'), modifiers: KeyModifiers::SHIFT},
-            pull: KeyEvent { code: KeyCode::Char('f'), modifiers: KeyModifiers::empty()},
-            abort_merge: KeyEvent { code: KeyCode::Char('M'), modifiers: KeyModifiers::SHIFT},
-            open_file_tree: KeyEvent { code: KeyCode::Char('F'), modifiers: KeyModifiers::SHIFT},
+            tab_status: Self::default_tab_status(),
+            tab_log: Self::default_tab_log(),
+            tab_stashing: Self::default_tab_stashing(),
+            tab_stashes: Self::default_tab_stashes(),
+            tab_toggle: Self::default_tab_toggle(),
+            tab_toggle_reverse: Self::default_tab_toggle_reverse(),
+            toggle_workarea: Self::default_toggle_workarea(),
+            focus_right: Self::default_focus_right(),
+            focus_left: Self::default_focus_left(),
+            focus_above: Self::default_focus_above(),
+            focus_below: Self::default_focus_below(),
+            exit: Self::default_exit(),
+            exit_popup: Self::default_exit_popup(),
+            open_commit: Self::default_open_commit(),
+            open_commit_editor: Self::default_open_commit_editor(),
+            open_help: Self::default_open_help(),
+            move_left: Self::default_move_left(),
+            move_right: Self::default_move_right(),
+            tree_collapse_recursive: Self::default_tree_collapse_recursive(),
+            tree_expand_recursive: Self::default_tree_expand_recursive(),
+            home: Self::default_home(),
+            end: Self::default_end(),
+            move_up: Self::default_move_up(),
+            move_down: Self::default_move_down(),
+            page_down: Self::default_page_down(),
+            page_up: Self::default_page_up(),
+            shift_up: Self::default_shift_up(),
+            shift_down: Self::default_shift_down(),
+            enter: Self::default_enter(),
+            blame: Self::default_blame(),
+            edit_file: Self::default_edit_file(),
+            status_stage_all: Self::default_status_stage_all(),
+            status_reset_item: Self::default_status_reset_item(),
+            diff_reset_lines: Self::default_diff_reset_lines(),
+            status_ignore_file: Self::default_status_ignore_file(),
+            diff_stage_lines: Self::default_diff_stage_lines(),
+            stashing_save: Self::default_stashing_save(),
+            stashing_toggle_untracked: Self::default_stashing_toggle_untracked(),
+            stashing_toggle_index: Self::default_stashing_toggle_index(),
+            stash_apply: Self::default_stash_apply(),
+            stash_open: Self::default_stash_open(),
+            stash_drop: Self::default_stash_drop(),
+            cmd_bar_toggle: Self::default_cmd_bar_toggle(),
+            log_tag_commit: Self::default_log_tag_commit(),
+            commit_amend: Self::default_commit_amend(),
+            copy: Self::default_copy(),
+            create_branch: Self::default_create_branch(),
+            rename_branch: Self::default_rename_branch(),
+            select_branch: Self::default_select_branch(),
+            delete_branch: Self::default_delete_branch(),
+            merge_branch: Self::default_merge_branch(),
+            push: Self::default_push(),
+            force_push: Self::default_force_push(),
+            pull: Self::default_pull(),
+            abort_merge: Self::default_abort_merge(),
+            open_file_tree: Self::default_open_file_tree(),
         }
     }
 }
@@ -269,8 +384,9 @@ impl KeyConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::KeyConfig;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::KeyConfig;
 
     #[test]
     fn test_get_hint() {
@@ -289,5 +405,20 @@ mod tests {
                 .is_ok(),
             true
         );
+    }
+
+    #[test]
+    fn test_key_config_fields_use_default_values_if_missing_during_deserialization() {
+        let input = "( tab_status: ( code: Char('6'), modifiers: ( bits: 1, ), ), )";
+        let result: ron::Result<KeyConfig> = ron::de::from_str(input);
+
+        assert_eq!(result.is_ok(), true);
+        let config = result.unwrap();
+
+        let expected_tab_status = KeyEvent { code: KeyCode::Char('6'), modifiers: KeyModifiers::SHIFT };
+        assert_eq!(config.tab_status, expected_tab_status);
+
+        let expected_default_tab_log = KeyEvent { code: KeyCode::Char('2'), modifiers: KeyModifiers::empty() };
+        assert_eq!(config.tab_log, expected_default_tab_log);
     }
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -1,57 +1,60 @@
 //TODO: remove once fixed https://github.com/rust-lang/rust-clippy/issues/6818
 #![allow(clippy::use_self)]
 
-use anyhow::Result;
-use asyncgit::{DiffLineType, StatusItemType};
-use ron::{
-    de::from_bytes,
-    ser::{to_string_pretty, PrettyConfig},
-};
-use serde::{Deserialize, Serialize};
 use std::{
     fs::{self, File},
     io::{Read, Write},
     path::PathBuf,
     rc::Rc,
 };
+
+use anyhow::Result;
+use ron::{
+    de::from_bytes,
+    ser::{PrettyConfig, to_string_pretty},
+};
+use serde::{Deserialize, Serialize};
 use tui::style::{Color, Modifier, Style};
+
+use asyncgit::{DiffLineType, StatusItemType};
 
 pub type SharedTheme = Rc<Theme>;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Theme {
+    #[serde(with = "Color", default = "Theme::default_selected_tab")]
     selected_tab: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_command_fg")]
     command_fg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_selection_bg")]
     selection_bg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_cmdbar_extra_lines_bg")]
     cmdbar_extra_lines_bg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_disabled_fg")]
     disabled_fg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_line_add")]
     diff_line_add: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_line_delete")]
     diff_line_delete: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_file_added")]
     diff_file_added: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_file_removed")]
     diff_file_removed: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_file_moved")]
     diff_file_moved: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_diff_file_modified")]
     diff_file_modified: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_commit_hash")]
     commit_hash: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_commit_time")]
     commit_time: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_commit_author")]
     commit_author: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_danger_fg")]
     danger_fg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_push_gauge_bg")]
     push_gauge_bg: Color,
-    #[serde(with = "Color")]
+    #[serde(with = "Color", default = "Theme::default_push_gauge_fg")]
     push_gauge_fg: Color,
 }
 
@@ -217,11 +220,11 @@ impl Theme {
         } else {
             Style::default().fg(self.disabled_fg)
         }
-        .bg(if line == 0 {
-            self.selection_bg
-        } else {
-            self.cmdbar_extra_lines_bg
-        })
+            .bg(if line == 0 {
+                self.selection_bg
+            } else {
+                self.cmdbar_extra_lines_bg
+            })
     }
 
     pub fn commit_hash(&self, selected: bool) -> Style {
@@ -301,28 +304,68 @@ impl Theme {
             Ok(Self::default())
         }
     }
+
+    fn default_selected_tab() -> Color { Color::Reset }
+    fn default_command_fg() -> Color { Color::White }
+    fn default_selection_bg() -> Color { Color::Blue }
+    fn default_cmdbar_extra_lines_bg() -> Color { Color::Blue }
+    fn default_disabled_fg() -> Color { Color::DarkGray }
+    fn default_diff_line_add() -> Color { Color::Green }
+    fn default_diff_line_delete() -> Color { Color::Red }
+    fn default_diff_file_added() -> Color { Color::LightGreen }
+    fn default_diff_file_removed() -> Color { Color::LightRed }
+    fn default_diff_file_moved() -> Color { Color::LightMagenta }
+    fn default_diff_file_modified() -> Color { Color::Yellow }
+    fn default_commit_hash() -> Color { Color::Magenta }
+    fn default_commit_time() -> Color { Color::LightCyan }
+    fn default_commit_author() -> Color { Color::Green }
+    fn default_danger_fg() -> Color { Color::Red }
+    fn default_push_gauge_bg() -> Color { Color::Blue }
+    fn default_push_gauge_fg() -> Color { Color::Reset }
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            selected_tab: Color::Reset,
-            command_fg: Color::White,
-            selection_bg: Color::Blue,
-            cmdbar_extra_lines_bg: Color::Blue,
-            disabled_fg: Color::DarkGray,
-            diff_line_add: Color::Green,
-            diff_line_delete: Color::Red,
-            diff_file_added: Color::LightGreen,
-            diff_file_removed: Color::LightRed,
-            diff_file_moved: Color::LightMagenta,
-            diff_file_modified: Color::Yellow,
-            commit_hash: Color::Magenta,
-            commit_time: Color::LightCyan,
-            commit_author: Color::Green,
-            danger_fg: Color::Red,
-            push_gauge_bg: Color::Blue,
-            push_gauge_fg: Color::Reset,
+            selected_tab: Self::default_selected_tab(),
+            command_fg: Self::default_command_fg(),
+            selection_bg: Self::default_selection_bg(),
+            cmdbar_extra_lines_bg: Self::default_cmdbar_extra_lines_bg(),
+            disabled_fg: Self::default_disabled_fg(),
+            diff_line_add: Self::default_diff_line_add(),
+            diff_line_delete: Self::default_diff_line_delete(),
+            diff_file_added: Self::default_diff_file_added(),
+            diff_file_removed: Self::default_diff_file_removed(),
+            diff_file_moved: Self::default_diff_file_moved(),
+            diff_file_modified: Self::default_diff_file_modified(),
+            commit_hash: Self::default_commit_hash(),
+            commit_time: Self::default_commit_time(),
+            commit_author: Self::default_commit_author(),
+            danger_fg: Self::default_danger_fg(),
+            push_gauge_bg: Self::default_push_gauge_bg(),
+            push_gauge_fg: Self::default_push_gauge_fg(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tui::style::Color;
+
+    use super::Theme;
+
+    #[test]
+    fn test_theme_fields_use_default_values_if_missing_during_deserialization() {
+        let input = "( selection_bg: Green, )";
+        let result: ron::Result<Theme> = ron::de::from_str(input);
+
+        assert_eq!(result.is_ok(), true);
+        let config = result.unwrap();
+
+        let expected_selection_bg = Color::Green;
+        assert_eq!(config.selection_bg, expected_selection_bg);
+
+        let expected_command_fg = Color::White;
+        assert_eq!(config.command_fg, expected_command_fg);
     }
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -365,7 +365,6 @@ mod tests {
         let expected_selection_bg = Color::Green;
         assert_eq!(config.selection_bg, expected_selection_bg);
 
-        let expected_command_fg = Color::White;
-        assert_eq!(config.command_fg, expected_command_fg);
+        assert_eq!(config.command_fg, Theme::default_command_fg());
     }
 }


### PR DESCRIPTION
## Background
- I have gitui key and theme config files versioned in my dotfiles repository. Whenever I update gitui, there are a few new keys that are supported by gitui and not in my config files. gitui refuses to load my config files and creates new default ones instead. This is very inconvenient since I need to compare my config files and default config files to see what values are missing to update

## What is in this PR?
- Use `serde(default = "path")` for fields in key config and theme to specify default values if they are missing from config files during deserialization. This does create a bunch of private functions (`default_xxx()`) but this is the only way that I can see from serde documentation
