### PR TITLE
Fixed formatting in "Cargo Install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Binaries available for:
 
 ### Cargo Install
 
-The simplest way to start playing around with `gitui` is to have `cargo` build and install it with `cargo install gitui`
+The simplest way to start playing around with `gitui` is to build it with `cargo build` and install it with `cargo install gitui`
 
 ## 8. <a name="diagnostics"></a> Diagnostics <small><sup>[Top ▲](#table-of-contents)</sup></small>
 


### PR DESCRIPTION
I fixed the formatting in the section "Cargo Install".