### PR TITLE
Calculate author width dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * support 'n'/'p' key to move to the next/prev hunk in diff component [[@hamflx](https://github.com/hamflx)] ([#1523](https://github.com/extrawurst/gitui/issues/1523))
 * simplify theme overrides [[@cruessler](https://github.com/cruessler)] ([#1367](https://github.com/extrawurst/gitui/issues/1367))
+* calculate author width dynamically [[@qixiaoo](https://github.com/qixiaoo)] ([#1739](https://github.com/extrawurst/gitui/issues/1739))
 
 ### Fixes
 * fix commit dialog char count for multibyte characters ([#1726](https://github.com/extrawurst/gitui/issues/1726))

--- a/src/components/blame_file.rs
+++ b/src/components/blame_file.rs
@@ -3,6 +3,7 @@ use super::{
 	Component, DrawableComponent, EventState, FileRevOpen,
 	InspectCommitOpen,
 };
+use crate::components::utils::{get_author_width, MAX_AUTHOR_WIDTH};
 use crate::{
 	components::{utils::string_width_align, ScrollType},
 	keys::{key_match, SharedKeyConfig},
@@ -30,8 +31,6 @@ use std::convert::TryInto;
 
 static NO_COMMIT_ID: &str = "0000000";
 static NO_AUTHOR: &str = "<no author>";
-static MIN_AUTHOR_WIDTH: usize = 3;
-static MAX_AUTHOR_WIDTH: usize = 20;
 
 #[derive(Clone, Debug)]
 pub struct BlameFileOpen {
@@ -587,11 +586,6 @@ impl BlameFileComponent {
 			commit_id
 		})
 	}
-}
-
-fn get_author_width(width: usize) -> usize {
-	(width.saturating_sub(19) / 3)
-		.clamp(MIN_AUTHOR_WIDTH, MAX_AUTHOR_WIDTH)
 }
 
 const fn number_of_digits(number: usize) -> usize {

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -1,4 +1,5 @@
 use super::utils::logitems::{ItemBatch, LogEntry};
+use crate::components::utils::get_author_width;
 use crate::{
 	components::{
 		utils::string_width_align, CommandBlocking, CommandInfo,
@@ -344,8 +345,7 @@ impl CommitList {
 
 		txt.push(splitter.clone());
 
-		let author_width =
-			(width.saturating_sub(19) / 3).clamp(3, 20);
+		let author_width = get_author_width(width);
 		let author = string_width_align(&e.author, author_width);
 
 		// commit author

--- a/src/components/utils/mod.rs
+++ b/src/components/utils/mod.rs
@@ -64,3 +64,11 @@ pub fn string_width_align(s: &str, width: usize) -> String {
 fn find_truncate_point(s: &str, chars: usize) -> usize {
 	s.chars().take(chars).map(char::len_utf8).sum()
 }
+
+pub static MIN_AUTHOR_WIDTH: usize = 3;
+pub static MAX_AUTHOR_WIDTH: usize = 20;
+
+pub fn get_author_width(width: usize) -> usize {
+	(width.saturating_sub(19) / 3)
+		.clamp(MIN_AUTHOR_WIDTH, MAX_AUTHOR_WIDTH)
+}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1739 .

It changes the following:
- It truncates author name in `TagListComponent` when window size is not big enough.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog