### PR TITLE
Fix freeze on copy when xclip is installed on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * crash on branches popup in small terminal ([#1470](https://github.com/extrawurst/gitui/issues/1470))
 * `edit` command duplication ([#1489](https://github.com/extrawurst/gitui/issues/1489))
 * syntax errors in `key_bindings.ron` will be logged ([#1491](https://github.com/extrawurst/gitui/issues/1491))
+* Fix UI freeze when copying with xclip installed on Linux ([#1497](https://github.com/extrawurst/gitui/issues/1497))
 * commit hooks report "command not found" on Windows with wsl2 installed ([#1528](https://github.com/extrawurst/gitui/issues/1528))
 
 ### Changed

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -8,6 +8,7 @@ fn exec_copy_with_args(
 	command: &str,
 	args: &[&str],
 	text: &str,
+	pipe_stderr: bool,
 ) -> Result<()> {
 	let binary = which(command)
 		.ok()
@@ -17,7 +18,11 @@ fn exec_copy_with_args(
 		.args(args)
 		.stdin(Stdio::piped())
 		.stdout(Stdio::null())
-		.stderr(Stdio::piped())
+		.stderr(if pipe_stderr {
+			Stdio::piped()
+		} else {
+			Stdio::null()
+		})
 		.spawn()
 		.map_err(|e| anyhow!("`{:?}`: {}", command, e))?;
 
@@ -45,7 +50,7 @@ fn exec_copy_with_args(
 }
 
 fn exec_copy(command: &str, text: &str) -> Result<()> {
-	exec_copy_with_args(command, &[], text)
+	exec_copy_with_args(command, &[], text, true)
 }
 
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
@@ -58,10 +63,16 @@ pub fn copy_string(text: &str) -> Result<()> {
 		"xclip",
 		&["-selection", "clipboard"],
 		text,
+		false,
 	)
 	.is_err()
 	{
-		return exec_copy_with_args("xsel", &["--clipboard"], text);
+		return exec_copy_with_args(
+			"xsel",
+			&["--clipboard"],
+			text,
+			true,
+		);
 	}
 
 	Ok(())


### PR DESCRIPTION
This Pull Request fixes/closes #1497 

It changes the following:
- It adds a boolean argument to determine if stderr should be piped, and sets it to false when running the xclip command.

I was able to reproduce the linked issue. If I run `killall xclip` then the UI resumes normal function. This issue started with e371153034db126235f342b52e2e6301e0880e70. Removing the `.stderr(Stdio::piped())` line fixes the freezing, but breaks the error reporting.

`xclip` waits for input on stdin. Something about piping stderr and stdin seems to cause the program to continue waiting for input. I tried different arguments to pass to xclip to tell it to exit, but nothing I tried seemed to work. I tried writing \x03 (End of Text) and \x04 (End of Transmission) and a few others that may have indicated to xclip to close. I tried passing `-l 1` (loop once then exit) which fixes the freezing, but results in the wrong thing being set on the clipboard. (It would always set the previous thing I copied, instead of the last)

In the end, passing a boolean to the function to indicate whether or not stderr should be piped seems to do the trick. If the command fails, we retry with `xsel` anyway, and report the error from that command. So the stderr output from `xclip` isn't needed.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog