### PR TITLE
Display commit changes on external editor #1420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * display tags and branches in the log view [[@alexmaco]](https://github.com/alexmaco)([#1371](https://github.com/extrawurst/gitui/pull/1371))
 * display current repository path in the top-right corner [[@alexmaco]](https://github.com/alexmaco)([#1387](https://github.com/extrawurst/gitui/pull/1387))
 * Add Linux targets for ARM, ARMv7 and AARCH64 [@adur1990](https://github.com/adur1990) ([#1419](https://github.com/extrawurst/gitui/pull/1419))
+* Add changes to commit message when opening external editor [[@bc-universe]](https://github.com/bc-universe) ([#1420](https://github.com/extrawurst/gitui/issues/1420))
 
 ### Fixes
 * remove insecure dependency `ansi_term` ([#1290](https://github.com/extrawurst/gitui/issues/1290))

--- a/src/app.rs
+++ b/src/app.rs
@@ -444,19 +444,17 @@ impl App {
 		} else if let InputEvent::State(polling_state) = ev {
 			self.external_editor_popup.hide();
 			if let InputState::Paused = polling_state {
-				let result = match self.file_to_open.take() {
-					Some(path) => {
+				let result =
+					if let Some(path) = self.file_to_open.take() {
 						ExternalEditorComponent::open_file_in_editor(
 							&self.repo.borrow(),
 							Path::new(&path),
 						)
-					}
-					None => {
+					} else {
 						let changes =
 							self.status_tab.get_files_changes()?;
 						self.commit.show_editor(changes)
-					}
-				};
+					};
 
 				if let Err(e) = result {
 					let msg =

--- a/src/app.rs
+++ b/src/app.rs
@@ -452,9 +452,10 @@ impl App {
 						)
 					}
 					None => {
-						let changes = self.status_tab.get_files_changes()?;
+						let changes =
+							self.status_tab.get_files_changes()?;
 						self.commit.show_editor(changes)
-					},
+					}
 				};
 
 				if let Err(e) = result {

--- a/src/app.rs
+++ b/src/app.rs
@@ -451,7 +451,10 @@ impl App {
 							Path::new(&path),
 						)
 					}
-					None => self.commit.show_editor(),
+					None => {
+						let changes = self.status_tab.get_files_changes()?;
+						self.commit.show_editor(changes)
+					},
 				};
 
 				if let Err(e) = result {

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -176,7 +176,7 @@ impl CommitComponent {
 					Self::item_status_char(change.status);
 				let message =
 					format!("\n#\t{}: {}", status_char, change.path);
-				file.write(message.as_bytes())?;
+				file.write_all(message.as_bytes())?;
 			}
 		}
 

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -11,10 +11,14 @@ use crate::{
 	ui::style::SharedTheme,
 };
 use anyhow::Result;
-use asyncgit::{cached, message_prettify, StatusItem, StatusItemType, sync::{
-	self, get_config_string, CommitId, HookResult, RepoPathRef,
-	RepoState,
-}};
+use asyncgit::{
+	cached, message_prettify,
+	sync::{
+		self, get_config_string, CommitId, HookResult, RepoPathRef,
+		RepoState,
+	},
+	StatusItem, StatusItemType,
+};
 use crossterm::event::Event;
 use easy_cast::Cast;
 use std::{
@@ -136,7 +140,9 @@ impl CommitComponent {
 		}
 	}
 
-	const fn item_status_char(item_type: StatusItemType) -> &'static str {
+	const fn item_status_char(
+		item_type: StatusItemType,
+	) -> &'static str {
 		match item_type {
 			StatusItemType::Modified => "modified",
 			StatusItemType::New => "new file",
@@ -147,7 +153,10 @@ impl CommitComponent {
 		}
 	}
 
-	pub fn show_editor(&mut self, changes: Vec<StatusItem>) -> Result<()> {
+	pub fn show_editor(
+		&mut self,
+		changes: Vec<StatusItem>,
+	) -> Result<()> {
 		let file_path = sync::repo_dir(&self.repo.borrow())?
 			.join("COMMIT_EDITMSG");
 
@@ -163,8 +172,10 @@ impl CommitComponent {
 			)?;
 
 			for change in changes {
-				let status_char = Self::item_status_char(change.status);
-				let message = format! ("\n#\t{}: {}", status_char, change.path);
+				let status_char =
+					Self::item_status_char(change.status);
+				let message =
+					format!("\n#\t{}: {}", status_char, change.path);
 				file.write(message.as_bytes())?;
 			}
 		}

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -146,7 +146,7 @@ impl CommitComponent {
 		match item_type {
 			StatusItemType::Modified => "modified",
 			StatusItemType::New => "new file",
-			StatusItemType::Deleted => "file deleted",
+			StatusItemType::Deleted => "deleted",
 			StatusItemType::Renamed => "renamed",
 			StatusItemType::Typechange => " ",
 			StatusItemType::Conflicted => "conflicted",

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -13,9 +13,15 @@ use crate::{
 	ui::style::SharedTheme,
 };
 use anyhow::Result;
-use asyncgit::{cached, sync::{
-	self, status::StatusType, RepoPath, RepoPathRef, RepoState,
-}, sync::{BranchCompare, CommitId}, AsyncDiff, AsyncGitNotification, AsyncStatus, DiffParams, DiffType, PushType, StatusParams, StatusItem};
+use asyncgit::{
+	cached,
+	sync::{
+		self, status::StatusType, RepoPath, RepoPathRef, RepoState,
+	},
+	sync::{BranchCompare, CommitId},
+	AsyncDiff, AsyncGitNotification, AsyncStatus, DiffParams,
+	DiffType, PushType, StatusItem, StatusParams,
+};
 use crossbeam_channel::Sender;
 use crossterm::event::Event;
 use itertools::Itertools;
@@ -445,7 +451,7 @@ impl Status {
 
 		Ok(())
 	}
-	
+
 	pub fn get_files_changes(&mut self) -> Result<Vec<StatusItem>> {
 		Ok(self.git_status_stage.last()?.items)
 	}

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -13,15 +13,9 @@ use crate::{
 	ui::style::SharedTheme,
 };
 use anyhow::Result;
-use asyncgit::{
-	cached,
-	sync::{
-		self, status::StatusType, RepoPath, RepoPathRef, RepoState,
-	},
-	sync::{BranchCompare, CommitId},
-	AsyncDiff, AsyncGitNotification, AsyncStatus, DiffParams,
-	DiffType, PushType, StatusParams,
-};
+use asyncgit::{cached, sync::{
+	self, status::StatusType, RepoPath, RepoPathRef, RepoState,
+}, sync::{BranchCompare, CommitId}, AsyncDiff, AsyncGitNotification, AsyncStatus, DiffParams, DiffType, PushType, StatusParams, StatusItem};
 use crossbeam_channel::Sender;
 use crossterm::event::Event;
 use itertools::Itertools;
@@ -450,6 +444,10 @@ impl Status {
 		}
 
 		Ok(())
+	}
+	
+	pub fn get_files_changes(&mut self) -> Result<Vec<StatusItem>> {
+		Ok(self.git_status_stage.last()?.items)
 	}
 
 	fn update_status(&mut self) -> Result<()> {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1420.

It changes the following:
- When opening a commit message on an external editor, file changes are displayed.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog