### PR TITLE
fix race issue in revlog message fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * syntax errors in `key_bindings.ron` will be logged ([#1491](https://github.com/extrawurst/gitui/issues/1491))
 * commit hooks report "command not found" on Windows with wsl2 installed ([#1528](https://github.com/extrawurst/gitui/issues/1528))
 * crashes on entering submodules ([#1510](https://github.com/extrawurst/gitui/issues/1510))
+* fix race issue: revlog messages sometimes appear empty ([#1473](https://github.com/extrawurst/gitui/issues/1473))
 
 ### Changed
 * minimum supported rust version bumped to 1.64 (thank you `clap`)

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -160,7 +160,10 @@ impl Revlog {
 		let commits = sync::get_commits_info(
 			&self.repo.borrow(),
 			&self.git_log.get_slice(want_min, SLICE_SIZE)?,
-			self.list.current_size().0.into(),
+			self.list
+				.current_size()
+				.map_or(100u16, |size| size.0)
+				.into(),
 		);
 
 		if let Ok(commits) = commits {


### PR DESCRIPTION
sometimes messages appear empty because getting the revlog is so fast (empty repo) that no draw happened yet and so we do not know yet what size the view will have.

fixes #1473