### PR TITLE
fix clippy::derive_partial_eq_without_eq

### DIFF
--- a/asyncgit/src/sync/rebase.rs
+++ b/asyncgit/src/sync/rebase.rs
@@ -69,7 +69,7 @@ pub fn conflict_free_rebase(
 }
 
 ///
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum RebaseState {
 	///
 	Finished,
@@ -144,7 +144,7 @@ pub fn continue_rebase(
 }
 
 ///
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct RebaseProgress {
 	///
 	pub steps: usize,

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use super::{RepoPath, ShowUntrackedFilesConfig};
 
 ///
-#[derive(Copy, Clone, Hash, PartialEq, Debug)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
 pub enum StatusItemType {
 	///
 	New,
@@ -59,7 +59,7 @@ impl From<Delta> for StatusItemType {
 }
 
 ///
-#[derive(Clone, Hash, PartialEq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub struct StatusItem {
 	///
 	pub path: String,

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 ///
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Head {
 	///
 	pub name: String,

--- a/filetreelist/src/item.rs
+++ b/filetreelist/src/item.rs
@@ -83,11 +83,11 @@ impl TreeItemInfo {
 }
 
 /// attribute used to indicate the collapse/expand state of a path item
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct PathCollapsed(pub bool);
 
 /// `FileTreeItem` can be of two kinds
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum FileTreeItemKind {
 	Path(PathCollapsed),
 	File,

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -192,7 +192,7 @@ pub enum Direction {
 }
 
 ///
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum CommandBlocking {
 	Blocking,
 	PassingOn,
@@ -220,7 +220,7 @@ pub trait DrawableComponent {
 }
 
 ///
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum EventState {
 	Consumed,
 	NotConsumed,

--- a/src/components/options_popup.rs
+++ b/src/components/options_popup.rs
@@ -23,7 +23,7 @@ use tui::{
 	Frame,
 };
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AppOption {
 	StatusShowUntracked,
 	DiffIgnoreWhitespaces,

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -22,7 +22,7 @@ use tui::{
 	Frame,
 };
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum InputType {
 	Singleline,
 	Multiline,

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -39,11 +39,11 @@ impl TreeItemInfo {
 }
 
 /// attribute used to indicate the collapse/expand state of a path item
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct PathCollapsed(pub bool);
 
 /// `FileTreeItem` can be of two kinds
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum FileTreeItemKind {
 	Path(PathCollapsed),
 	File(StatusItem),

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,13 +79,13 @@ pub enum QueueEvent {
 	InputEvent(InputEvent),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SyntaxHighlightProgress {
 	Progress,
 	Done,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AsyncAppNotification {
 	///
 	SyntaxHighlighting(SyntaxHighlightProgress),

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -32,7 +32,7 @@ use tui::{
 };
 
 /// what part of the screen is focused
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum Focus {
 	WorkDir,
 	Diff,
@@ -51,7 +51,7 @@ impl Focus {
 }
 
 /// which target are we showing a diff against
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 enum DiffTarget {
 	Stage,
 	WorkingDir,


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes nightly toolchain CI failures.

It changes the following:
- fix clippy::derive_partial_eq_without_eq

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog