### PR TITLE
Show remote branches in log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * allow `fetch` on status tab [[@alensiljak]](https://github.com/alensiljak) ([#1471](https://github.com/extrawurst/gitui/issues/1471))
 * allow `copy` file path on revision files and status tree [[@yanganto]](https://github.com/yanganto)  ([#1516](https://github.com/extrawurst/gitui/pull/1516))
 * print message of where log will be written if `-l` is set ([#1472](https://github.com/extrawurst/gitui/pull/1472))
+* show remote branches in log [[@cruessler](https://github.com/cruessler)] ([#1501](https://github.com/extrawurst/gitui/issues/1501))
 
 ### Fixes
 * commit msg history ordered the wrong way ([#1445](https://github.com/extrawurst/gitui/issues/1445))

--- a/asyncgit/src/sync/branch/mod.rs
+++ b/asyncgit/src/sync/branch/mod.rs
@@ -55,7 +55,16 @@ pub struct LocalBranch {
 	///
 	pub has_upstream: bool,
 	///
+	pub upstream: Option<UpstreamBranch>,
+	///
 	pub remote: Option<String>,
+}
+
+///
+#[derive(Clone, Debug)]
+pub struct UpstreamBranch {
+	///
+	pub reference: String,
 }
 
 ///
@@ -154,10 +163,18 @@ pub fn get_branches_info(
 
 			let name_bytes = branch.name_bytes()?;
 
+			let upstream_branch =
+				upstream.ok().and_then(|upstream| {
+					bytes2string(upstream.get().name_bytes())
+						.ok()
+						.map(|reference| UpstreamBranch { reference })
+				});
+
 			let details = if local {
 				BranchDetails::Local(LocalBranch {
 					is_head: branch.is_head(),
-					has_upstream: upstream.is_ok(),
+					has_upstream: upstream_branch.is_some(),
+					upstream: upstream_branch,
 					remote,
 				})
 			} else {

--- a/asyncgit/src/sync/branch/mod.rs
+++ b/asyncgit/src/sync/branch/mod.rs
@@ -48,7 +48,7 @@ pub(crate) fn get_branch_name_repo(
 }
 
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LocalBranch {
 	///
 	pub is_head: bool,
@@ -59,14 +59,14 @@ pub struct LocalBranch {
 }
 
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RemoteBranch {
 	///
 	pub has_tracking: bool,
 }
 
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum BranchDetails {
 	///
 	Local(LocalBranch),
@@ -75,7 +75,7 @@ pub enum BranchDetails {
 }
 
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BranchInfo {
 	///
 	pub name: String,

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -41,7 +41,7 @@ pub use branch::{
 	merge_commit::merge_upstream_commit,
 	merge_ff::branch_merge_upstream_fastforward,
 	merge_rebase::merge_upstream_rebase, rename::rename_branch,
-	validate_branch_name, BranchCompare, BranchInfo,
+	validate_branch_name, BranchCompare, BranchDetails, BranchInfo,
 };
 pub use commit::{amend, commit, tag_commit};
 pub use commit_details::{

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -42,7 +42,8 @@ pub struct CommitList {
 	marked: Vec<(usize, CommitId)>,
 	scroll_state: (Instant, f32),
 	tags: Option<Tags>,
-	branches: BTreeMap<CommitId, Vec<String>>,
+	local_branches: BTreeMap<CommitId, Vec<BranchInfo>>,
+	remote_branches: BTreeMap<CommitId, Vec<BranchInfo>>,
 	current_size: Cell<Option<(u16, u16)>>,
 	scroll_top: Cell<usize>,
 	theme: SharedTheme,
@@ -67,7 +68,8 @@ impl CommitList {
 			count_total: 0,
 			scroll_state: (Instant::now(), 0_f32),
 			tags: None,
-			branches: BTreeMap::default(),
+			local_branches: BTreeMap::default(),
+			remote_branches: BTreeMap::default(),
 			current_size: Cell::new(None),
 			scroll_top: Cell::new(0),
 			theme,
@@ -297,7 +299,8 @@ impl CommitList {
 		e: &'a LogEntry,
 		selected: bool,
 		tags: Option<String>,
-		branches: Option<String>,
+		local_branches: Option<String>,
+		remote_branches: Option<String>,
 		theme: &Theme,
 		width: usize,
 		now: DateTime<Local>,
@@ -358,10 +361,18 @@ impl CommitList {
 			txt.push(Span::styled(tags, theme.tags(selected)));
 		}
 
-		if let Some(branches) = branches {
+		if let Some(local_branches) = local_branches {
 			txt.push(splitter.clone());
 			txt.push(Span::styled(
-				branches,
+				local_branches,
+				theme.branch(selected, true),
+			));
+		}
+
+		if let Some(remote_branches) = remote_branches {
+			txt.push(splitter.clone());
+			txt.push(Span::styled(
+				remote_branches,
 				theme.branch(selected, true),
 			));
 		}
@@ -406,12 +417,27 @@ impl CommitList {
 					},
 				);
 
-			let branches = self.branches.get(&e.id).map(|names| {
-				names
-					.iter()
-					.map(|name| format!("{{{name}}}"))
-					.join(" ")
-			});
+			let local_branches =
+				self.local_branches.get(&e.id).map(|local_branch| {
+					local_branch
+						.iter()
+						.map(|local_branch| {
+							format!("{{{0}}}", local_branch.name)
+						})
+						.join(" ")
+				});
+
+			let remote_branches = self
+				.remote_branches
+				.get(&e.id)
+				.map(|remote_branches| {
+					remote_branches
+						.iter()
+						.map(|remote_branch| {
+							format!("[{0}]", remote_branch.name)
+						})
+						.join(" ")
+				});
 
 			let marked = if any_marked {
 				self.is_marked(&e.id)
@@ -423,7 +449,8 @@ impl CommitList {
 				e,
 				idx + self.scroll_top.get() == selection,
 				tags,
-				branches,
+				local_branches,
+				remote_branches,
 				&self.theme,
 				width,
 				now,
@@ -455,14 +482,31 @@ impl CommitList {
 		}
 	}
 
-	pub fn set_branches(&mut self, branches: Vec<BranchInfo>) {
-		self.branches.clear();
+	pub fn set_local_branches(
+		&mut self,
+		local_branches: Vec<BranchInfo>,
+	) {
+		self.local_branches.clear();
 
-		for b in branches {
-			self.branches
-				.entry(b.top_commit)
+		for local_branch in local_branches {
+			self.local_branches
+				.entry(local_branch.top_commit)
 				.or_default()
-				.push(b.name);
+				.push(local_branch);
+		}
+	}
+
+	pub fn set_remote_branches(
+		&mut self,
+		remote_branches: Vec<BranchInfo>,
+	) {
+		self.remote_branches.clear();
+
+		for remote_branch in remote_branches {
+			self.remote_branches
+				.entry(remote_branch.top_commit)
+				.or_default()
+				.push(remote_branch);
 		}
 	}
 }

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -36,7 +36,8 @@ pub struct Revlog {
 	list: CommitList,
 	git_log: AsyncLog,
 	git_tags: AsyncTags,
-	git_branches: AsyncSingleJob<AsyncBranchesJob>,
+	git_local_branches: AsyncSingleJob<AsyncBranchesJob>,
+	git_remote_branches: AsyncSingleJob<AsyncBranchesJob>,
 	queue: Queue,
 	visible: bool,
 	key_config: SharedKeyConfig,
@@ -74,7 +75,8 @@ impl Revlog {
 				None,
 			),
 			git_tags: AsyncTags::new(repo.borrow().clone(), sender),
-			git_branches: AsyncSingleJob::new(sender.clone()),
+			git_local_branches: AsyncSingleJob::new(sender.clone()),
+			git_remote_branches: AsyncSingleJob::new(sender.clone()),
 			visible: false,
 			key_config,
 		}
@@ -84,7 +86,8 @@ impl Revlog {
 	pub fn any_work_pending(&self) -> bool {
 		self.git_log.is_pending()
 			|| self.git_tags.is_pending()
-			|| self.git_branches.is_pending()
+			|| self.git_local_branches.is_pending()
+			|| self.git_remote_branches.is_pending()
 			|| self.commit_details.any_work_pending()
 	}
 
@@ -136,12 +139,26 @@ impl Revlog {
 					}
 				}
 				AsyncGitNotification::Branches => {
-					if let Some(branches) =
-						self.git_branches.take_last()
+					if let Some(local_branches) =
+						self.git_local_branches.take_last()
 					{
-						if let Some(Ok(branches)) = branches.result()
+						if let Some(Ok(local_branches)) =
+							local_branches.result()
 						{
-							self.list.set_branches(branches);
+							self.list
+								.set_local_branches(local_branches);
+							self.update()?;
+						}
+					}
+
+					if let Some(remote_branches) =
+						self.git_remote_branches.take_last()
+					{
+						if let Some(Ok(remote_branches)) =
+							remote_branches.result()
+						{
+							self.list
+								.set_remote_branches(remote_branches);
 							self.update()?;
 						}
 					}
@@ -505,9 +522,14 @@ impl Component for Revlog {
 		self.visible = true;
 		self.list.clear();
 
-		self.git_branches.spawn(AsyncBranchesJob::new(
+		self.git_local_branches.spawn(AsyncBranchesJob::new(
 			self.repo.borrow().clone(),
 			true,
+		));
+
+		self.git_remote_branches.spawn(AsyncBranchesJob::new(
+			self.repo.borrow().clone(),
+			false,
 		));
 
 		self.update()?;


### PR DESCRIPTION
I opened this draft in order to have the PR run on CI. `make check` passes on 1.68.2, but one tests fails on nightly. The PR itself is mostly done, I think. I’ll add more context to this description in the coming days.

This Pull Request closes #1501.

It changes the following:

- Show remote branches in revlog
- Don’t show upstream if commit is local branch head

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog
