### PR TITLE
Use ctrl+arrow to switch focus between panes in the status tab

### DIFF
--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -112,6 +112,10 @@ pub struct KeysList {
 	pub view_submodule_parent: GituiKeyEvent,
 	pub update_submodule: GituiKeyEvent,
 	pub commit_history_next: GituiKeyEvent,
+	pub focus_pane_right: GituiKeyEvent,
+	pub focus_pane_left: GituiKeyEvent,
+	pub focus_pane_above: GituiKeyEvent,
+	pub focus_pane_below: GituiKeyEvent,
 }
 
 #[rustfmt::skip]
@@ -194,6 +198,10 @@ impl Default for KeysList {
 			view_submodule_parent: GituiKeyEvent::new(KeyCode::Char('p'),  KeyModifiers::empty()),
 			update_submodule: GituiKeyEvent::new(KeyCode::Char('u'),  KeyModifiers::empty()),
 			commit_history_next: GituiKeyEvent::new(KeyCode::Char('n'),  KeyModifiers::CONTROL),
+			focus_pane_right: GituiKeyEvent::new(KeyCode::Right,  KeyModifiers::CONTROL),
+			focus_pane_left: GituiKeyEvent::new(KeyCode::Left,  KeyModifiers::CONTROL),
+			focus_pane_above: GituiKeyEvent::new(KeyCode::Up,  KeyModifiers::CONTROL),
+			focus_pane_below: GituiKeyEvent::new(KeyCode::Down,  KeyModifiers::CONTROL),
 		}
 	}
 }

--- a/src/keys/key_list_file.rs
+++ b/src/keys/key_list_file.rs
@@ -83,6 +83,10 @@ pub struct KeysListFile {
 	pub view_submodule_parent: Option<GituiKeyEvent>,
 	pub update_dubmodule: Option<GituiKeyEvent>,
 	pub commit_history_next: Option<GituiKeyEvent>,
+	pub focus_pane_right: Option<GituiKeyEvent>,
+	pub focus_pane_left: Option<GituiKeyEvent>,
+	pub focus_pane_above: Option<GituiKeyEvent>,
+	pub focus_pane_below: Option<GituiKeyEvent>,
 }
 
 impl KeysListFile {
@@ -174,6 +178,10 @@ impl KeysListFile {
 			view_submodule_parent: self.view_submodule_parent.unwrap_or(default.view_submodule_parent),
 			update_submodule: self.update_dubmodule.unwrap_or(default.update_submodule),
 			commit_history_next: self.commit_history_next.unwrap_or(default.commit_history_next),
+			focus_pane_right: self.focus_pane_right.unwrap_or(default.focus_pane_right),
+			focus_pane_left: self.focus_pane_left.unwrap_or(default.focus_pane_left),
+			focus_pane_above: self.focus_pane_above.unwrap_or(default.focus_pane_above),
+			focus_pane_below: self.focus_pane_below.unwrap_or(default.focus_pane_below),
 		}
 	}
 }

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -848,28 +848,42 @@ impl Component for Status {
 				{
 					self.switch_focus(self.focus.toggled_focus())
 						.map(Into::into)
-				} else if key_match(
+				} else if (key_match(
 					k,
 					self.key_config.keys.focus_right,
-				) && self.can_focus_diff()
+				) || key_match(
+					k,
+					self.key_config.keys.focus_pane_right,
+				)) && self.can_focus_diff()
 				{
 					self.switch_focus(Focus::Diff).map(Into::into)
 				} else if key_match(
 					k,
 					self.key_config.keys.focus_left,
+				) || key_match(
+					k,
+					self.key_config.keys.focus_pane_left,
 				) {
 					self.switch_focus(match self.diff_target {
 						DiffTarget::Stage => Focus::Stage,
 						DiffTarget::WorkingDir => Focus::WorkDir,
 					})
 					.map(Into::into)
-				} else if key_match(k, self.key_config.keys.move_down)
-					&& self.focus == Focus::WorkDir
+				} else if (key_match(
+					k,
+					self.key_config.keys.move_down,
+				) || key_match(
+					k,
+					self.key_config.keys.focus_pane_below,
+				)) && self.focus == Focus::WorkDir
 					&& !self.index.is_empty()
 				{
 					self.switch_focus(Focus::Stage).map(Into::into)
-				} else if key_match(k, self.key_config.keys.move_up)
-					&& self.focus == Focus::Stage
+				} else if (key_match(k, self.key_config.keys.move_up)
+					|| key_match(
+						k,
+						self.key_config.keys.focus_pane_above,
+					)) && self.focus == Focus::Stage
 					&& !self.index_wd.is_empty()
 				{
 					self.switch_focus(Focus::WorkDir).map(Into::into)


### PR DESCRIPTION
Currently, the only way to switch between the tree and stage is by scrolling through the entire list.
This adds a way of doing it quickly for very long lists.

This Pull Request fixes/closes #1295 .

It changes the following:
- adds 4 new key combos (focus_pane_$direction), defaulting to ctrl+arrow
- uses those combos in the status tab to switch views

Right now it doesn't add these combos as commands, since the available commands is already very crowded and confusing, but I can add the commands if necessary.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog