### PR TITLE
Switch to status tab after merge / rebase with conflicts

### DIFF
--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -79,8 +79,8 @@ pub use tags::{
 };
 pub use tree::{tree_file_content, tree_files, TreeFile};
 pub use utils::{
-	get_head, get_head_tuple, has_conflicts, is_bare_repo, is_repo,
-	repo_dir, stage_add_all, stage_add_file, stage_addremoved, Head,
+	get_head, get_head_tuple, is_bare_repo, is_repo, repo_dir,
+	stage_add_all, stage_add_file, stage_addremoved, Head,
 };
 
 #[cfg(test)]

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -197,14 +197,6 @@ pub(crate) fn repo_write_file(
 	Ok(())
 }
 
-/// checks if repository has conflicts
-pub fn has_conflicts(repo_path: &str) -> Result<bool> {
-	let repo = repo(repo_path)?;
-	let index = repo.index()?;
-
-	Ok(index.has_conflicts())
-}
-
 #[cfg(test)]
 pub(crate) fn repo_read_file(
 	repo: &Repository,

--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -19,6 +19,7 @@ use asyncgit::{
 			RemoteBranch,
 		},
 		checkout_branch, get_branches_info, BranchInfo, CommitId,
+		RepoState,
 	},
 	AsyncGitNotification, CWD,
 };
@@ -368,7 +369,7 @@ impl BranchListComponent {
 		{
 			sync::merge_branch(CWD, &branch.name)?;
 
-			self.hide_and_check_for_conflicts()?;
+			self.hide_and_switch_tab()?;
 		}
 
 		Ok(())
@@ -380,17 +381,17 @@ impl BranchListComponent {
 		{
 			sync::rebase_branch(CWD, &branch.name)?;
 
-			self.hide_and_check_for_conflicts()?;
+			self.hide_and_switch_tab()?;
 		}
 
 		Ok(())
 	}
 
-	fn hide_and_check_for_conflicts(&mut self) -> Result<()> {
+	fn hide_and_switch_tab(&mut self) -> Result<()> {
 		self.hide();
 		self.queue.push(InternalEvent::Update(NeedsUpdate::ALL));
 
-		if sync::has_conflicts(CWD)? {
+		if sync::repo_state(CWD)? != RepoState::Clean {
 			self.queue.push(InternalEvent::TabSwitch);
 		}
 


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #926.

It changes the following:
- Switch to status tab after merging or rebasing with conflicts

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog