### PR TITLE
make XDG_XXX_HOME work for Windows

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -145,9 +145,9 @@ fn get_app_cache_path() -> Result<PathBuf> {
 		env::var("XDG_CACHE_HOME")
 			.ok()
 			.map(PathBuf::from)
-			.or_else(|| dirs_next::config_dir())
+			.or_else(|| dirs_next::cache_dir())
 	} else {
-		dirs_next::config_dir()
+		dirs_next::cache_dir()
 	}
 	.ok_or_else(|| anyhow!("failed to find os cache dir."))?;
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -145,7 +145,7 @@ fn get_app_cache_path() -> Result<PathBuf> {
 		env::var("XDG_CACHE_HOME")
 			.ok()
 			.map(PathBuf::from)
-			.or_else(|| dirs_next::cache_dir())
+			.or_else(dirs_next::cache_dir)
 	} else {
 		dirs_next::cache_dir()
 	}
@@ -159,15 +159,13 @@ fn get_app_cache_path() -> Result<PathBuf> {
 pub fn get_app_config_path() -> Result<PathBuf> {
 	let mut path = if cfg!(target_os = "macos") {
 		dirs_next::home_dir().map(|h| h.join(".config"))
+	} else if cfg!(windows) {
+		env::var("XDG_CONFIG_HOME")
+			.ok()
+			.map(PathBuf::from)
+			.or_else(dirs_next::config_dir)
 	} else {
-		if cfg!(windows) {
-			env::var("XDG_CONFIG_HOME")
-				.ok()
-				.map(PathBuf::from)
-				.or_else(|| dirs_next::config_dir())
-		} else {
-			dirs_next::config_dir()
-		}
+		dirs_next::config_dir()
 	}
 	.ok_or_else(|| anyhow!("failed to find os config dir."))?;
 


### PR DESCRIPTION
This Pull Request fixes/closes #1498.

- If XDG_CONFIG_HOME is set on Windows then use it instead of what `dirs_next` says
- if XDG_CACHE_HOME is set on Windows then use it instead of what `dirs_next` says

Note that `dirs_next` already honors XDG_XXX_HOME on Linux

It is arguable that not doing this for Mac is odd, but that not whats asked for in the bug.

I followed the checklist:
- [ ] I added unittests
- [ x] I ran `make check` without errors
- [ x] I tested the overall application
- [ ] I added an appropriate item to the changelog