### PR TITLE
Use git_message_prettify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - appropriate error message when pulling deleted remote branch ([#911](https://github.com/extrawurst/gitui/issues/991))
 - improved color contrast in branches popup for light themes  [[@Cottser](https://github.com/Cottser)] ([#922](https://github.com/extrawurst/gitui/issues/922))
+- use git_message_prettify for commit messages ([#917](https://github.com/extrawurst/gitui/issues/917))
 
 ## [0.17.1] - 2021-09-10
 

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -57,6 +57,7 @@ pub use crate::{
 	},
 	tags::AsyncTags,
 };
+pub use git2::message_prettify;
 use std::{
 	collections::hash_map::DefaultHasher,
 	hash::{Hash, Hasher},

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -149,7 +149,7 @@ impl CommitComponent {
 		drop(file);
 		std::fs::remove_file(&file_path)?;
 
-		message = self.prettify_message(message);
+		message = message_prettify(message, Some(b'#'))?;
 		self.input.set_text(message);
 		self.input.show()?;
 
@@ -181,7 +181,7 @@ impl CommitComponent {
 			)));
 			return Ok(());
 		}
-		let mut msg = self.prettify_message(msg);
+		let mut msg = message_prettify(msg, Some(b'#'))?;
 		if let HookResult::NotOk(e) =
 			sync::hooks_commit_msg(CWD, &mut msg)?
 		{
@@ -221,19 +221,6 @@ impl CommitComponent {
 		self.queue.push(InternalEvent::Update(NeedsUpdate::ALL));
 
 		Ok(())
-	}
-
-	fn prettify_message(&mut self, msg: String) -> String {
-		return match message_prettify(&msg, Some(b'#')) {
-			Ok(new_value) => new_value,
-			Err(e) => {
-				log::error!("post-commit hook error: {}", e);
-				self.queue.push(InternalEvent::ShowErrorMsg(
-					format!("post-commit hook error:\n{}", e),
-				));
-				return msg;
-			}
-		};
 	}
 
 	fn can_commit(&self) -> bool {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #917.

It changes the following:
Adds message cleanup using built-in git_message_prettify function on commit
Changes custom cleanup for git_message_prettify after using external commit message editor

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog