### PR TITLE
Issue-768 Support Markdown Emoji

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-emoji"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6af39cf9a679d7195b3370f5454381ba49c4791bc7ce3ae2a7bf1a2a89c7adf"
+dependencies = [
+ "phf",
+ "regex",
+]
+
+[[package]]
 name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +491,7 @@ dependencies = [
  "dirs-next",
  "easy-cast",
  "filetreelist",
+ "gh-emoji",
  "itertools",
  "lazy_static",
  "log",
@@ -897,6 +908,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1270,12 @@ dependencies = [
  "chrono",
  "log",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ easy-cast = "0.4"
 bugreport = "0.4"
 lazy_static = "1.4"
 syntect = { version = "4.5", default-features = false, features = ["metadata", "default-fancy"]}
+gh-emoji = "1.0.6"
 
 [target.'cfg(all(target_family="unix",not(target_os="macos")))'.dependencies]
 which = "4.1"

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -42,7 +42,7 @@ pub fn get_tags(repo_path: &str) -> Result<Tags> {
 	repo.tag_foreach(|id, name| {
 		if let Ok(name) =
 			// skip the `refs/tags/` part
-			String::from_utf8(name[10..name.len()].into())
+		 String::from_utf8(name[10..name.len()].into())
 		{
 			//NOTE: find_tag (git_tag_lookup) only works on annotated tags
 			// lightweight tags `id` already points to the target commit

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -298,10 +298,12 @@ impl CommitList {
 		txt.push(splitter);
 
 		// commit msg
+		let r = gh_emoji::Replacer::new();
 		txt.push(Span::styled(
-			Cow::from(e.msg.as_str()),
+			Cow::from(r.replace_all(e.msg.as_str())),
 			theme.text(true, selected),
 		));
+
 		Spans::from(txt)
 	}
 

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -300,7 +300,7 @@ impl CommitList {
 		// commit msg
 		let r = gh_emoji::Replacer::new();
 		txt.push(Span::styled(
-			Cow::from(r.replace_all(e.msg.as_str())),
+			r.replace_all(e.msg.as_str()),
 			theme.text(true, selected),
 		));
 


### PR DESCRIPTION
Please let me know any ways that this PR can be improved! It's my first time contributing to a Rust project, so hopefully this all makes sense!

This Pull Request fixes/closes #768 .

It changes the following:
- Adds ''gh-emoji" crate to dependencies
- Added emoji functionality to 'commitlist.rs' commit msg

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog