### PR TITLE
Add push tags to popup

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -325,9 +325,10 @@ pub mod commands {
     ) -> CommandText {
         CommandText::new(
             format!(
-                "Tab [{}{}{}{}]",
+                "Tab [{}{}{}{}{}]",
                 key_config.get_hint(key_config.tab_status),
                 key_config.get_hint(key_config.tab_log),
+                key_config.get_hint(key_config.tab_files),
                 key_config.get_hint(key_config.tab_stashing),
                 key_config.get_hint(key_config.tab_stashes),
             ),


### PR DESCRIPTION
This is a small PR that contains minor improvements to the tags popup. I tested it locally, and in my copy of the `gitui`, I encountered no issues.

- Update missing remote tags after tags are pushed.
- Add shortcut for files tab to help.
