### PR TITLE
Fixing the CI Pipeline

### DIFF
--- a/src/components/blame_file.rs
+++ b/src/components/blame_file.rs
@@ -286,10 +286,8 @@ impl BlameFileComponent {
 		&mut self,
 		event: AsyncGitNotification,
 	) -> Result<()> {
-		if self.is_visible() {
-			if let AsyncGitNotification::Blame = event {
-				self.update()?;
-			}
+		if self.is_visible() && event == AsyncGitNotification::Blame {
+			self.update()?;
 		}
 
 		Ok(())

--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -350,10 +350,8 @@ impl BranchListComponent {
 		&mut self,
 		ev: AsyncGitNotification,
 	) -> Result<()> {
-		if self.is_visible() {
-			if let AsyncGitNotification::Push = ev {
-				self.update_branches()?;
-			}
+		if self.is_visible() && ev == AsyncGitNotification::Push {
+			self.update_branches()?;
 		}
 
 		Ok(())

--- a/src/components/compare_commits.rs
+++ b/src/components/compare_commits.rs
@@ -209,9 +209,9 @@ impl CompareCommitsComponent {
 		ev: AsyncGitNotification,
 	) -> Result<()> {
 		if self.is_visible() {
-			if let AsyncGitNotification::CommitFiles = ev {
+			if ev == AsyncGitNotification::CommitFiles {
 				self.update()?;
-			} else if let AsyncGitNotification::Diff = ev {
+			} else if ev == AsyncGitNotification::Diff {
 				self.update_diff()?;
 			}
 		}

--- a/src/components/inspect_commit.rs
+++ b/src/components/inspect_commit.rs
@@ -227,9 +227,9 @@ impl InspectCommitComponent {
 		ev: AsyncGitNotification,
 	) -> Result<()> {
 		if self.is_visible() {
-			if let AsyncGitNotification::CommitFiles = ev {
+			if ev == AsyncGitNotification::CommitFiles {
 				self.update()?;
-			} else if let AsyncGitNotification::Diff = ev {
+			} else if ev == AsyncGitNotification::Diff {
 				self.update_diff()?;
 			}
 		}

--- a/src/components/pull.rs
+++ b/src/components/pull.rs
@@ -111,15 +111,13 @@ impl PullComponent {
 
 	///
 	pub fn update_git(&mut self, ev: AsyncGitNotification) {
-		if self.is_visible() {
-			if let AsyncGitNotification::Fetch = ev {
-				if let Err(error) = self.update() {
-					self.pending = false;
-					self.hide();
-					self.queue.push(InternalEvent::ShowErrorMsg(
-						format!("fetch failed:\n{}", error),
-					));
-				}
+		if self.is_visible() && ev == AsyncGitNotification::Fetch {
+			if let Err(error) = self.update() {
+				self.pending = false;
+				self.hide();
+				self.queue.push(InternalEvent::ShowErrorMsg(
+					format!("fetch failed:\n{}", error),
+				));
 			}
 		}
 	}

--- a/src/components/push.rs
+++ b/src/components/push.rs
@@ -158,10 +158,8 @@ impl PushComponent {
 		&mut self,
 		ev: AsyncGitNotification,
 	) -> Result<()> {
-		if self.is_visible() {
-			if let AsyncGitNotification::Push = ev {
-				self.update()?;
-			}
+		if self.is_visible() && ev == AsyncGitNotification::Push {
+			self.update()?;
 		}
 
 		Ok(())

--- a/src/components/push_tags.rs
+++ b/src/components/push_tags.rs
@@ -101,10 +101,8 @@ impl PushTagsComponent {
 		&mut self,
 		ev: AsyncGitNotification,
 	) -> Result<()> {
-		if self.is_visible() {
-			if let AsyncGitNotification::PushTags = ev {
-				self.update()?;
-			}
+		if self.is_visible() && ev == AsyncGitNotification::PushTags {
+			self.update()?;
 		}
 
 		Ok(())

--- a/src/tabs/stashing.rs
+++ b/src/tabs/stashing.rs
@@ -91,11 +91,9 @@ impl Stashing {
 		&mut self,
 		ev: AsyncGitNotification,
 	) -> Result<()> {
-		if self.is_visible() {
-			if let AsyncGitNotification::Status = ev {
-				let status = self.git_status.last()?;
-				self.index.update(&status.items)?;
-			}
+		if self.is_visible() && ev == AsyncGitNotification::Status {
+			let status = self.git_status.last()?;
+			self.index.update(&status.items)?;
 		}
 
 		Ok(())

--- a/src/ui/stateful_paragraph.rs
+++ b/src/ui/stateful_paragraph.rs
@@ -160,7 +160,7 @@ impl<'a> StatefulWidget for StatefulParagraph<'a> {
 					&mut styled,
 					text_area.width,
 				));
-				if let Alignment::Left = self.alignment {
+				if self.alignment == Alignment::Left {
 					line_composer
 						.set_horizontal_offset(state.scroll.x);
 				}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->
It changes the following:
- Rust nightly (1.57.0-nightly) was throwing errors when running `cargo clippy`.
- Fixes the CI Pipeline.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog