### PR TITLE
Add specific key bindings to stage / unstage items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - support rebasing branches with conflicts ([#895](https://github.com/extrawurst/gitui/issues/895))
+- specific key bindings to stage / unstage items [[@alessandroasm](https://github.com/alessandroasm)] ([#909](https://github.com/extrawurst/gitui/issues/909))
 
 ## Fixed
 - appropriate error message when pulling deleted remote branch ([#911](https://github.com/extrawurst/gitui/issues/991))

--- a/src/components/changes.rs
+++ b/src/components/changes.rs
@@ -233,7 +233,12 @@ impl Component for ChangesComponent {
 
 		if self.focused() {
 			if let Event::Key(e) = ev {
-				return if e == self.key_config.enter {
+				let stage_or_reset_key = if self.is_working_dir {
+					self.key_config.stage_item
+				} else {
+					self.key_config.unstage_item
+				};
+				return if e == stage_or_reset_key {
 					try_or_popup!(
 						self,
 						"staging error:",

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -88,6 +88,8 @@ pub struct KeyConfig {
 	pub pull: KeyEvent,
 	pub abort_merge: KeyEvent,
 	pub undo_commit: KeyEvent,
+	pub stage_item: KeyEvent,
+	pub unstage_item: KeyEvent,
 }
 
 #[rustfmt::skip]
@@ -161,6 +163,8 @@ impl Default for KeyConfig {
 			abort_merge: KeyEvent { code: KeyCode::Char('A'), modifiers: KeyModifiers::SHIFT},
 			open_file_tree: KeyEvent { code: KeyCode::Char('F'), modifiers: KeyModifiers::SHIFT},
 			file_find: KeyEvent { code: KeyCode::Char('f'), modifiers: KeyModifiers::empty()},
+			stage_item: KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::empty()},
+			unstage_item: KeyEvent { code: KeyCode::Enter, modifiers: KeyModifiers::empty()},
 		}
 	}
 }

--- a/vim_style_key_config.ron
+++ b/vim_style_key_config.ron
@@ -100,6 +100,9 @@
     open_file_tree: ( code: Char('F'), modifiers: ( bits: 1,),),
     file_find: ( code: Char('f'), modifiers: ( bits: 0,),),
 
+    stage_item: ( code: Enter, modifiers: ( bits: 0,),),
+    unstage_item: ( code: Enter, modifiers: ( bits: 0,),),
+
     //removed in 0.11
     //tab_toggle_reverse_windows: ( code: BackTab, modifiers: ( bits: 1,),),
 )


### PR DESCRIPTION
This Pull Request fixes/closes #909.

It changes the following:

- Adds specific key bindings to stage / unstage items in the Status tab.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog