### PR TITLE
Make fuzzy find popup scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * allow `copy` file path on revision files and status tree [[@yanganto]](https://github.com/yanganto)  ([#1516](https://github.com/extrawurst/gitui/pull/1516))
 * print message of where log will be written if `-l` is set ([#1472](https://github.com/extrawurst/gitui/pull/1472))
 * show remote branches in log [[@cruessler](https://github.com/cruessler)] ([#1501](https://github.com/extrawurst/gitui/issues/1501))
+* scrolling functionality to fuzzy-find [[@AmmarAbouZor](https://github.com/AmmarAbouZor)] ([#1732](https://github.com/extrawurst/gitui/issues/1732))
 
 ### Fixes
 * fixed side effect of crossterm 0.26 on windows that caused double input of all keys [[@pm100]](https://github/pm100) ([#1686](https://github.com/extrawurst/gitui/pull/1686))

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -242,7 +242,7 @@ impl FuzzyFindPopup {
 					f,
 					area,
 					&self.theme,
-					self.filtered.len(),
+					self.filtered.len().saturating_sub(1),
 					self.selection,
 					ui::Orientation::Vertical,
 				);

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -171,6 +171,80 @@ impl FuzzyFindPopup {
 
 		false
 	}
+
+	#[inline]
+	fn draw_matches_list<B: Backend>(
+		&self,
+		f: &mut Frame<B>,
+		area: Rect,
+	) {
+		{
+			// Block has two lines up and down which need to be considered
+			const HEIGHT_BLOCK_MARGIN: usize = 2;
+
+			let title = format!("Hits: {}", self.filtered.len());
+
+			let height = usize::from(area.height);
+			let width = usize::from(area.width);
+
+			let list_height =
+				height.saturating_sub(HEIGHT_BLOCK_MARGIN);
+
+			let scroll_skip =
+				self.selection.saturating_sub(list_height);
+
+			let items = self
+				.filtered
+				.iter()
+				.skip(scroll_skip)
+				.take(height)
+				.map(|(idx, indicies)| {
+					let selected = self
+						.selected_index
+						.map_or(false, |index| index == *idx);
+					let full_text =
+						trim_length_left(&self.contents[*idx], width);
+					Line::from(
+						full_text
+							.char_indices()
+							.map(|(c_idx, c)| {
+								Span::styled(
+									Cow::from(c.to_string()),
+									self.theme.text(
+										selected,
+										indicies.contains(&c_idx),
+									),
+								)
+							})
+							.collect::<Vec<_>>(),
+					)
+				});
+
+			ui::draw_list_block(
+				f,
+				area,
+				Block::default()
+					.title(Span::styled(
+						title,
+						self.theme.title(true),
+					))
+					.borders(Borders::TOP),
+				items,
+			);
+
+			// Draw scrollbar when needed
+			if self.filtered.len() > list_height {
+				ui::draw_scrollbar(
+					f,
+					area,
+					&self.theme,
+					self.filtered.len(),
+					self.selection,
+					ui::Orientation::Vertical,
+				);
+			}
+		}
+	}
 }
 
 impl DrawableComponent for FuzzyFindPopup {
@@ -232,72 +306,7 @@ impl DrawableComponent for FuzzyFindPopup {
 			self.find_text.draw(f, chunks[0])?;
 
 			if any_hits {
-				// Block has two lines up and down which need to be considered
-				const HEIGHT_BLOCK_MARGIN: usize = 2;
-
-				let title = format!("Hits: {}", self.filtered.len());
-
-				let height = usize::from(chunks[1].height);
-				let width = usize::from(chunks[1].width);
-
-				let list_height =
-					height.saturating_sub(HEIGHT_BLOCK_MARGIN);
-
-				let scroll_skip =
-					self.selection.saturating_sub(list_height);
-
-				let items = self
-					.filtered
-					.iter()
-					.skip(scroll_skip)
-					.take(height)
-					.map(|(idx, indicies)| {
-						let selected = self
-							.selected_index
-							.map_or(false, |index| index == *idx);
-						let full_text = trim_length_left(
-							&self.contents[*idx],
-							width,
-						);
-						Line::from(
-							full_text
-								.char_indices()
-								.map(|(c_idx, c)| {
-									Span::styled(
-										Cow::from(c.to_string()),
-										self.theme.text(
-											selected,
-											indicies.contains(&c_idx),
-										),
-									)
-								})
-								.collect::<Vec<_>>(),
-						)
-					});
-
-				ui::draw_list_block(
-					f,
-					chunks[1],
-					Block::default()
-						.title(Span::styled(
-							title,
-							self.theme.title(true),
-						))
-						.borders(Borders::TOP),
-					items,
-				);
-
-				// Draw scrollbar when needed
-				if self.filtered.len() > list_height {
-					ui::draw_scrollbar(
-						f,
-						chunks[1],
-						&self.theme,
-						self.filtered.len(),
-						self.selection,
-						ui::Orientation::Vertical,
-					);
-				}
+				self.draw_matches_list(f, chunks[1]);
 			}
 		}
 		Ok(())

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -176,7 +176,7 @@ impl FuzzyFindPopup {
 	fn draw_matches_list<B: Backend>(
 		&self,
 		f: &mut Frame<B>,
-		area: Rect,
+		mut area: Rect,
 	) {
 		{
 			// Block has two lines up and down which need to be considered
@@ -234,6 +234,10 @@ impl FuzzyFindPopup {
 
 			// Draw scrollbar when needed
 			if self.filtered.len() > list_height {
+				// Reset list area margin
+				area.width += 1;
+				area.height += 1;
+
 				ui::draw_scrollbar(
 					f,
 					area,

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -237,31 +237,38 @@ impl DrawableComponent for FuzzyFindPopup {
 				let height = usize::from(chunks[1].height);
 				let width = usize::from(chunks[1].width);
 
-				let items = self.filtered.iter().take(height).map(
-					|(idx, indicies)| {
-						let selected = self
-							.selected_index
-							.map_or(false, |index| index == *idx);
-						let full_text = trim_length_left(
-							&self.contents[*idx],
-							width,
-						);
-						Line::from(
-							full_text
-								.char_indices()
-								.map(|(c_idx, c)| {
-									Span::styled(
-										Cow::from(c.to_string()),
-										self.theme.text(
-											selected,
-											indicies.contains(&c_idx),
-										),
-									)
-								})
-								.collect::<Vec<_>>(),
-						)
-					},
-				);
+				const HEIGHT_BLOCK_MARGINE: usize = 2;
+				let skip = self
+					.selection
+					.saturating_sub(height - HEIGHT_BLOCK_MARGINE);
+
+				let items =
+					self.filtered.iter().skip(skip).take(height).map(
+						|(idx, indicies)| {
+							let selected = self
+								.selected_index
+								.map_or(false, |index| index == *idx);
+							let full_text = trim_length_left(
+								&self.contents[*idx],
+								width,
+							);
+							Line::from(
+								full_text
+									.char_indices()
+									.map(|(c_idx, c)| {
+										Span::styled(
+											Cow::from(c.to_string()),
+											self.theme.text(
+												selected,
+												indicies
+													.contains(&c_idx),
+											),
+										)
+									})
+									.collect::<Vec<_>>(),
+							)
+						},
+					);
 
 				ui::draw_list_block(
 					f,

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -232,43 +232,46 @@ impl DrawableComponent for FuzzyFindPopup {
 			self.find_text.draw(f, chunks[0])?;
 
 			if any_hits {
+				// Block has two lines up and down which need to be considered
+				const HEIGHT_BLOCK_MARGINE: usize = 2;
+
 				let title = format!("Hits: {}", self.filtered.len());
 
 				let height = usize::from(chunks[1].height);
 				let width = usize::from(chunks[1].width);
 
-				const HEIGHT_BLOCK_MARGINE: usize = 2;
-				let skip = self
+				let scroll_skip = self
 					.selection
 					.saturating_sub(height - HEIGHT_BLOCK_MARGINE);
 
-				let items =
-					self.filtered.iter().skip(skip).take(height).map(
-						|(idx, indicies)| {
-							let selected = self
-								.selected_index
-								.map_or(false, |index| index == *idx);
-							let full_text = trim_length_left(
-								&self.contents[*idx],
-								width,
-							);
-							Line::from(
-								full_text
-									.char_indices()
-									.map(|(c_idx, c)| {
-										Span::styled(
-											Cow::from(c.to_string()),
-											self.theme.text(
-												selected,
-												indicies
-													.contains(&c_idx),
-											),
-										)
-									})
-									.collect::<Vec<_>>(),
-							)
-						},
-					);
+				let items = self
+					.filtered
+					.iter()
+					.skip(scroll_skip)
+					.take(height)
+					.map(|(idx, indicies)| {
+						let selected = self
+							.selected_index
+							.map_or(false, |index| index == *idx);
+						let full_text = trim_length_left(
+							&self.contents[*idx],
+							width,
+						);
+						Line::from(
+							full_text
+								.char_indices()
+								.map(|(c_idx, c)| {
+									Span::styled(
+										Cow::from(c.to_string()),
+										self.theme.text(
+											selected,
+											indicies.contains(&c_idx),
+										),
+									)
+								})
+								.collect::<Vec<_>>(),
+						)
+					});
 
 				ui::draw_list_block(
 					f,

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -233,7 +233,7 @@ impl DrawableComponent for FuzzyFindPopup {
 
 			if any_hits {
 				// Block has two lines up and down which need to be considered
-				const HEIGHT_BLOCK_MARGINE: usize = 2;
+				const HEIGHT_BLOCK_MARGIN: usize = 2;
 
 				let title = format!("Hits: {}", self.filtered.len());
 
@@ -242,7 +242,7 @@ impl DrawableComponent for FuzzyFindPopup {
 
 				let scroll_skip = self
 					.selection
-					.saturating_sub(height - HEIGHT_BLOCK_MARGINE);
+					.saturating_sub(height - HEIGHT_BLOCK_MARGIN);
 
 				let items = self
 					.filtered

--- a/src/components/fuzzy_find_popup.rs
+++ b/src/components/fuzzy_find_popup.rs
@@ -240,9 +240,11 @@ impl DrawableComponent for FuzzyFindPopup {
 				let height = usize::from(chunks[1].height);
 				let width = usize::from(chunks[1].width);
 
-				let scroll_skip = self
-					.selection
-					.saturating_sub(height - HEIGHT_BLOCK_MARGIN);
+				let list_height =
+					height.saturating_sub(HEIGHT_BLOCK_MARGIN);
+
+				let scroll_skip =
+					self.selection.saturating_sub(list_height);
 
 				let items = self
 					.filtered
@@ -284,6 +286,18 @@ impl DrawableComponent for FuzzyFindPopup {
 						.borders(Borders::TOP),
 					items,
 				);
+
+				// Draw scrollbar when needed
+				if self.filtered.len() > list_height {
+					ui::draw_scrollbar(
+						f,
+						chunks[1],
+						&self.theme,
+						self.filtered.len(),
+						self.selection,
+						ui::Orientation::Vertical,
+					);
+				}
 			}
 		}
 		Ok(())


### PR DESCRIPTION
This Pull Request fixes/closes #1732.

It changes the following:
- It makes the fuzzy-find popup scrollable

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog