### PR TITLE
fix test failure on nightly due to cef81dc

### DIFF
--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -251,7 +251,7 @@ impl TextInputComponent {
 
 		let cursor_highlighting = {
 			let mut h = HashMap::with_capacity(2);
-			h.insert("\n", "\u{21b5}\n\r");
+			h.insert("\n", "\u{21b5}\r\n\n");
 			h.insert(" ", symbol::WHITESPACE);
 			h
 		};


### PR DESCRIPTION
simple fix in the end. Restores the behaviour - 

which is that 

        h.insert("\n", "\u{21b5}\n\r"); // old

	h.insert("\n", "\u{21b5}\r\n\n");  // new

this substitution string gets parsed as

    `arrow` and `""`

The new one works on stable and nightly