### PR TITLE
Display tags and branches in the revlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * add `regex-fancy` and `regex-onig` features to allow building Syntect with Onigumara regex engine instead of the default engine based on fancy-regex [[@jirutka](https://github.com/jirutka)]
 * add `vendor-openssl` feature to allow building without vendored openssl [[@jirutka](https://github.com/jirutka)]
 * allow copying marked commits [[@remique](https://github.com/remique)] ([#1288](https://github.com/extrawurst/gitui/issues/1288))
+* display tags and branches in the log view ([#1371](https://github.com/extrawurst/gitui/pull/1371))
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -373,12 +373,10 @@ impl CommitList {
 		txt.push(splitter.clone());
 
 		// commit tags
-		txt.push(Span::styled(
-			Cow::from(tags.map_or_else(String::new, |tags| {
-				format!(" {}", tags)
-			})),
-			theme.tags(selected),
-		));
+		if let Some(tags) = tags {
+			txt.push(splitter.clone());
+			txt.push(Span::styled(tags, theme.tags(selected)));
+		}
 
 		txt.push(splitter);
 
@@ -413,7 +411,11 @@ impl CommitList {
 		{
 			let tags =
 				self.tags.as_ref().and_then(|t| t.get(&e.id)).map(
-					|tags| tags.iter().map(|t| &t.name).join(" "),
+					|tags| {
+						tags.iter()
+							.map(|t| format!("<{}>", t.name))
+							.join(" ")
+					},
 				);
 
 			let marked = if any_marked {

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::Result;
 use asyncgit::{
 	cached,
-	sync::{self, CommitId, RepoPathRef},
+	sync::{self, get_branches_info, CommitId, RepoPathRef},
 	AsyncGitNotification, AsyncLog, AsyncTags, CommitFilesParams,
 	FetchStatus,
 };
@@ -106,6 +106,11 @@ impl Revlog {
 			self.list.set_branch(
 				self.branch_name.lookup().map(Some).unwrap_or(None),
 			);
+
+			self.list.set_branches(get_branches_info(
+				&self.repo.borrow(),
+				true,
+			)?);
 
 			if self.commit_details.is_visible() {
 				let commit = self.selected_commit();

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -36,6 +36,7 @@ pub struct Theme {
 	danger_fg: Color,
 	push_gauge_bg: Color,
 	push_gauge_fg: Color,
+	tag_fg: Color,
 }
 
 impl Theme {
@@ -89,7 +90,7 @@ impl Theme {
 
 	pub fn tags(&self, selected: bool) -> Style {
 		Style::default()
-			.fg(self.selected_tab)
+			.fg(self.tag_fg)
 			.add_modifier(Modifier::BOLD)
 			.bg(if selected {
 				self.selection_bg
@@ -325,6 +326,7 @@ impl Default for Theme {
 			danger_fg: Color::Red,
 			push_gauge_bg: Color::Blue,
 			push_gauge_fg: Color::Reset,
+			tag_fg: Color::LightMagenta,
 		}
 	}
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -37,6 +37,7 @@ pub struct Theme {
 	push_gauge_bg: Color,
 	push_gauge_fg: Color,
 	tag_fg: Color,
+	branch_fg: Color,
 }
 
 impl Theme {
@@ -65,14 +66,11 @@ impl Theme {
 			Style::default().add_modifier(Modifier::BOLD)
 		} else {
 			Style::default()
-		};
+		}
+		.fg(self.branch_fg);
 
 		if selected {
-			branch.patch(
-				Style::default()
-					.fg(self.command_fg)
-					.bg(self.selection_bg),
-			)
+			branch.patch(Style::default().bg(self.selection_bg))
 		} else {
 			branch
 		}
@@ -327,6 +325,7 @@ impl Default for Theme {
 			push_gauge_bg: Color::Blue,
 			push_gauge_fg: Color::Reset,
 			tag_fg: Color::LightMagenta,
+			branch_fg: Color::LightYellow,
 		}
 	}
 }


### PR DESCRIPTION
fixes #1252

It changes the following:
- adds fg colors to the theme for tags and branches
- displays local branches as labels on their respective commit heads

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog