### PR TITLE
Make .bat and .cmd editors work on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "89511277159354bea13ae1e53e0c9ab85ba1b20d7e91618fa30e6bc5566857fb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1019,9 +1019,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.15.0+1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "032e537ae4dd4e50c877f258dc55fcd0657b5021f454094a425bb6bcc9edea4c"
 dependencies = [
  "cc",
  "libc",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -383,7 +383,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -784,6 +784,7 @@ dependencies = [
  "scopeguard",
  "scopetime",
  "serde",
+ "serial_test",
  "simplelog",
  "struct-patch",
  "syntect",
@@ -1402,7 +1403,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1425,9 +1426,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -1443,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1590,7 +1591,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1606,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
 dependencies = [
  "dashmap",
  "futures",
@@ -1620,13 +1621,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1753,7 +1754,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1784,6 +1785,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,7 +1884,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2059,7 +2071,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2081,7 +2093,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,16 +56,15 @@ unicode-truncate = "0.2"
 unicode-width = "0.1"
 which = "4.4"
 
-
 # pprof is not available on windows
 [target.'cfg(not(windows))'.dependencies]
 pprof = { version = "0.11", features = ["flamegraph"], optional = true }
 
 [dev-dependencies]
+asyncgit = { path = "asyncgit", features = ["test_utils"] }
 pretty_assertions = "1.3"
-tempfile = "3.4"
-asyncgit = {path = "asyncgit", features = ["test_utils"]}
 serial_test = "2.0.0"
+tempfile = "3.4"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,3 @@ codegen-units = 1
 [profile.dev.package."tui"]
 opt-level = 3
 
-#[patch.crates-io]
-#num_cpus = { git = 'https://github.com/seanmonstar/num_cpus.git' }
-#notify = { git = 'https://github.com/notify-rs/notify.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ unicode-truncate = "0.2"
 unicode-width = "0.1"
 which = "4.4"
 
+
 # pprof is not available on windows
 [target.'cfg(not(windows))'.dependencies]
 pprof = { version = "0.11", features = ["flamegraph"], optional = true }
@@ -63,6 +64,8 @@ pprof = { version = "0.11", features = ["flamegraph"], optional = true }
 [dev-dependencies]
 pretty_assertions = "1.3"
 tempfile = "3.4"
+asyncgit = {path = "asyncgit", features = ["test_utils"]}
+serial_test = "2.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -94,3 +97,7 @@ codegen-units = 1
 # makes their debug profile slow
 [profile.dev.package."tui"]
 opt-level = 3
+
+#[patch.crates-io]
+#num_cpus = { git = 'https://github.com/seanmonstar/num_cpus.git' }
+#notify = { git = 'https://github.com/notify-rs/notify.git' }

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["git"]
 [dependencies]
 crossbeam-channel = "0.5"
 easy-cast = "0.5"
-git2 = "0.16"
+git2 = "0.17"
 log = "0.4"
 # git2 = { path = "../../extern/git2-rs", features = ["vendored-openssl"]}
 # git2 = { git="https://github.com/extrawurst/git2-rs.git", rev="fc13dcc", features = ["vendored-openssl"]}

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["git"]
 [dependencies]
 crossbeam-channel = "0.5"
 easy-cast = "0.5"
+env_logger = "0.10"
 git2 = "0.17"
 log = "0.4"
 # git2 = { path = "../../extern/git2-rs", features = ["vendored-openssl"]}
@@ -24,17 +25,15 @@ rayon-core = "1.11"
 scopetime = { path = "../scopetime", version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.1"
+tempfile = "3.4"
 thiserror = "1.0"
 unicode-truncate = "0.2.0"
 url = "2.3"
-tempfile = "3.4"
-env_logger = "0.10"
 
 [dev-dependencies]
 invalidstring = { path = "../invalidstring", version = "0.1" }
 pretty_assertions = "1.3"
 serial_test = "2.0.0"
-
 
 [features]
 default = ["trace-libgit"]

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -27,15 +27,17 @@ shellexpand = "3.0"
 thiserror = "1.0"
 unicode-truncate = "0.2.0"
 url = "2.3"
+tempfile = "3.4"
+env_logger = "0.10"
 
 [dev-dependencies]
-env_logger = "0.10"
 invalidstring = { path = "../invalidstring", version = "0.1" }
 pretty_assertions = "1.3"
-serial_test = "1.0"
-tempfile = "3.4"
+serial_test = "2.0.0"
+
 
 [features]
 default = ["trace-libgit"]
 trace-libgit = []
 vendor-openssl = ["openssl-sys"]
+test_utils =[]

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -23,7 +23,8 @@
 // #![deny(clippy::expect_used)]
 //TODO: consider cleaning some up and allow specific places
 #![allow(clippy::significant_drop_tightening)]
-#![allow(clippy::multiple_crate_versions)]
+
+//#![allow(clippy::multiple_crate_versions)]
 
 pub mod asyncjob;
 mod blame;

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -23,8 +23,7 @@
 // #![deny(clippy::expect_used)]
 //TODO: consider cleaning some up and allow specific places
 #![allow(clippy::significant_drop_tightening)]
-
-//#![allow(clippy::multiple_crate_versions)]
+#![allow(clippy::multiple_crate_versions)]
 
 pub mod asyncjob;
 mod blame;

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -23,6 +23,7 @@
 // #![deny(clippy::expect_used)]
 //TODO: consider cleaning some up and allow specific places
 #![allow(clippy::significant_drop_tightening)]
+#![allow(clippy::multiple_crate_versions)]
 
 pub mod asyncjob;
 mod blame;

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -100,8 +100,11 @@ pub use utils::{
 
 pub use git2::ResetType;
 
-#[cfg(test)]
-mod tests {
+#[cfg(feature = "test_utils")]
+/// test utilities - exported now
+/// see https://github.com/rust-lang/cargo/issues/8379
+///
+pub mod tests {
 	use super::{
 		commit,
 		repository::repo,

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -102,9 +102,16 @@ pub use git2::ResetType;
 
 #[cfg(feature = "test_utils")]
 /// test utilities - exported now
-/// see https://github.com/rust-lang/cargo/issues/8379
-///
+// see https://github.com/rust-lang/cargo/issues/8379
 pub mod tests {
+	// these are now not under 'test' so they get clippied with 'all-features'
+	// we dont care about tests that panic
+	#![allow(clippy::unwrap_used, clippy::missing_panics_doc)]
+	// minor niggles
+	#![allow(clippy::nursery)]
+	// this clippy is confused by the name 'read'
+	// should probably be changed to read_into
+	#![allow(clippy::read_zero_byte_vec)]
 	use super::{
 		commit,
 		repository::repo,

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -288,7 +288,7 @@ pub mod tests {
 
 	// init log
 	fn init_log() {
-		let _ = env_logger::builder()
+		let _b = env_logger::builder()
 			.is_test(true)
 			.filter_level(log::LevelFilter::Trace)
 			.try_init();

--- a/deny.toml
+++ b/deny.toml
@@ -22,5 +22,6 @@ version = "1.0.3"
 multiple-versions = "deny"
 skip-tree = [
     { name = "windows-sys" },
-    { name = "hermit-abi" }
+    { name = "hermit-abi" },
+    { name = "syn" }
 ]

--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -122,8 +122,10 @@ impl ExternalEditorComponent {
 			if exec_result.is_err() {
 				let cmd_string =
 					format!("/C {} {}", command, path.display());
-				let exec_result2 =
-					Command::new("cmd").arg(cmd_string).status();
+				let exec_result2 = Command::new("cmd")
+					.current_dir(work_dir)
+					.arg(cmd_string)
+					.status();
 
 				match exec_result2 {
 					// failed to start (unlikely as cmd would have to be missing)

--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -64,9 +64,12 @@ impl ExternalEditorComponent {
 			bail!("file not found: {:?}", path);
 		}
 
-		io::stdout().execute(LeaveAlternateScreen)?;
-		defer! {
-			io::stdout().execute(EnterAlternateScreen).expect("reset terminal");
+		// so that the output is not messed up when running tests
+		if cfg!(not(test)) {
+			io::stdout().execute(LeaveAlternateScreen)?;
+			defer! {
+				io::stdout().execute(EnterAlternateScreen).expect("reset terminal");
+			}
 		}
 
 		let environment_options = ["GIT_EDITOR", "VISUAL", "EDITOR"];
@@ -80,6 +83,7 @@ impl ExternalEditorComponent {
 			.or_else(|| env::var(environment_options[2]).ok())
 			.unwrap_or_else(|| String::from("vi"));
 
+		log::trace!("external editor:{}", editor);
 		// TODO: proper handling arguments containing whitespaces
 		// This does not do the right thing if the input is `editor --something "with spaces"`
 
@@ -112,19 +116,29 @@ impl ExternalEditorComponent {
 
 		args.push(path.as_os_str());
 
-		let exec_result = Command::new(command.clone())
-			.current_dir(work_dir.clone())
-			.args(args)
+		let exec_result = Command::new(&command)
+			.current_dir(&work_dir)
+			.args(&args)
 			.status();
 
 		if cfg!(windows) {
 			// if command failed to run on windows retry as a batch file (.bat, .cmd,...)
 			if exec_result.is_err() {
-				let cmd_string =
-					format!("/C {} {}", command, path.display());
+				/*  here args contains the arguments pulled from the configured editor string
+					"myeditor --color blue" ->
+						args[0] = "--color"
+						args[1] = "blue"
+
+					now insert before these
+						"/C"
+						"myeditor"
+				*/
+
+				args.insert(0, OsStr::new("/C"));
+				args.insert(1, OsStr::new(&command));
 				let exec_result2 = Command::new("cmd")
 					.current_dir(work_dir)
-					.arg(cmd_string)
+					.args(args)
 					.status();
 
 				match exec_result2 {
@@ -222,5 +236,182 @@ impl Component for ExternalEditorComponent {
 		self.visible = true;
 
 		Ok(())
+	}
+}
+#[cfg(test)]
+mod tests {
+
+	use crate::components::ExternalEditorComponent;
+	use anyhow::Result;
+	use asyncgit::sync::tests::repo_init;
+	use asyncgit::sync::utils::read_file;
+	use asyncgit::sync::RepoPath;
+	use serial_test::serial;
+	use std::env;
+	use std::fs::File;
+	use std::io::*;
+	use tempfile::TempDir;
+
+	fn write_temp_file(
+		td: &TempDir,
+		file: &str,
+		content: &str,
+	) -> Result<()> {
+		let binding = td.path().join(file);
+		let file_path = binding.to_str().unwrap();
+		let mut file = File::create(file_path)?;
+		file.write_all(content.as_bytes())?;
+		Ok(())
+	}
+	const TEST_FILE_NAME: &str = "test1.txt";
+	const TEST_FILE_DATA: &str = "test file data";
+
+	fn setup_repo() -> (TempDir, RepoPath) {
+		let (td, repo) = repo_init().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: RepoPath =
+			root.as_os_str().to_str().unwrap().into();
+
+		// create a dummy file to operate on
+		let txt = String::from(TEST_FILE_DATA);
+		write_temp_file(&td, TEST_FILE_NAME, &txt).unwrap();
+		(td, repo_path)
+	}
+
+	// these have to de serialzied because they set env variables to control which editor to use
+
+	#[test]
+	#[serial]
+	fn editor_missing() {
+		let (td, repo_path) = setup_repo();
+		let target_file_path = td.path().join(TEST_FILE_NAME);
+		env::set_var("GIT_EDITOR", "i_doubt_this_exists");
+		let foo = ExternalEditorComponent::open_file_in_editor(
+			&repo_path,
+			&target_file_path,
+		);
+		assert!(foo.is_err());
+	}
+
+	#[cfg(windows)]
+	mod win_test {
+		use super::*;
+		#[test]
+		#[serial]
+		fn editor_is_bat() {
+			let (td, repo_path) = setup_repo();
+			let target_file_path = td.path().join(TEST_FILE_NAME);
+			env::set_var("GIT_EDITOR", "testbat");
+			let bat = String::from("@echo off\ntype %1 >made.txt");
+			write_temp_file(&td, "testbat.bat", &bat).unwrap();
+
+			let runit = ExternalEditorComponent::open_file_in_editor(
+				&repo_path,
+				&target_file_path,
+			);
+			assert!(runit.is_ok());
+
+			let echo_file = td.path().join("made.txt");
+			let read_text = read_file(echo_file.as_path()).unwrap();
+
+			assert_eq!(
+				read_text.lines().next(),
+				Some(TEST_FILE_DATA)
+			);
+		}
+		#[test]
+		#[serial]
+		fn editor_is_bat_ext() {
+			let (td, repo_path) = setup_repo();
+			let target_file_path = td.path().join(TEST_FILE_NAME);
+
+			env::set_var("GIT_EDITOR", "testbat.bat");
+
+			let bat = String::from("@echo off\ntype %1 >made.txt");
+			write_temp_file(&td, "testbat.bat", &bat).unwrap();
+
+			let runit = ExternalEditorComponent::open_file_in_editor(
+				&repo_path,
+				&target_file_path,
+			);
+			assert!(runit.is_ok());
+
+			let echo_file = td.path().join("made.txt");
+			let read_text = read_file(echo_file.as_path()).unwrap();
+			assert_eq!(
+				read_text.lines().next(),
+				Some(TEST_FILE_DATA)
+			);
+		}
+		#[test]
+		#[serial]
+		fn editor_is_bat_noext_arg() {
+			let (td, repo_path) = setup_repo();
+			let target_file_path = td.path().join(TEST_FILE_NAME);
+
+			env::set_var("GIT_EDITOR", "testbat --foo");
+
+			let bat = String::from("@echo off\ntype %2 >made.txt");
+			write_temp_file(&td, "testbat.bat", &bat).unwrap();
+
+			let runit = ExternalEditorComponent::open_file_in_editor(
+				&repo_path,
+				&target_file_path,
+			);
+			assert!(runit.is_ok());
+
+			let echo_file = td.path().join("made.txt");
+			let read_text = read_file(echo_file.as_path()).unwrap();
+			assert_eq!(
+				read_text.lines().next(),
+				Some(TEST_FILE_DATA)
+			);
+		}
+		#[test]
+		#[serial]
+		fn editor_is_cmd() {
+			let (td, repo_path) = setup_repo();
+			let target_file_path = td.path().join(TEST_FILE_NAME);
+			env::set_var("GIT_EDITOR", "testcmd");
+			let bat = String::from("@echo off\ntype %1 >made.txt");
+			write_temp_file(&td, "testcmd.cmd", &bat).unwrap();
+
+			let runit = ExternalEditorComponent::open_file_in_editor(
+				&repo_path,
+				&target_file_path,
+			);
+			assert!(runit.is_ok());
+
+			let echo_file = td.path().join("made.txt");
+			let read_text = read_file(echo_file.as_path()).unwrap();
+
+			assert_eq!(
+				read_text.lines().next(),
+				Some(TEST_FILE_DATA)
+			);
+		}
+		#[test]
+		#[serial]
+		fn editor_is_cmd_arg() {
+			let (td, repo_path) = setup_repo();
+			let target_file_path = td.path().join(TEST_FILE_NAME);
+			env::set_var("GIT_EDITOR", "testcmd --bar");
+			let bat = String::from("@echo off\ntype %2 >made.txt");
+			write_temp_file(&td, "testcmd.cmd", &bat).unwrap();
+
+			let runit = ExternalEditorComponent::open_file_in_editor(
+				&repo_path,
+				&target_file_path,
+			);
+			assert!(runit.is_ok());
+
+			let echo_file = td.path().join("made.txt");
+			let read_text = read_file(echo_file.as_path()).unwrap();
+
+			assert_eq!(
+				read_text.lines().next(),
+				Some(TEST_FILE_DATA)
+			);
+		}
 	}
 }

--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -240,16 +240,16 @@ impl Component for ExternalEditorComponent {
 }
 #[cfg(test)]
 mod tests {
-
 	use crate::components::ExternalEditorComponent;
 	use anyhow::Result;
 	use asyncgit::sync::tests::repo_init;
+	#[cfg(windows)]
 	use asyncgit::sync::utils::read_file;
 	use asyncgit::sync::RepoPath;
 	use serial_test::serial;
 	use std::env;
 	use std::fs::File;
-	use std::io::*;
+	use std::io::Write;
 	use tempfile::TempDir;
 
 	fn write_temp_file(


### PR DESCRIPTION
This Pull Request fixes/closes #1316.

This has several parts
- first it adds code to enable .bat and .cmd commands to be invoked without the .bat or .cmd being given (core.editor='vim' will now run vim.bat)
- it then adds unit tests
- it also reorganized some code used for testing in asyncgit so that it can be used in the main, gitui, product

The actual fix is fairly straightforward.
- if on windows and the configured editor fails to launch then retry
- retry using `cmd /C <editor> <file>`
- if that fails to start or cmd reports an error then report that to the user

The reorg needs an explanation
- open_file_in_editor need a repo. 
- there is test plumbing in asyncgit that provides many repo utilities
- sadly things declared 'test' are not available in other products / subcrates. But there is a solution. see https://github.com/rust-lang/cargo/issues/8379. It involves creating a test-utils feature and making that a dev dependency.
- That now makes that test plumbing in asyncgit/sync/mod.rs no longer hidden under a test umbrella. The exhaustive cliuppy, lints, cargo-sort etc now picks up all sorts of issues there (that really dont matter) so now I had to add in a few things to stop those being picked up. Note that they are still only being compiled when doing tests, its just that clippy 'all-features' doesnt realize that

I also note that there are no other external editor test cases. I will add more once I get this in (I willl look at #1654 and put them in the fix for that). I did add one generic test, but there should be more 


I followed the checklist:
- [ x] I added unittests
- [x ] I ran `make check` without errors
- [x ] I tested the overall application
- [ ] I added an appropriate item to the changelog