### PR TITLE
Make gh-emoji optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support merging and rebasing remote branches ([#920](https://github.com/extrawurst/gitui/issues/920))
 - add highlighting matches in fuzzy finder ([#893](https://github.com/extrawurst/gitui/issues/893))
 - support `home` and `end` keys in branchlist ([#957](https://github.com/extrawurst/gitui/issues/957))
+- add `ghemoji` feature to make gh-emoji (GitHub emoji) optional ([#954](https://github.com/extrawurst/gitui/pull/954))
 
 ## Fixed
 - honor options (for untracked files) in `stage_all` command ([#933](https://github.com/extrawurst/gitui/issues/933))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ easy-cast = "0.4"
 bugreport = "0.4"
 lazy_static = "1.4"
 syntect = { version = "4.5", default-features = false, features = ["metadata", "default-fancy"]}
-gh-emoji = "1.0.6"
+gh-emoji = { version = "1.0.6", optional = true }
 fuzzy-matcher = "0.3"
 
 [target.'cfg(all(target_family="unix",not(target_os="macos")))'.dependencies]
@@ -64,7 +64,8 @@ pretty_assertions = "1.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default=["trace-libgit"]
+default=["ghemoji", "trace-libgit"]
+ghemoji=["gh-emoji"]
 timing=["scopetime/enabled"]
 trace-libgit=["asyncgit/trace-libgit"]
 

--- a/src/components/utils/emoji.rs
+++ b/src/components/utils/emoji.rs
@@ -1,0 +1,17 @@
+use lazy_static::lazy_static;
+use std::borrow::Cow;
+
+lazy_static! {
+	static ref EMOJI_REPLACER: gh_emoji::Replacer =
+		gh_emoji::Replacer::new();
+}
+
+// Replace markdown emojis with Unicode equivalent
+// :hammer: --> 🔨
+#[inline]
+pub fn emojifi_string(s: &mut String) {
+	let resulting_cow = EMOJI_REPLACER.replace_all(s);
+	if let Cow::Owned(altered_s) = resulting_cow {
+		*s = altered_s;
+	}
+}

--- a/src/components/utils/logitems.rs
+++ b/src/components/utils/logitems.rs
@@ -2,7 +2,8 @@ use asyncgit::sync::{CommitId, CommitInfo};
 use chrono::{DateTime, Duration, Local, NaiveDateTime, Utc};
 use std::slice::Iter;
 
-use crate::components::utils::emojifi_string;
+#[cfg(feature = "ghemoji")]
+use super::emoji::emojifi_string;
 
 static SLICE_OFFSET_RELOAD_THRESHOLD: usize = 100;
 
@@ -27,9 +28,12 @@ impl From<CommitInfo> for LogEntry {
 				Utc,
 			));
 
-		// Replace markdown emojis with Unicode equivalent
 		let author = c.author;
+		#[allow(unused_mut)]
 		let mut msg = c.message;
+
+		// Replace markdown emojis with Unicode equivalent
+		#[cfg(feature = "ghemoji")]
 		emojifi_string(&mut msg);
 
 		Self {
@@ -113,6 +117,7 @@ impl ItemBatch {
 }
 
 #[cfg(test)]
+#[cfg(feature = "ghemoji")]
 mod tests {
 	use super::*;
 

--- a/src/components/utils/mod.rs
+++ b/src/components/utils/mod.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Local, NaiveDateTime, Utc};
-use lazy_static::lazy_static;
-use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
+#[cfg(feature = "ghemoji")]
+pub mod emoji;
 pub mod filetree;
 pub mod logitems;
 pub mod scroll_vertical;
@@ -52,21 +52,6 @@ pub fn string_width_align(s: &str, width: usize) -> String {
 		let mut s = s.to_string();
 		s.truncate(find_truncate_point(&s, width_wo_postfix));
 		format!("{}{}", s, POSTFIX)
-	}
-}
-
-lazy_static! {
-	static ref EMOJI_REPLACER: gh_emoji::Replacer =
-		gh_emoji::Replacer::new();
-}
-
-// Replace markdown emojis with Unicode equivalent
-// :hammer: --> 🔨
-#[inline]
-pub fn emojifi_string(s: &mut String) {
-	let resulting_cow = EMOJI_REPLACER.replace_all(s);
-	if let Cow::Owned(altered_s) = resulting_cow {
-		*s = altered_s;
 	}
 }
 


### PR DESCRIPTION
gh-emoji crate includes *images* of GitHub's emoji - this is quite big dependency. It increases the binary size by 1 MiB; that's +25 % when building v0.18.0 on Alpine Linux with build flags to optimize size. I consider it an unnecessary bloat that should be optional.

Note: I’m maintainer of Alpine Linux’s [gitui](https://pkgs.alpinelinux.org/packages?name=gitui) package ([APKBUILD](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/gitui/APKBUILD)).