### PR TITLE
Fix #1473 - correct msg limit in get_commits_intf

### DIFF
--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -88,9 +88,9 @@ impl CommitList {
 	}
 
 	///
-	pub fn current_size(&self) -> (u16, u16) {
-		self.current_size.get()
-	}
+	//pub fn current_size(&self) -> (u16, u16) {
+	//	self.current_size.get()
+	//}
 
 	///
 	pub fn set_count_total(&mut self, total: usize) {

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -28,6 +28,7 @@ use tui::{
 };
 
 const SLICE_SIZE: usize = 1200;
+static MAX_MESSAGE_WIDTH: usize = 100;
 
 ///
 pub struct Revlog {
@@ -160,7 +161,7 @@ impl Revlog {
 		let commits = sync::get_commits_info(
 			&self.repo.borrow(),
 			&self.git_log.get_slice(want_min, SLICE_SIZE)?,
-			self.list.current_size().0.into(),
+			MAX_MESSAGE_WIDTH,
 		);
 
 		if let Ok(commits) = commits {


### PR DESCRIPTION
When sync::get_commits_inf is called in revlog:::fetch_commits, the message limit used was the length of the list which can be zero at start up before items are fetched. This results in initial view of the Log view showing empty messages.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
-
-

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog