### PR TITLE
Fix blame tabs indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+* tabs indentation in blame ([#1111](https://github.com/extrawurst/gitui/issues/1117))
+
 ### Added
 * file history log [[@cruessler](https://github.com/cruessler)] ([#381](https://github.com/extrawurst/gitui/issues/381))
 

--- a/src/components/blame_file.rs
+++ b/src/components/blame_file.rs
@@ -6,6 +6,7 @@ use crate::{
 	components::{utils::string_width_align, ScrollType},
 	keys::SharedKeyConfig,
 	queue::{InternalEvent, Queue},
+	string_utils::tabs_to_spaces,
 	strings,
 	ui::{self, style::SharedTheme},
 };
@@ -415,7 +416,7 @@ impl BlameFileComponent {
 			.style(self.theme.text(true, false)),
 		);
 		cells.push(
-			Cell::from(String::from(line))
+			Cell::from(tabs_to_spaces(String::from(line)))
 				.style(self.theme.text(true, false)),
 		);
 


### PR DESCRIPTION
This Pull Request fixes/closes #1117 .

It changes the following:
- Transform tabs to spaces in blame file.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog