### PR TITLE
fixed wrong fuzzy-find highlight in long str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * fix commit dialog char count for multibyte characters ([#1726](https://github.com/extrawurst/gitui/issues/1726))
+* fix wrong hit highlighting in fuzzy find popup [[@UUGTech](https://github.com/UUGTech)] ([#1731](https://github.com/extrawurst/gitui/pull/1731))
 
 ## [0.23.0] - 2022-06-19
 

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -237,31 +237,35 @@ impl DrawableComponent for FuzzyFindPopup {
 				let height = usize::from(chunks[1].height);
 				let width = usize::from(chunks[1].width);
 
-				let items = self.filtered.iter().take(height).map(
-					|(idx, indicies)| {
-						let selected = self
-							.selected_index
-							.map_or(false, |index| index == *idx);
-						let full_text = trim_length_left(
-							&self.contents[*idx],
-							width,
-						);
-						Line::from(
-							full_text
-								.char_indices()
-								.map(|(c_idx, c)| {
-									Span::styled(
+				let items =
+					self.filtered.iter().take(height).map(
+						|(idx, indicies)| {
+							let selected = self
+								.selected_index
+								.map_or(false, |index| index == *idx);
+							let full_text = trim_length_left(
+								&self.contents[*idx],
+								width,
+							);
+							let trim_length = self.contents[*idx]
+								.len() - full_text
+								.len();
+							Line::from(
+								full_text
+									.char_indices()
+									.map(|(c_idx, c)| {
+										Span::styled(
 										Cow::from(c.to_string()),
 										self.theme.text(
 											selected,
-											indicies.contains(&c_idx),
+											indicies.contains(&(c_idx + trim_length)),
 										),
 									)
-								})
-								.collect::<Vec<_>>(),
-						)
-					},
-				);
+									})
+									.collect::<Vec<_>>(),
+							)
+						},
+					);
 
 				ui::draw_list_block(
 					f,

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -21,6 +21,7 @@ use ratatui::{
 	Frame,
 };
 use std::borrow::Cow;
+use unicode_segmentation::UnicodeSegmentation;
 
 pub struct FuzzyFindPopup {
 	queue: Queue,
@@ -248,19 +249,22 @@ impl DrawableComponent for FuzzyFindPopup {
 								width,
 							);
 							let trim_length = self.contents[*idx]
-								.len() - full_text
-								.len();
+								.graphemes(true)
+								.count() - full_text
+								.graphemes(true)
+								.count();
 							Line::from(
 								full_text
-									.char_indices()
+									.graphemes(true)
+									.enumerate()
 									.map(|(c_idx, c)| {
 										Span::styled(
-										Cow::from(c.to_string()),
-										self.theme.text(
-											selected,
-											indicies.contains(&(c_idx + trim_length)),
-										),
-									)
+											Cow::from(c.to_string()),
+											self.theme.text(
+												selected,
+												indicies.contains(&(c_idx + trim_length)),
+											),
+										)
 									})
 									.collect::<Vec<_>>(),
 							)


### PR DESCRIPTION
Sorry.
When I tried to implement fuzzy_find in other content, I found a bug in fuzzy_find_popup.rs.

### The hit highlighting is wrong in long strings due to the effect of trimming.

Before Fix
![スクリーンショット 2023-06-22 22 23 14](https://github.com/extrawurst/gitui/assets/55311933/d3022c5a-3da7-47b0-bd09-2418ef5850a5)

After Fix
![スクリーンショット 2023-06-22 22 14 01](https://github.com/extrawurst/gitui/assets/55311933/dfb2a3f4-d890-4e2a-bf21-ab7b8c4c0a59)


I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog