### PR TITLE
Bump and clap update from 3.2. to 4.0.7 latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,25 +216,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "0a1af219c3e254a8b4649d6ddaef886b2015089f35f2ac5e1db31410c0566ab8"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bitflags = "1.3"
 bugreport = "0.5"
 bytesize = { version = "1.1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = [ "clock" ] }
-clap = { version = "3.2", features = [ "env", "cargo" ] }
+clap = { version = "4.0.7", features = [ "env", "cargo" ] }
 crossbeam-channel = "0.5"
 crossterm = { version = "0.25", features = [ "serde" ] }
 dirs-next = "2.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -45,9 +45,7 @@ pub fn process_cmdline() -> Result<CliArgs> {
 
 	let arg_theme = arg_matches
 		.get_one::<String>("theme")
-		.map(PathBuf::from)
-		.unwrap_or_else(|| PathBuf::from("theme.ron"));
-
+		.map_or_else(|| PathBuf::from("theme.ron"), PathBuf::from);
 	if get_app_config_path()?.join(&arg_theme).is_file() {
 		Ok(CliArgs {
 			theme: get_app_config_path()?.join(&arg_theme),
@@ -62,7 +60,7 @@ pub fn process_cmdline() -> Result<CliArgs> {
 }
 
 fn app() -> ClapApp {
-	let app = ClapApp::new(crate_name!())
+	ClapApp::new(crate_name!())
 		.author(crate_authors!())
 		.version(crate_version!())
 		.about(crate_description!())
@@ -100,8 +98,7 @@ fn app() -> ClapApp {
 				.long("workdir")
 				.env("GIT_WORK_TREE")
 				.num_args(1),
-		);
-	app
+		)
 }
 
 fn setup_logging() -> Result<()> {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:
- Update for clap in the Cargo.toml
- Update of the src/args.rs file to migrate clap to 4.x series.

I followed the checklist:
- [ ] I added unittests
- [x ] I ran `make check` without errors
- [x ] I tested the overall application
- [ ] I added an appropriate item to the changelog