### PR TITLE
Improve UI selection and command bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * submodules support ([#1087](https://github.com/extrawurst/gitui/issues/1087))
+* selected lines in files and log lists now fills the entire container
+* new color for command bar items background (`cmdbar_bg`)
 
 ## [0.21.0] - 2021-08-17
 

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -301,9 +301,13 @@ impl CommitList {
 
 		txt.push(splitter);
 
+		let message_width = width.saturating_sub(
+			txt.iter().map(|span| span.content.len()).sum(),
+		);
+
 		// commit msg
 		txt.push(Span::styled(
-			Cow::from(&*e.msg),
+			format!("{:w$}", &e.msg, w = message_width),
 			theme.text(true, selected),
 		));
 

--- a/src/components/revision_files.rs
+++ b/src/components/revision_files.rs
@@ -119,6 +119,7 @@ impl RevisionFilesComponent {
 	fn tree_item_to_span<'a>(
 		item: &'a FileTreeItem,
 		theme: &SharedTheme,
+		width: usize,
 		selected: bool,
 	) -> Span<'a> {
 		let path = item.info().path_str();
@@ -141,7 +142,17 @@ impl RevisionFilesComponent {
 			symbol::EMPTY_STR
 		};
 
-		let path = format!("{}{}{}", indent_str, path_arrow, path);
+		let available_width =
+			width.saturating_sub(indent_str.len() + path_arrow.len());
+
+		let path = format!(
+			"{}{}{:w$}",
+			indent_str,
+			path_arrow,
+			path,
+			w = available_width
+		);
+
 		Span::styled(path, theme.file_tree_item(is_path, selected))
 	}
 
@@ -221,6 +232,7 @@ impl RevisionFilesComponent {
 
 	fn draw_tree<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
 		let tree_height = usize::from(area.height.saturating_sub(2));
+		let tree_width = usize::from(area.width);
 
 		self.tree.visual_selection().map_or_else(
 			|| {
@@ -239,7 +251,12 @@ impl RevisionFilesComponent {
 			.tree
 			.iterate(self.scroll.get_top(), tree_height)
 			.map(|(item, selected)| {
-				Self::tree_item_to_span(item, &self.theme, selected)
+				Self::tree_item_to_span(
+					item,
+					&self.theme,
+					tree_width,
+					selected,
+				)
 			});
 
 		let is_tree_focused = matches!(self.focus, Focus::Tree);

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -23,6 +23,8 @@ pub struct Theme {
 	#[serde(with = "Color")]
 	selection_bg: Color,
 	#[serde(with = "Color")]
+	cmdbar_bg: Color,
+	#[serde(with = "Color")]
 	cmdbar_extra_lines_bg: Color,
 	#[serde(with = "Color")]
 	disabled_fg: Color,
@@ -220,7 +222,7 @@ impl Theme {
 			Style::default().fg(self.disabled_fg)
 		}
 		.bg(if line == 0 {
-			self.selection_bg
+			self.cmdbar_bg
 		} else {
 			self.cmdbar_extra_lines_bg
 		})
@@ -323,6 +325,7 @@ impl Default for Theme {
 			selected_tab: Color::Reset,
 			command_fg: Color::White,
 			selection_bg: Color::Blue,
+			cmdbar_bg: Color::Reset,
 			cmdbar_extra_lines_bg: Color::Blue,
 			disabled_fg: Color::DarkGray,
 			diff_line_add: Color::Green,


### PR DESCRIPTION
It changes the following:
- Selected line in log and files tab now fill the entire container
- Command bar visible commands uses a different background colour than the selection_bg colour

### Before the patch
![files tab before](https://user-images.githubusercontent.com/3147882/187240948-e632ca8f-91e3-4c76-91b4-1bf2ccc7045f.png)

![log tab before](https://user-images.githubusercontent.com/3147882/187240972-2202eae6-30ab-4522-9968-39f2e32e388d.png)

### After the patch
![files tab after](https://user-images.githubusercontent.com/3147882/187240919-1926cbca-1c18-4d79-bead-58ba2e1816f5.png)

![log tab after](https://user-images.githubusercontent.com/3147882/187240959-1579c384-f996-45c8-8ded-b81244979911.png)

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog