### PR TITLE
Factor out file history lookup into AsyncFileLogJob

### DIFF
--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -269,15 +269,21 @@ impl AsyncJob for AsyncFileLogJob {
 		&mut self,
 		_params: RunParams<Self::Notification, Self::Progress>,
 	) -> Result<Self::Notification> {
+		let mut notification = AsyncGitNotification::FinishUnchanged;
+
 		if let Ok(mut state) = self.state.lock() {
 			*state = state.take().map(|state| match state {
-				JobState::Request(_, _) => JobState::Response(()),
+				JobState::Request(_, _) => {
+					notification = AsyncGitNotification::Log;
+
+					JobState::Response(())
+				}
 				JobState::Response(result) => {
 					JobState::Response(result)
 				}
 			});
 		}
 
-		Ok(AsyncGitNotification::FinishUnchanged)
+		Ok(notification)
 	}
 }

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -31,7 +31,7 @@ pub struct AsyncLog {
 	current: Arc<Mutex<Vec<CommitId>>>,
 	current_head: Arc<Mutex<Option<CommitId>>>,
 	sender: Sender<AsyncGitNotification>,
-	job: AsyncSingleJob<AsyncLogJob>,
+	job: AsyncSingleJob<AsyncFileLogJob>,
 	background: Arc<AtomicBool>,
 	filter: Option<LogWalkerFilter>,
 	repo: RepoPath,
@@ -205,7 +205,7 @@ impl AsyncLog {
 
 	///
 	pub fn request(&mut self) -> Result<()> {
-		self.job.spawn(AsyncLogJob::new(
+		self.job.spawn(AsyncFileLogJob::new(
 			self.repo.clone(),
 			self.filter.clone(),
 		));
@@ -220,11 +220,11 @@ enum JobState {
 
 ///
 #[derive(Clone, Default)]
-pub struct AsyncLogJob {
+pub struct AsyncFileLogJob {
 	state: Arc<Mutex<Option<JobState>>>,
 }
 
-impl AsyncLogJob {
+impl AsyncFileLogJob {
 	///
 	pub fn new(
 		repo: RepoPath,
@@ -252,7 +252,7 @@ impl AsyncLogJob {
 	}
 }
 
-impl AsyncJob for AsyncLogJob {
+impl AsyncJob for AsyncFileLogJob {
 	type Notification = AsyncGitNotification;
 	type Progress = ();
 

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -261,14 +261,19 @@ impl AsyncFileLogJob {
 	}
 
 	fn fetch_log(repo_path: &RepoPath) -> Result<()> {
-		let mut entries = Vec::with_capacity(LIMIT_COUNT);
+		let mut all_entries: Vec<CommitId> = Vec::new();
+		let mut current_entries: Vec<CommitId> = Vec::with_capacity(LIMIT_COUNT);
 		let repo = repo(&repo_path)?;
 		let mut walker =
 			LogWalker::new(&repo, LIMIT_COUNT)?.filter(None);
 
 		loop {
-			entries.clear();
-			let _res_is_err = walker.read(&mut entries).is_err();
+			current_entries.clear();
+			let res_is_err = walker.read(&mut current_entries).is_err();
+
+			if !res_is_err {
+				all_entries.extend(current_entries.iter());
+			}
 
 			break;
 		}

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -262,14 +262,16 @@ impl AsyncFileLogJob {
 
 	fn fetch_log(repo_path: &RepoPath) -> Result<()> {
 		let mut all_entries: Vec<CommitId> = Vec::new();
-		let mut current_entries: Vec<CommitId> = Vec::with_capacity(LIMIT_COUNT);
+		let mut current_entries: Vec<CommitId> =
+			Vec::with_capacity(LIMIT_COUNT);
 		let repo = repo(&repo_path)?;
 		let mut walker =
 			LogWalker::new(&repo, LIMIT_COUNT)?.filter(None);
 
 		loop {
 			current_entries.clear();
-			let res_is_err = walker.read(&mut current_entries).is_err();
+			let res_is_err =
+				walker.read(&mut current_entries).is_err();
 
 			if !res_is_err {
 				all_entries.extend(current_entries.iter());


### PR DESCRIPTION
This PR partly addresses #1115. As of 2022-08-03, it is still a draft.

It changes the following:
- It factors out getting commit info into `AsyncFileLogJob`. It does not move getting commit info into a worker thread.

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog