### PR TITLE
Allow to build without vendored openssl, allow to build syntect with regex-onig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * customizable `cmdbar_bg` theme color & screen spanning selected line bg [[@gigitsu](https://github.com/gigitsu)] ([#1299](https://github.com/extrawurst/gitui/pull/1299))
 * use filewatcher instead of polling updates ([#1](https://github.com/extrawurst/gitui/issues/1))
 * word motions to text input [[@Rodrigodd](https://github.com/Rodrigodd)] ([#1256](https://github.com/extrawurst/gitui/issues/1256))
+* add `regex-fancy` and `regex-onig` features to allow building Syntect with Onigumara regex engine instead of the default engine based on fancy-regex [[@jirutka](https://github.com/jirutka)]
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * use filewatcher instead of polling updates ([#1](https://github.com/extrawurst/gitui/issues/1))
 * word motions to text input [[@Rodrigodd](https://github.com/Rodrigodd)] ([#1256](https://github.com/extrawurst/gitui/issues/1256))
 * add `regex-fancy` and `regex-onig` features to allow building Syntect with Onigumara regex engine instead of the default engine based on fancy-regex [[@jirutka](https://github.com/jirutka)]
+* add `vendor-openssl` feature to allow building without vendored openssl [[@jirutka](https://github.com/jirutka)]
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1640,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "once_cell",
+ "onig",
  "regex-syntax",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,14 @@ pretty_assertions = "1.3"
 maintenance = { status = "actively-developed" }
 
 [features]
-default =["ghemoji", "regex-fancy", "trace-libgit"]
+default =["ghemoji", "regex-fancy", "trace-libgit", "vendor-openssl"]
 ghemoji =["gh-emoji"]
 # regex-* features are mutually exclusive.
 regex-fancy = ["syntect/regex-fancy"]
 regex-onig = ["syntect/regex-onig"]
 timing =["scopetime/enabled"]
 trace-libgit =["asyncgit/trace-libgit"]
+vendor-openssl = ["asyncgit/vendor-openssl"]
 
 [workspace]
 members =[

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ scopeguard = "1.1"
 scopetime = { path = "./scopetime", version = "0.1" }
 serde = "1.0"
 simplelog = { version = "0.12", default-features = false }
-syntect = { version = "5.0", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "html", "regex-fancy"] }
+syntect = { version = "5.0", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "html"] }
 textwrap = "0.15"
 tui = { version = "0.19", default-features = false, features = ['crossterm', 'serde'] }
 unicode-segmentation = "1.9"
@@ -65,8 +65,11 @@ pretty_assertions = "1.3"
 maintenance = { status = "actively-developed" }
 
 [features]
-default =["ghemoji", "trace-libgit"]
+default =["ghemoji", "regex-fancy", "trace-libgit"]
 ghemoji =["gh-emoji"]
+# regex-* features are mutually exclusive.
+regex-fancy = ["syntect/regex-fancy"]
+regex-onig = ["syntect/regex-onig"]
 timing =["scopetime/enabled"]
 trace-libgit =["asyncgit/trace-libgit"]
 

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 # git2 = { path = "../../extern/git2-rs", features = ["vendored-openssl"]}
 # git2 = { git="https://github.com/extrawurst/git2-rs.git", rev="fc13dcc", features = ["vendored-openssl"]}
 # pinning to vendored openssl, using the git2 feature this gets lost with new resolver
-openssl-sys = { version = '0.9', features = ["vendored"] }
+openssl-sys = { version = '0.9', features = ["vendored"], optional = true }
 rayon-core = "1.9"
 scopetime = { path = "../scopetime", version = "0.1" }
 shellexpand = "2.1"
@@ -37,3 +37,4 @@ tempfile = "3.2"
 [features]
 default = ["trace-libgit"]
 trace-libgit = []
+vendor-openssl = ["openssl-sys"]


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

Please see the commit messages and changelog items.

I’m the maintainer of the [gitui](https://pkgs.alpinelinux.org/packages?name=gitui) package in Alpine Linux. The package is build with Onigurama and system-provided libgit2 (without vendored openssl) since the beginning (more than a year ago), so now I’m just upstreaming these changes.

I followed the checklist:
- [ ] ~~I added unittests~~ (N/A)
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog