### PR TITLE
Bump clap to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,13 +208,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "f6f34b09b9ee8c7c7b400fe2f8df39cafc9538b03d6ba7f4ae13e4cb90bfbb7d"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "textwrap",
 ]
 
 [[package]]
@@ -526,7 +528,7 @@ dependencies = [
  "serde",
  "simplelog",
  "syntect",
- "textwrap 0.14.2",
+ "textwrap",
  "tui",
  "unicode-segmentation",
  "unicode-truncate",
@@ -888,6 +890,15 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1404,15 +1415,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bitflags = "1.3"
 bugreport = "0.4"
 bytesize = { version = "1.1", default-features = false }
 chrono = "0.4"
-clap = { version = "2.33", default-features = false }
+clap = { version = "3.0", default-features = false, features = ["std", "cargo"] }
 crossbeam-channel = "0.5"
 crossterm = { version = "0.20", features = [ "serde" ] }
 dirs-next = "2.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,48 +19,7 @@ pub struct CliArgs {
 }
 
 pub fn process_cmdline() -> Result<CliArgs> {
-	let app = ClapApp::new(crate_name!())
-		.author(crate_authors!())
-		.version(crate_version!())
-		.about(crate_description!())
-		.arg(
-			Arg::new("theme")
-				.help("Set the color theme (defaults to theme.ron)")
-				.short('t')
-				.long("theme")
-				.value_name("THEME")
-				.allow_invalid_utf8(true)
-				.takes_value(true),
-		)
-		.arg(
-			Arg::new("logging")
-				.help("Stores logging output into a cache directory")
-				.short('l')
-				.long("logging"),
-		)
-		.arg(
-			Arg::new("bugreport")
-				.help("Generate a bug report")
-				.long("bugreport"),
-		)
-		.arg(
-			Arg::new("directory")
-				.help("Set the git directory")
-				.short('d')
-				.long("directory")
-				.allow_invalid_utf8(true)
-				.takes_value(true),
-		)
-		.arg(
-			Arg::new("workdir")
-				.help("Set the working directory")
-				.short('w')
-				.long("workdir")
-				.allow_invalid_utf8(true)
-				.takes_value(true),
-		);
-
-	let arg_matches = app.get_matches();
+	let arg_matches = app().get_matches();
 	if arg_matches.is_present("bugreport") {
 		bug_report::generate_bugreport();
 		std::process::exit(0);
@@ -99,6 +58,49 @@ pub fn process_cmdline() -> Result<CliArgs> {
 	}
 }
 
+fn app() -> ClapApp<'static> {
+	ClapApp::new(crate_name!())
+		.author(crate_authors!())
+		.version(crate_version!())
+		.about(crate_description!())
+		.arg(
+			Arg::new("theme")
+				.help("Set the color theme (defaults to theme.ron)")
+				.short('t')
+				.long("theme")
+				.value_name("THEME")
+				.allow_invalid_utf8(true)
+				.takes_value(true),
+		)
+		.arg(
+			Arg::new("logging")
+				.help("Stores logging output into a cache directory")
+				.short('l')
+				.long("logging"),
+		)
+		.arg(
+			Arg::new("bugreport")
+				.help("Generate a bug report")
+				.long("bugreport"),
+		)
+		.arg(
+			Arg::new("directory")
+				.help("Set the git directory")
+				.short('d')
+				.long("directory")
+				.allow_invalid_utf8(true)
+				.takes_value(true),
+		)
+		.arg(
+			Arg::new("workdir")
+				.help("Set the working directory")
+				.short('w')
+				.long("workdir")
+				.allow_invalid_utf8(true)
+				.takes_value(true),
+		)
+}
+
 fn setup_logging() -> Result<()> {
 	let mut path = get_app_cache_path()?;
 	path.push("gitui.log");
@@ -132,4 +134,9 @@ pub fn get_app_config_path() -> Result<PathBuf> {
 	path.push("gitui");
 	fs::create_dir_all(&path)?;
 	Ok(path)
+}
+
+#[test]
+fn verify_app() {
+	app().debug_assert();
 }


### PR DESCRIPTION
This Pull Request fixes/closes #1065.

It changes the following:

- Bump clap to v3: Mainly replacing deprecated functions/items. A notable change is that `AppSettings::StrictUtf8` is now default behavior so we need to allow invalid UTF8 on args related to path. Also adding a new [`debug_assert`](https://docs.rs/clap/3.0.5/clap/struct.App.html#method.debug_assert) provided by clap itself

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog