### PR TITLE
Improve redraw performance

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -387,7 +387,7 @@ impl App {
 			self.push_tags_popup.update_git(ev)?;
 			self.pull_popup.update_git(ev);
 			self.select_branch_popup.update_git(ev)?;
-			self.commit.update_git(ev)?;
+			self.commit.update_git(ev);
 		}
 
 		self.files_tab.update_async(ev);

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -81,22 +81,14 @@ impl CommitComponent {
 	}
 
 	///
-	pub fn update_git(
-		&mut self,
-		ev: AsyncGitNotification,
-	) -> Result<()> {
-		match ev {
-			AsyncGitNotification::Status => self.update_status()?,
-			_ => (),
+	pub fn update_git(&mut self, ev: AsyncGitNotification) {
+		if ev == AsyncGitNotification::Status {
+			self.update_status();
 		}
-
-		Ok(())
 	}
 
-	fn update_status(&mut self) -> Result<()> {
+	fn update_status(&mut self) {
 		self.can_amend = self.get_can_amend();
-
-		Ok(())
 	}
 
 	fn draw_branch_name<B: Backend>(&self, f: &mut Frame<B>) {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #869.

It changes the following:
- Improves redraw performance by moving sync repo operations off the UI thread

I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [X] I added an appropriate item to the changelog