### PR TITLE
fix: returns 0 exit code on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
 
 	if !valid_path(&cliargs.repo_path) {
 		eprintln!("invalid path\nplease run gitui inside of a non-bare git repository");
-		return Ok(());
+		process::exit(1);
 	}
 
 	let key_config = KeyConfig::init()

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,8 +112,7 @@ fn main() -> Result<()> {
 	asyncgit::register_tracing_logging();
 
 	if !valid_path(&cliargs.repo_path) {
-		eprintln!("invalid path\nplease run gitui inside of a non-bare git repository");
-		process::exit(1);
+		bail!("invalid path\nplease run gitui inside of a non-bare git repository");
 	}
 
 	let key_config = KeyConfig::init()


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1315.

It changes the following:
- changes exit code to 1, while initializing gitui in a bare git repo (let me know if the exit code needs to be something else)

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog