### PR TITLE
Add building debian package to github actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,12 +47,19 @@ jobs:
         rustup target add x86_64-unknown-linux-musl
         sudo apt-get -qq install musl-tools
 
+    - name: Add cargo deb
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        cargo install cargo-deb
+
     - name: Build Release Mac
       if: matrix.os == 'macos-latest'
       run: make release-mac
-    - name: Build Release Linux
+    - name: Build Release Linux + Debian package
       if: matrix.os == 'ubuntu-latest'
-      run: make release-linux-musl
+      run: |
+        make release-linux-musl
+        make release-linux-musl-deb
     - name: Build Release Win
       if: matrix.os == 'windows-latest'
       run: make release-win
@@ -76,6 +83,7 @@ jobs:
           ./release/*.tar.gz
           ./release/*.zip
           ./release/*.msi
+          ./release/*.deb
           
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,6 @@ opt-level = 3
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[package.metadata.deb]
+depends = ""

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ release-linux-musl: build-linux-musl-release
 	mkdir -p release
 	tar -C ./target/x86_64-unknown-linux-musl/release/ -czvf ./release/gitui-linux-musl.tar.gz ./gitui
 
+release-linux-musl-deb: build-linux-musl-release
+	cargo deb --no-build --target x86_64-unknown-linux-musl
+	cp ./target/x86_64-unknown-linux-musl/debian/*.deb ./release/
+
 build-linux-musl-debug:
 	cargo build --target=x86_64-unknown-linux-musl
 


### PR DESCRIPTION
This commit modifies the Makefile to have a new command

make release-linux-musl-deb

that packages a deb package and copies it to ./release/

I have tested in two docker containers that the debian package installs and works(AFAICT) on `ubuntu:bionic` and `debian:buster`.

This pull request fixes #1018.

I followed the checklist:
- n/a I added unittests
- [ y] I ran `make check` without errors
- [ y] I tested the overall application
- n/a I added an appropriate item to the changelog