### PR TITLE
Disable fetch,pull,push on local only repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep commit message when pre-commit hook fails ([#1035](https://github.com/extrawurst/gitui/issues/1035))
 - honor `pushurl` when checking credentials for pushing ([#953](https://github.com/extrawurst/gitui/issues/953))
 - use git-path instead of workdir finding hooks ([#1046](https://github.com/extrawurst/gitui/issues/1046))
+- only enable remote actions (fetch/pull/push) if there are remote branches ([#1047](https://github.com/extrawurst/gitui/issues/1047))
 
 ### Key binding notes
 - added `gg`/`G` vim bindings to `vim_style_key_config.ron` ([#1039](https://github.com/extrawurst/gitui/issues/1039))

--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -247,7 +247,7 @@ impl Component for BranchListComponent {
 				if !self.local {
 					self.has_remotes =
 						get_branches_info(&self.repo.borrow(), false)
-							.map(|branches| branches.len() > 0)
+							.map(|branches| !branches.is_empty())
 							.unwrap_or(false);
 				}
 				self.update_branches()?;

--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -42,6 +42,7 @@ pub struct BranchListComponent {
 	repo: RepoPathRef,
 	branches: Vec<BranchInfo>,
 	local: bool,
+	has_remotes: bool,
 	visible: bool,
 	selection: u16,
 	scroll: VerticalScroll,
@@ -200,7 +201,7 @@ impl Component for BranchListComponent {
 
 			out.push(CommandInfo::new(
 				strings::commands::fetch_remotes(&self.key_config),
-				true,
+				self.has_remotes,
 				!self.local,
 			));
 		}
@@ -243,6 +244,12 @@ impl Component for BranchListComponent {
 					.map(Into::into);
 			} else if e == self.key_config.keys.tab_toggle {
 				self.local = !self.local;
+				if !self.local {
+					self.has_remotes =
+						get_branches_info(&self.repo.borrow(), false)
+							.map(|branches| branches.len() > 0)
+							.unwrap_or(false);
+				}
 				self.update_branches()?;
 			} else if e == self.key_config.keys.enter {
 				try_or_popup!(
@@ -297,7 +304,9 @@ impl Component for BranchListComponent {
 					self.queue
 						.push(InternalEvent::CompareCommits(b, None));
 				}
-			} else if e == self.key_config.keys.pull && !self.local {
+			} else if e == self.key_config.keys.pull
+				&& !self.local && self.has_remotes
+			{
 				self.queue.push(InternalEvent::FetchRemotes);
 			} else if e == self.key_config.keys.cmd_bar_toggle {
 				//do not consume if its the more key
@@ -333,6 +342,7 @@ impl BranchListComponent {
 		Self {
 			branches: Vec::new(),
 			local: true,
+			has_remotes: false,
 			visible: false,
 			selection: 0,
 			scroll: VerticalScroll::new(),

--- a/src/components/branchlist.rs
+++ b/src/components/branchlist.rs
@@ -244,12 +244,7 @@ impl Component for BranchListComponent {
 					.map(Into::into);
 			} else if e == self.key_config.keys.tab_toggle {
 				self.local = !self.local;
-				if !self.local {
-					self.has_remotes =
-						get_branches_info(&self.repo.borrow(), false)
-							.map(|branches| !branches.is_empty())
-							.unwrap_or(false);
-				}
+				self.check_remotes();
 				self.update_branches()?;
 			} else if e == self.key_config.keys.enter {
 				try_or_popup!(
@@ -362,9 +357,19 @@ impl BranchListComponent {
 		Ok(())
 	}
 
+	fn check_remotes(&mut self) {
+		if !self.local {
+			self.has_remotes =
+				get_branches_info(&self.repo.borrow(), false)
+					.map(|branches| !branches.is_empty())
+					.unwrap_or(false);
+		}
+	}
+
 	/// fetch list of branches
 	pub fn update_branches(&mut self) -> Result<()> {
 		if self.is_visible() {
+			self.check_remotes();
 			self.branches =
 				get_branches_info(&self.repo.borrow(), self.local)?;
 			//remove remote branch called `HEAD`

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -165,7 +165,7 @@ impl Status {
 			focus: Focus::WorkDir,
 			diff_target: DiffTarget::WorkingDir,
 			local_only: get_branches_info(&repo_clone, false)
-				.map(|l| l.len() == 0)
+				.map(|l| l.is_empty())
 				.unwrap_or(true),
 			index_wd: ChangesComponent::new(
 				repo.clone(),
@@ -593,7 +593,7 @@ impl Status {
 			&& !self.local_only
 	}
 
-	fn can_pull(&self) -> bool {
+	const fn can_pull(&self) -> bool {
 		!self.local_only
 	}
 


### PR DESCRIPTION
This Pull Request fixes/closes #1047

It changes the following:
dis able the following buttons and functions in repos without any remote branches
- push in status tab
- pull in status tab
- fetch in branches window of status tab


I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors -> shows error event fn too long but is unrelated to my changes
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog -> not sure where