### PR TITLE
file blame at right revision from commit-details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ![submodules](assets/submodules.gif)
 
-
 ### Added
 * submodules support ([#1087](https://github.com/extrawurst/gitui/issues/1087))
 * customizable `cmdbar_bg` theme color & screen spanning selected line bg [[@gigitsu](https://github.com/gigitsu)] ([#1299](https://github.com/extrawurst/gitui/pull/1299))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ![submodules](assets/submodules.gif)
 
+
 ### Added
 * submodules support ([#1087](https://github.com/extrawurst/gitui/issues/1087))
 * customizable `cmdbar_bg` theme color & screen spanning selected line bg [[@gigitsu](https://github.com/gigitsu)] ([#1299](https://github.com/extrawurst/gitui/pull/1299))
 * use filewatcher instead of polling updates ([#1](https://github.com/extrawurst/gitui/issues/1))
 * word motions to text input [[@Rodrigodd](https://github.com/Rodrigodd)] ([#1256](https://github.com/extrawurst/gitui/issues/1256))
+* file blame at right revision from commit-details [[@heiskane](https://github.com/heiskane)] ([#1122](https://github.com/extrawurst/gitui/issues/1122))
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/src/components/commit_details/mod.rs
+++ b/src/components/commit_details/mod.rs
@@ -102,6 +102,8 @@ impl CommitDetailsComponent {
 		self.commit = params;
 
 		if let Some(id) = params {
+			self.file_tree.set_commit(Some(id.id));
+
 			if let Some(other) = id.other {
 				self.compare_details
 					.set_commits(Some((id.id, other)));

--- a/src/components/status_tree.rs
+++ b/src/components/status_tree.rs
@@ -14,7 +14,7 @@ use crate::{
 	ui::style::SharedTheme,
 };
 use anyhow::Result;
-use asyncgit::{hash, StatusItem, StatusItemType};
+use asyncgit::{hash, sync::CommitId, StatusItem, StatusItemType};
 use crossterm::event::Event;
 use std::{borrow::Cow, cell::Cell, convert::From, path::Path};
 use tui::{backend::Backend, layout::Rect, text::Span, Frame};
@@ -35,6 +35,7 @@ pub struct StatusTreeComponent {
 	key_config: SharedKeyConfig,
 	scroll_top: Cell<usize>,
 	visible: bool,
+	revision: Option<CommitId>,
 }
 
 impl StatusTreeComponent {
@@ -58,7 +59,12 @@ impl StatusTreeComponent {
 			scroll_top: Cell::new(0),
 			pending: true,
 			visible: false,
+			revision: None,
 		}
+	}
+
+	pub fn set_commit(&mut self, revision: Option<CommitId>) {
+		self.revision = revision;
 	}
 
 	///
@@ -428,7 +434,7 @@ impl Component for StatusTreeComponent {
 								StackablePopupOpen::BlameFile(
 									BlameFileOpen {
 										file_path: status_item.path,
-										commit_id: None,
+										commit_id: self.revision,
 										selection: None,
 									},
 								),


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1122.

It changes the following:
- When blaming file from the log tab selected revision is used.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog