### PR TITLE
Add openSUSE (TW) to 'Installation' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ sudo emerge --sync dm9pZCAq
 sudo emerge dev-vcs/gitui::dm9pZCAq
 ```
 
+### [openSUSE](https://software.opensuse.org/package/gitui) (Tumbleweed)
+
+```sh
+sudo zypper install gitui
+```
+
 ### Homebrew (macOS)
 
 ```sh


### PR DESCRIPTION
Since gitui is now available in the official software repository for openSUSE Tumbleweed it would make sense to add it to the install instructions.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:
- README.md: Add installation instructions for openSUSE Tumbleweed