### PR TITLE
Add Linux targets for ARM, ARMv7 and AARCH64

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -29,10 +29,13 @@ jobs:
         components: clippy
 
     - name: Build
+      if: matrix.os != 'ubuntu-22.04'
       run: cargo build
     - name: Run tests
+      if: matrix.os != 'ubuntu-22.04'
       run: make test
     - name: Run clippy
+      if: matrix.os != 'ubuntu-22.04'
       run: |
         cargo clean
         make clippy
@@ -43,6 +46,22 @@ jobs:
         rustup target add x86_64-unknown-linux-musl
         sudo apt-get -qq install musl-tools
 
+    - name: Setup ARM toolchain
+      if: matrix.os == 'ubuntu-22.04'
+      run: |
+        rustup target add aarch64-unknown-linux-gnu
+        rustup target add armv7-unknown-linux-gnueabihf
+        rustup target add arm-unknown-linux-gnueabihf
+
+        curl -o $GITHUB_WORKSPACE/aarch64.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz
+        curl -o $GITHUB_WORKSPACE/arm.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz
+
+        tar xf $GITHUB_WORKSPACE/aarch64.tar.xz
+        tar xf $GITHUB_WORKSPACE/arm.tar.xz
+
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf/bin" >> $GITHUB_PATH
+
     - name: Build Release Mac
       if: matrix.os == 'macos-latest'
       run: make release-mac
@@ -52,6 +71,9 @@ jobs:
     - name: Build Release Win
       if: matrix.os == 'windows-latest'
       run: make release-win
+    - name: Build Release Linux ARM
+      if: matrix.os == 'ubuntu-22.04'
+      run: make release-linux-arm
 
     - name: Set SHA
       if: matrix.os == 'macos-latest'
@@ -72,7 +94,7 @@ jobs:
           ./release/*.tar.gz
           ./release/*.zip
           ./release/*.msi
-          
+
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         ls -l ./target/release/gitui
-    
+
     - name: Binary Size (win)
       if: matrix.os == 'windows-latest'
       run: |
@@ -120,6 +120,45 @@ jobs:
       run: |
         make test-linux-musl
 
+  build-linux-arm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly, stable, '1.60']
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+        default: true
+        override: true
+    - name: Setup ARM toolchain
+      run: |
+        rustup target add aarch64-unknown-linux-gnu
+        rustup target add armv7-unknown-linux-gnueabihf
+        rustup target add arm-unknown-linux-gnueabihf
+
+        curl -o $GITHUB_WORKSPACE/aarch64.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz
+        curl -o $GITHUB_WORKSPACE/arm.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz
+
+        tar xf $GITHUB_WORKSPACE/aarch64.tar.xz
+        tar xf $GITHUB_WORKSPACE/arm.tar.xz
+
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf/bin" >> $GITHUB_PATH
+
+    - name: Build Debug
+      run: |
+        make build-linux-arm-debug
+    - name: Build Release
+      run: |
+        make build-linux-arm-release
+        ls -l ./target/aarch64-unknown-linux-gnu/release/gitui || ls -l ./target/armv7-unknown-linux-gnueabihf/release/gitui || ls -l ./target/arm-unknown-linux-gnueabihf/release/gitui
+
   linting:
     name: Lints
     runs-on: ubuntu-latest
@@ -131,7 +170,7 @@ jobs:
         toolchain: stable
         override: true
         components: rustfmt
-    
+
     - run: cargo fmt -- --check
 
     - name: cargo-sort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Feedback for success/failure of copying hash commit [[@sergioribera]](https://github.com/sergioribera)([#1160](https://github.com/extrawurst/gitui/issues/1160))
 * display tags and branches in the log view [[@alexmaco]](https://github.com/alexmaco)([#1371](https://github.com/extrawurst/gitui/pull/1371))
 * display current repository path in the top-right corner [[@alexmaco]](https://github.com/alexmaco)([#1387](https://github.com/extrawurst/gitui/pull/1387))
+* Add Linux targets for ARM, ARMv7 and AARCH64 [@adur1990](https://github.com/adur1990) ([#1419](https://github.com/extrawurst/gitui/pull/1419))
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,27 @@ build-linux-musl-release:
 test-linux-musl:
 	cargo test --workspace --target=x86_64-unknown-linux-musl
 
+release-linux-arm: build-linux-arm-release
+	mkdir -p release
+
+	aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/gitui
+	arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/gitui
+	arm-linux-gnueabihf-strip target/arm-unknown-linux-gnueabihf/release/gitui
+
+	tar -C ./target/aarch64-unknown-linux-gnu/release/ -czvf ./release/gitui-linux-aarch64.tar.gz ./gitui
+	tar -C ./target/armv7-unknown-linux-gnueabihf/release/ -czvf ./release/gitui-linux-armv7.tar.gz ./gitui
+	tar -C ./target/arm-unknown-linux-gnueabihf/release/ -czvf ./release/gitui-linux-arm.tar.gz ./gitui
+
+build-linux-arm-debug:
+	cargo build --target=aarch64-unknown-linux-gnu
+	cargo build --target=armv7-unknown-linux-gnueabihf
+	cargo build --target=arm-unknown-linux-gnueabihf
+
+build-linux-arm-release:
+	cargo build --release --target=aarch64-unknown-linux-gnu
+	cargo build --release --target=armv7-unknown-linux-gnueabihf
+	cargo build --release --target=arm-unknown-linux-gnueabihf
+
 test:
 	cargo test --workspace
 


### PR DESCRIPTION
This Pull Request fixes/closes #1343.

It changes the following:
- Adds compilation target for ARM, ARMv7 and AARCH64

As now code was changed, no tests beyond executing the binary are needed.