### PR TITLE
Display commit description in addition to hash in file view

### DIFF
--- a/src/components/revision_files_popup.rs
+++ b/src/components/revision_files_popup.rs
@@ -95,7 +95,7 @@ impl RevisionFilesPopup {
 			if let Some(revision) = self.files.revision() {
 				self.queue.push(InternalEvent::PopupStackPush(
 					StackablePopupOpen::FileTree(FileTreeOpen {
-						commit_id: revision,
+						commit_id: revision.id,
 						selection: self.files.selection(),
 					}),
 				));


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:
- displays the commit name besides the hash in the file view

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog