### PR TITLE
Simplify theme overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 * `focus_XYZ` key bindings are merged into the `move_XYZ` set, so only one way to bind arrow-like keys from now on ([#1539](https://github.com/extrawurst/gitui/issues/1539))
+* The format of `theme.ron` has changed
 
 ### Added
 * allow reset (soft,mixed,hard) from commit log ([#1500](https://github.com/extrawurst/gitui/issues/1500))
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * allow `copy` file path on revision files and status tree [[@yanganto]](https://github.com/yanganto)  ([#1516](https://github.com/extrawurst/gitui/pull/1516))
 * print message of where log will be written if `-l` is set ([#1472](https://github.com/extrawurst/gitui/pull/1472))
 * show remote branches in log [[@cruessler](https://github.com/cruessler)] ([#1501](https://github.com/extrawurst/gitui/issues/1501))
+* simplify theme overrides [[@cruessler](https://github.com/cruessler)] ([#1367](https://github.com/extrawurst/gitui/issues/1367))
 
 ### Fixes
 * fixed side effect of crossterm 0.26 on windows that caused double input of all keys [[@pm100]](https://github/pm100) ([#1686](https://github.com/extrawurst/gitui/pull/1686))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 * `focus_XYZ` key bindings are merged into the `move_XYZ` set, so only one way to bind arrow-like keys from now on ([#1539](https://github.com/extrawurst/gitui/issues/1539))
-* The format of `theme.ron` has changed
+* Do you use a custom theme?
+
+  The way themes work got changed and simplified ([see docs](https://github.com/extrawurst/gitui/blob/master/THEMES.md) for more info):
+
+  * The format of `theme.ron` has changed: you only specify the colors etc. that should differ from their default value
+  * Future additions of colors etc. will not break existing themes anymore
 
 ### Added
 * allow reset (soft,mixed,hard) from commit log ([#1500](https://github.com/extrawurst/gitui/issues/1500))

--- a/THEMES.md
+++ b/THEMES.md
@@ -3,15 +3,27 @@
 default on light terminal:
 ![](assets/light-theme.png)
 
-to change the colors of the default theme you have to modify `theme.ron` file
-[Ron format](https://github.com/ron-rs/ron) located at config path. The path differs depending on the operating system:
+To change the colors of the default theme you need to add a `theme.ron` file that contains the colors you want to override. Note that you don’t have to specify the full theme anymore (as of 0.23). Instead, it is sufficient to override just the values that you want to differ from their default values.
+
+The file uses the [Ron format](https://github.com/ron-rs/ron) and is located at one of the following paths, depending on your operating system:
 
 * `$HOME/.config/gitui/theme.ron` (mac)
 * `$XDG_CONFIG_HOME/gitui/theme.ron` (linux using XDG)
 * `$HOME/.config/gitui/theme.ron` (linux)
 * `%APPDATA%/gitui/theme.ron` (Windows)
 
-Alternatively you may make a theme in the same directory mentioned above with and select with the `-t` flag followed by the name of the file in the directory. E.g. If you are on linux calling `gitui -t arc.ron` wil use `$XDG_CONFIG_HOME/gitui/arc.ron` or `$HOME/.config/gitui/arc.ron`
+Alternatively, you can create a theme in the same directory mentioned above and use it with the `-t` flag followed by the name of the file in the directory. E.g. If you are on linux calling `gitui -t arc.ron`, this will load the theme in `$XDG_CONFIG_HOME/gitui/arc.ron` or `$HOME/.config/gitui/arc.ron`.
+
+Example theme override:
+
+```
+(
+    selection_bg: Some(Blue),
+    selection_fg: Some(White),
+)
+```
+
+Note that you need to wrap values in `Some` due to the way the overrides work (as of 0.23).
 
 Notes:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,9 +138,7 @@ fn main() -> Result<()> {
 	let key_config = KeyConfig::init()
 		.map_err(|e| eprintln!("KeyConfig loading error: {e}"))
 		.unwrap_or_default();
-	let theme = Theme::init(&cliargs.theme)
-		.map_err(|e| eprintln!("Theme loading error: {e}"))
-		.unwrap_or_default();
+	let theme = Theme::init(&cliargs.theme);
 
 	setup_terminal()?;
 	defer! {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -319,5 +319,6 @@ mod tests {
 
 		assert_eq!(theme.selection_fg, Theme::default().selection_fg);
 		assert_eq!(theme.selection_bg, Color::White);
+		assert_ne!(theme.selection_bg, Theme::default().selection_bg);
 	}
 }


### PR DESCRIPTION
This Pull Request closes #1367.

It changes the following:

Theme overrides are now loaded the same way key overrides are loaded. The config file, `theme.ron`, does not have to contain a complete theme anymore. Instead, it is possible to specify only the values that are supposed to override their corresponding default values.

This PR is marked as draft because this change is breaking, and their is no automatic migration for existing configs. If that’s ok, I would extend the `Breaking Changes` entry, otherwise I would add code to migrate existing themes.

Update 2023-06-25: I added code for migrating existing themes to the new format.

I followed the checklist:

- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog
