### PR TITLE
make .bat and .cmd files work for editors on windows

### DIFF
--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -122,8 +122,10 @@ impl ExternalEditorComponent {
 			if exec_result.is_err() {
 				let cmd_string =
 					format!("/C {} {}", command, path.display());
-				let exec_result2 =
-					Command::new("cmd").arg(cmd_string).status();
+				let exec_result2 = Command::new("cmd")
+					.current_dir(work_dir)
+					.arg(cmd_string)
+					.status();
 
 				match exec_result2 {
 					// failed to start (unlikely as cmd would have to be missing)


### PR DESCRIPTION
This Pull Request fixes/closes #1316

if command launch on windows fails then retry doing

    cmd /C <editor> <file name>

verified that it fixed vim (original bug) plus code (added by commenter)

it is arguable that the rust core code should do this, they get close but are not quite there

I followed the checklist:
- [ ] I added unittests
- [x ] I ran `make check` without errors
- [ x] I tested the overall application
- [ ] I added an appropriate item to the changelog