### PR TITLE
Fix commit hooks error and "no such file" error on Windows with wsl2 installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * crash on branches popup in small terminal ([#1470](https://github.com/extrawurst/gitui/issues/1470))
 * `edit` command duplication ([#1489](https://github.com/extrawurst/gitui/issues/1489))
 * syntax errors in `key_bindings.ron` will be logged ([#1491](https://github.com/extrawurst/gitui/issues/1491))
+* commit hooks report "command not found" on Windows with wsl2 installed ([#1528](https://github.com/extrawurst/gitui/issues/1528))
 
 ### Changed
 * minimum supported rust version bumped to 1.64 (thank you `clap`)

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -285,6 +285,28 @@ exit 0
 	}
 
 	#[test]
+	fn test_hooks_commit_msg_with_shell_command_ok() {
+		let (_td, repo) = repo_init().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		let hook = br#"#!/bin/sh
+sed -i 's/sth/shell_command/g' "$1"
+exit 0
+        "#;
+
+		create_hook(repo_path, HOOK_COMMIT_MSG, hook);
+
+		let mut msg = String::from("test_sth");
+		let res = hooks_commit_msg(repo_path, &mut msg).unwrap();
+
+		assert_eq!(res, HookResult::Ok);
+
+		assert_eq!(msg, String::from("test_shell_command"));
+	}
+
+	#[test]
 	fn test_pre_commit_sh() {
 		let (_td, repo) = repo_init().unwrap();
 		let root = repo.path().parent().unwrap();

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -292,7 +292,8 @@ exit 0
 			&root.as_os_str().to_str().unwrap().into();
 
 		let hook = br#"#!/bin/sh
-sed -i 's/sth/shell_command/g' "$1"
+COMMIT_MSG="$(cat "$1")"
+printf "$COMMIT_MSG" | sed 's/sth/shell_command/g' >"$1"
 exit 0
         "#;
 


### PR DESCRIPTION
This Pull Request fixes/closes #1528.

It changes the following:
- `run_hook` finds git's bash not wsl's on Windows.

I followed the checklist:
- [x] I added unittests
  - make `cargo test -p asyncgit sync::hooks::tests::test_commit_msg_no_block_but_alter` pass on my machine.
  - Add unit tests that run shell commands in hook scripts (test `-l` options).
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog
