### PR TITLE
fix double key input on windows due to crossterm 0.26

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,7 @@
 use crate::notify_mutex::NotifyableMutex;
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver, Sender};
-use crossterm::event::{self, Event};
+use crossterm::event::{self, Event, Event::Key, KeyEventKind};
 use std::{
 	sync::{
 		atomic::{AtomicBool, Ordering},
@@ -113,6 +113,12 @@ impl Input {
 				arc_current.store(true, Ordering::Relaxed);
 
 				if let Some(e) = Self::poll(POLL_DURATION)? {
+					// windows send key release too, only process key press
+					if let Key(key) = e {
+						if key.kind != KeyEventKind::Press {
+							continue;
+						}
+					}
 					tx.send(InputEvent::Input(e))?;
 				}
 			} else {


### PR DESCRIPTION
crossterm 0.26 adds key release event on windows, this causes all key inputs to be duplicated in apps that dont explciitly look at the key event type

It changes the following:
- in input.rs is not key press then skip input


I followed the checklist:
- [ ] I added unittests
- [ x] I ran `make check` without errors
- [ x] I tested the overall application
- [ ] I added an appropriate item to the changelog