### PR TITLE
chore(cargo): use crates.io sparse protocol

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,3 +6,7 @@ linker = "arm-linux-gnueabihf-gcc"
 
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[registries.crates-io]
+protocol = "sparse"
+


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:
- Use crates.io sparse protocol
- Saves on compile time as downloading index is quicker
-https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
