### PR TITLE
fix windows path handling in blame view

### DIFF
--- a/asyncgit/src/sync/blame.rs
+++ b/asyncgit/src/sync/blame.rs
@@ -50,7 +50,15 @@ pub fn blame_file(
 
     let commit_id = utils::get_head_repo(&repo)?;
 
-    let spec = format!("{}:{}", commit_id.to_string(), file_path);
+    let spec = if cfg!(unix) {
+        format!("{}:{}", commit_id.to_string(), file_path)
+    } else {
+        format!(
+            "{}:{}",
+            commit_id.to_string(),
+            file_path.replace("\\", "/")
+        )
+    };
 
     let object = repo.revparse_single(&spec)?;
     let blob = repo.find_blob(object.id())?;


### PR DESCRIPTION
`revparse_single` uses a git object name and not a file path - that means backslashes must be translated to slashes on windows.
Otherwise the blame view fails:
```
┌Blame -- src\main.rs -- <no blame available>
```

I reused the `cfg!` conditional from `git2-rs/src/remote.rs`, but there might be a better way to do that.

Resulting blame view on windows:
```
 Blame -- src\main.rs -- 869e4b7───────────────────────────────────────────────────────────────┐
 │f8f05d6 2020-03-31 Stephan Dilly          0│ #![forbid(unsafe_code)]                         │
```