### PR TITLE
Report failure to copy to clipboard

### DIFF
--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -171,7 +171,15 @@ impl CommitList {
 		true
 	}
 
-	pub fn copy_marked_hashes(&self) -> Result<()> {
+	pub fn copy_commit_hash(&self) -> Result<()> {
+		if self.marked_count() > 1 {
+			self.copy_marked_hashes()
+		} else {
+			self.copy_entry_hash()
+		}
+	}
+
+	fn copy_marked_hashes(&self) -> Result<()> {
 		if self.marked_consecutive() {
 			let m = self.marked_indexes();
 
@@ -220,7 +228,7 @@ impl CommitList {
 		Ok(())
 	}
 
-	pub fn copy_entry_hash(&self) -> Result<()> {
+	fn copy_entry_hash(&self) -> Result<()> {
 		match self.marked_count() {
 			0 => {
 				if let Some(e) = self.items.iter().nth(

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -6,7 +6,7 @@ use crate::{
 	},
 	keys::{key_match, SharedKeyConfig},
 	queue::{InternalEvent, Queue},
-	strings::{self, copy_fail, copy_success, symbol},
+	strings::{self, symbol},
 	ui::style::{SharedTheme, Theme},
 	ui::{calc_scroll_top, draw_scrollbar},
 };
@@ -188,14 +188,9 @@ impl CommitList {
 		};
 
 		if let Some(yank) = yank {
-			if let Err(e) = crate::clipboard::copy_string(&yank) {
-				self.queue.push(InternalEvent::ShowErrorMsg(
-					copy_fail(&e.to_string()),
-				));
-				return Err(e);
-			}
+			crate::clipboard::copy_string(&yank)?;
 			self.queue.push(InternalEvent::ShowInfoMsg(
-				copy_success(&yank),
+				strings::copy_success(&yank),
 			));
 		}
 		Ok(())

--- a/src/components/utils/mod.rs
+++ b/src/components/utils/mod.rs
@@ -12,7 +12,7 @@ pub mod statustree;
 /// It will show a popup in that case
 #[macro_export]
 macro_rules! try_or_popup {
-	($self:ident, $msg:literal, $e:expr) => {
+	($self:ident, $msg:expr, $e:expr) => {
 		if let Err(err) = $e {
 			::log::error!("{} {}", $msg, err);
 			$self.queue.push(InternalEvent::ShowErrorMsg(format!(

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -30,7 +30,7 @@ pub static PUSH_TAGS_STATES_DONE: &str = "done";
 pub static POPUP_TITLE_SUBMODULES: &str = "Submodules";
 pub static POPUP_TITLE_FUZZY_FIND: &str = "Fuzzy Finder";
 
-pub static POPUP_FAIL_COPY: &str = "Failed to copy the Text";
+pub static POPUP_FAIL_COPY: &str = "Failed to copy text";
 pub static POPUP_SUCCESS_COPY: &str = "Copied Text";
 
 pub mod symbol {
@@ -358,10 +358,6 @@ pub fn rename_branch_popup_msg(
 
 pub fn copy_success(s: &str) -> String {
 	format!("{POPUP_SUCCESS_COPY} \"{s}\"")
-}
-
-pub fn copy_fail(e: &str) -> String {
-	format!("{POPUP_FAIL_COPY}: {e}")
 }
 
 pub fn ellipsis_trim_start(s: &str, width: usize) -> Cow<str> {

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -163,15 +163,6 @@ impl Revlog {
 		self.list.selected_entry().map(|e| e.id)
 	}
 
-	fn copy_commit_hash(&self) -> Result<()> {
-		if self.list.marked_count() > 1 {
-			self.list.copy_marked_hashes()?;
-		} else {
-			self.list.copy_entry_hash()?;
-		}
-		Ok(())
-	}
-
 	fn selected_commit_tags(
 		&self,
 		commit: &Option<CommitId>,
@@ -260,7 +251,7 @@ impl Component for Revlog {
 					self.update()?;
 					return Ok(EventState::Consumed);
 				} else if key_match(k, self.key_config.keys.copy) {
-					self.copy_commit_hash()?;
+					self.list.copy_commit_hash()?;
 					return Ok(EventState::Consumed);
 				} else if key_match(k, self.key_config.keys.push) {
 					self.queue.push(InternalEvent::PushTags);

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -251,7 +251,11 @@ impl Component for Revlog {
 					self.update()?;
 					return Ok(EventState::Consumed);
 				} else if key_match(k, self.key_config.keys.copy) {
-					self.list.copy_commit_hash()?;
+					try_or_popup!(
+						self,
+						strings::POPUP_FAIL_COPY,
+						self.list.copy_commit_hash()
+					);
 					return Ok(EventState::Consumed);
 				} else if key_match(k, self.key_config.keys.push) {
 					self.queue.push(InternalEvent::PushTags);


### PR DESCRIPTION
This Pull Request improves failures to copy to clipboard for more system configs.

Right now, when xsel and xclip fail, they return 1 but the status is never checked and execution seems successful.
Additionally, xsel's stderr output sometimes overwrites the screen in random places.

It changes the following:
- preamble refactor of commit copying
- reports subprocess failure from `clipboard::exec_copy_with_args`
- opens failure popup without closing the application when copying to clipboard fails

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog