### PR TITLE
Improve contrast in branch popup for selected branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - appropriate error message when pulling deleted remote branch ([#911](https://github.com/extrawurst/gitui/issues/991))
+- improved color contrast in branches popup for light themes ([#922](https://github.com/extrawurst/gitui/issues/922))
 
 ## [0.17.1] - 2021-09-10
 

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -84,7 +84,11 @@ impl Theme {
 		};
 
 		if selected {
-			branch.patch(Style::default().bg(self.selection_bg))
+			branch.patch(
+				Style::default()
+					.fg(self.command_fg)
+					.bg(self.selection_bg),
+			)
 		} else {
 			branch
 		}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #922.

It changes the following:
- Updates the foreground color for selected branch in the branch popup

I followed the checklist:
- [ ] I added unittests (I'm not sure that it would make sense to add for styles)
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog