### PR TITLE
Default to tick-based updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * commit hooks report "command not found" on Windows with wsl2 installed ([#1528](https://github.com/extrawurst/gitui/issues/1528))
 * crashes on entering submodules ([#1510](https://github.com/extrawurst/gitui/issues/1510))
 * fix race issue: revlog messages sometimes appear empty ([#1473](https://github.com/extrawurst/gitui/issues/1473))
+* default to tick-based updates [[@cruessler](https://github.com/cruessler)] ([#1444](https://github.com/extrawurst/gitui/issues/1444))
 
 ### Changed
 * minimum supported rust version bumped to 1.64 (thank you `clap`)

--- a/FAQ.md
+++ b/FAQ.md
@@ -18,3 +18,8 @@ Note that in some cases adding the line `ssh-add -K ~/.ssh/id_ed25519`(or whatev
 
 If you want to use `vi`-style keys or customize your key bindings in any other fassion see the specific docs on that: [key config](./KEY_CONFIG.md)
 
+## 3. <a name="watcher"></a> Watching for changes <small><sup>[Top ▲](#table-of-contents)</sup></small>
+
+By default, `gitui` polls for changes in the working directory every 5 seconds. If you supply `--watcher` as an argument, it uses a `notify`-based approach instead. This is usually faster and was for some time the default update strategy. It turned out, however, that `notify`-based updates can cause issues on some platforms, so tick-based updates seemed like a safer default.
+
+See #1444 for details.

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,7 @@ use std::{
 pub struct CliArgs {
 	pub theme: PathBuf,
 	pub repo_path: RepoPath,
+	pub notify_watcher: bool,
 	pub poll_watcher: bool,
 }
 
@@ -54,11 +55,14 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		get_app_config_path()?.join("theme.ron")
 	};
 
+	let notify_watcher: bool =
+		*arg_matches.get_one("watcher").unwrap_or(&false);
 	let arg_poll: bool =
 		*arg_matches.get_one("poll").unwrap_or(&false);
 
 	Ok(CliArgs {
 		theme,
+		notify_watcher,
 		poll_watcher: arg_poll,
 		repo_path,
 	})
@@ -94,6 +98,12 @@ fn app() -> ClapApp {
 				.short('l')
 				.long("logging")
 				.num_args(0),
+		)
+		.arg(
+			Arg::new("watcher")
+				.help("Use notify-based file system watcher instead of tick-based update. This is more performant, but can cause issues in larger repositories")
+				.long("watcher")
+				.action(clap::ArgAction::SetTrue),
 		)
 		.arg(
 			Arg::new("poll")

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,7 +16,6 @@ pub struct CliArgs {
 	pub theme: PathBuf,
 	pub repo_path: RepoPath,
 	pub notify_watcher: bool,
-	pub poll_watcher: bool,
 }
 
 pub fn process_cmdline() -> Result<CliArgs> {
@@ -57,14 +56,11 @@ pub fn process_cmdline() -> Result<CliArgs> {
 
 	let notify_watcher: bool =
 		*arg_matches.get_one("watcher").unwrap_or(&false);
-	let arg_poll: bool =
-		*arg_matches.get_one("poll").unwrap_or(&false);
 
 	Ok(CliArgs {
 		theme,
-		notify_watcher,
-		poll_watcher: arg_poll,
 		repo_path,
+		notify_watcher,
 	})
 }
 
@@ -103,12 +99,6 @@ fn app() -> ClapApp {
 			Arg::new("watcher")
 				.help("Use notify-based file system watcher instead of tick-based update. This is more performant, but can cause issues on some platforms. See https://github.com/extrawurst/gitui/blob/master/FAQ.md#watcher for details.")
 				.long("watcher")
-				.action(clap::ArgAction::SetTrue),
-		)
-		.arg(
-			Arg::new("poll")
-				.help("Poll folder for changes instead of using file system events. This can be useful if you run into issues with maximum # of file descriptors")
-				.long("polling")
 				.action(clap::ArgAction::SetTrue),
 		)
 		.arg(

--- a/src/args.rs
+++ b/src/args.rs
@@ -101,7 +101,7 @@ fn app() -> ClapApp {
 		)
 		.arg(
 			Arg::new("watcher")
-				.help("Use notify-based file system watcher instead of tick-based update. This is more performant, but can cause issues in larger repositories")
+				.help("Use notify-based file system watcher instead of tick-based update. This is more performant, but can cause issues on some platforms. See https://github.com/extrawurst/gitui/blob/master/FAQ.md#watcher for details.")
 				.long("watcher")
 				.action(clap::ArgAction::SetTrue),
 		)

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ use asyncgit::{
 	AsyncGitNotification,
 };
 use backtrace::Backtrace;
-use crossbeam_channel::{tick, unbounded, Receiver, Select};
+use crossbeam_channel::{never, tick, unbounded, Receiver, Select};
 use crossterm::{
 	terminal::{
 		disable_raw_mode, enable_raw_mode, EnterAlternateScreen,
@@ -83,11 +83,13 @@ use tui::{
 use ui::style::Theme;
 use watcher::RepoWatcher;
 
+static TICK_INTERVAL: Duration = Duration::from_secs(5);
 static SPINNER_INTERVAL: Duration = Duration::from_millis(80);
 
 ///
 #[derive(Clone)]
 pub enum QueueEvent {
+	Tick,
 	Notify,
 	SpinnerUpdate,
 	AsyncEvent(AsyncNotification),
@@ -112,6 +114,13 @@ pub enum AsyncNotification {
 	App(AsyncAppNotification),
 	///
 	Git(AsyncGitNotification),
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Updater {
+	Ticker,
+	PollWatcher,
+	NotifyWatcher,
 }
 
 fn main() -> Result<()> {
@@ -145,6 +154,13 @@ fn main() -> Result<()> {
 	let mut repo_path = cliargs.repo_path;
 	let input = Input::new();
 
+	let updater = match (cliargs.notify_watcher, cliargs.poll_watcher)
+	{
+		(true, true) => Updater::PollWatcher,
+		(true, false) => Updater::NotifyWatcher,
+		_ => Updater::Ticker,
+	};
+
 	loop {
 		let quit_state = run_app(
 			app_start,
@@ -152,7 +168,7 @@ fn main() -> Result<()> {
 			theme,
 			key_config.clone(),
 			&input,
-			cliargs.poll_watcher,
+			updater,
 			&mut terminal,
 		)?;
 
@@ -173,18 +189,27 @@ fn run_app(
 	theme: Theme,
 	key_config: KeyConfig,
 	input: &Input,
-	poll_watcher: bool,
+	updater: Updater,
 	terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) -> Result<QuitState, anyhow::Error> {
 	let (tx_git, rx_git) = unbounded();
 	let (tx_app, rx_app) = unbounded();
 
 	let rx_input = input.receiver();
-	let watcher = RepoWatcher::new(
-		repo_work_dir(&repo)?.as_str(),
-		poll_watcher,
-	);
-	let rx_watcher = watcher.receiver();
+
+	let (rx_ticker, rx_watcher) = match updater {
+		Updater::NotifyWatcher | Updater::PollWatcher => {
+			let poll_watcher = updater == Updater::PollWatcher;
+			let repo_watcher = RepoWatcher::new(
+				repo_work_dir(&repo)?.as_str(),
+				poll_watcher,
+			);
+
+			(never(), repo_watcher.receiver())
+		}
+		Updater::Ticker => (tick(TICK_INTERVAL), never()),
+	};
+
 	let spinner_ticker = tick(SPINNER_INTERVAL);
 
 	let mut app = App::new(
@@ -210,6 +235,7 @@ fn run_app(
 				&rx_input,
 				&rx_git,
 				&rx_app,
+				&rx_ticker,
 				&rx_watcher,
 				&spinner_ticker,
 			)?
@@ -235,7 +261,9 @@ fn run_app(
 					}
 					app.event(ev)?;
 				}
-				QueueEvent::Notify => app.update()?,
+				QueueEvent::Tick | QueueEvent::Notify => {
+					app.update()?;
+				}
 				QueueEvent::AsyncEvent(ev) => {
 					if !matches!(
 						ev,
@@ -309,6 +337,7 @@ fn select_event(
 	rx_input: &Receiver<InputEvent>,
 	rx_git: &Receiver<AsyncGitNotification>,
 	rx_app: &Receiver<AsyncAppNotification>,
+	rx_ticker: &Receiver<Instant>,
 	rx_notify: &Receiver<()>,
 	rx_spinner: &Receiver<Instant>,
 ) -> Result<QueueEvent> {
@@ -317,6 +346,7 @@ fn select_event(
 	sel.recv(rx_input);
 	sel.recv(rx_git);
 	sel.recv(rx_app);
+	sel.recv(rx_ticker);
 	sel.recv(rx_notify);
 	sel.recv(rx_spinner);
 
@@ -331,8 +361,9 @@ fn select_event(
 		2 => oper.recv(rx_app).map(|e| {
 			QueueEvent::AsyncEvent(AsyncNotification::App(e))
 		}),
-		3 => oper.recv(rx_notify).map(|_| QueueEvent::Notify),
-		4 => oper.recv(rx_spinner).map(|_| QueueEvent::SpinnerUpdate),
+		3 => oper.recv(rx_ticker).map(|_| QueueEvent::Notify),
+		4 => oper.recv(rx_notify).map(|_| QueueEvent::Notify),
+		5 => oper.recv(rx_spinner).map(|_| QueueEvent::SpinnerUpdate),
 		_ => bail!("unknown select source"),
 	}?;
 


### PR DESCRIPTION
This Pull Request fixes/closes #1444.

It changes the following:

- This commit reintroduces code that was previously removed in favor of a notify-based update trigger. It turned out that notify-based updates can cause issues in larger repositories, so tick-based updates seemed like a safer default.

PR that introduced the notify-based watcher: https://github.com/extrawurst/gitui/pull/1310

I followed the checklist:

- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog
