### PR TITLE
vim style config: allow Q in pop-up inputs

### DIFF
--- a/vim_style_key_config.ron
+++ b/vim_style_key_config.ron
@@ -26,8 +26,8 @@
 
     open_help: ( code: F(1), modifiers: ( bits: 0,),),
 
-    exit: ( code: Char('Q'), modifiers: ( bits: 1,),),
-	quit: ( code: Char('q'), modifiers: ( bits: 0,),),
+    exit: ( code: Char('c'), modifiers: ( bits: 2,),),
+    quit: ( code: Char('q'), modifiers: ( bits: 0,),),
     exit_popup: ( code: Esc, modifiers: ( bits: 0,),),
 
     open_commit: ( code: Char('c'), modifiers: ( bits: 0,),),


### PR DESCRIPTION
Change `exit` (which exits the app regardless of context) to <kbd>Ctrl</kbd>+<kbd>C</kbd>, and move <kbd>Shift</kbd>+<kbd>Q</kbd> to `quit` (which doesn’t cause quitting on upper-case `Q` insert in popup inputs, cf. #771).

+ make indendation consistent