### PR TITLE
README: Add `Termux (Android)` installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ NixOS
 nix-env -iA nixos.gitui
 ```
 
+### [Termux](https://github.com/termux/termux-packages/tree/master/packages/gitui) (Android)
+
+```
+pkg install gitui
+```
+
 ## Release Binaries
 
 [Available for download in releases](https://github.com/extrawurst/gitui/releases)


### PR DESCRIPTION
gitui can now be installed on android (termux): https://github.com/termux/termux-packages/pull/9076

It changes the following:
- README

Signed-off-by: PeroSar <perosar1111@gmail.com>