### PR TITLE
Add filter to AsyncLog

### DIFF
--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -55,7 +55,7 @@ pub use hooks::{
 };
 pub use hunks::{reset_hunk, stage_hunk, unstage_hunk};
 pub use ignore::add_to_ignore;
-pub use logwalker::LogWalker;
+pub use logwalker::{LogWalker, LogWalkerFilter};
 pub use merge::{
     abort_merge, merge_branch, merge_commit, merge_msg, mergehead_ids,
 };

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -60,7 +60,7 @@ impl Revlog {
                 theme,
                 key_config.clone(),
             ),
-            git_log: AsyncLog::new(sender),
+            git_log: AsyncLog::new(sender, None),
             git_tags: AsyncTags::new(sender),
             visible: false,
             branch_name: cached::BranchName::new(CWD),


### PR DESCRIPTION
This is a small change that makes it possible to reuse the logic in `AsyncLog` for the file history view. `AsyncLog` passes the filter to `FileLogWalker` unchanged.

@extrawurst What do you think? Does it make sense to share the revlog logic? An alternative would be to add a `FileRevlog`.
