### PR TITLE
Change focus when current list is empty

### DIFF
--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -412,6 +412,7 @@ impl Status {
 				.unwrap_or(RepoState::Clean);
 
 			self.branch_compare();
+			self.update_status()?;
 		}
 
 		Ok(())
@@ -462,17 +463,17 @@ impl Status {
 
 		if self.git_action_executed {
 			self.git_action_executed = false;
+		}
 
-			if self.focus == Focus::WorkDir
-				&& workdir_status.items.is_empty()
-				&& !stage_status.items.is_empty()
-			{
-				self.switch_focus(Focus::Stage)?;
-			} else if self.focus == Focus::Stage
-				&& stage_status.items.is_empty()
-			{
-				self.switch_focus(Focus::WorkDir)?;
-			}
+		if self.focus == Focus::WorkDir
+			&& workdir_status.items.is_empty()
+			&& !stage_status.items.is_empty()
+		{
+			self.switch_focus(Focus::Stage)?;
+		} else if self.focus == Focus::Stage
+			&& stage_status.items.is_empty()
+		{
+			self.switch_focus(Focus::WorkDir)?;
 		}
 
 		Ok(())


### PR DESCRIPTION
This Pull Request fixes/closes #{issue_num}.
this is a feature enhancement.
It changes the following:
- Change focus when current workdir or staging area list is empty.
   Most of the time, when I staging all the files, the next step is to commit, in current version I need to press the arrow down key or 'w' to change focus manually. But I think gitui can change focus for me :) , that is when current list is empty just try to change focus. I don't know this is a feature other people need too. If not, just close this pr.


I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [ ] I added an appropriate item to the changelog