### PR TITLE
Restore left-arrow shortcut to back out of diff view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * support 'n'/'p' key to move to the next/prev hunk in diff component [[@hamflx](https://github.com/hamflx)] ([#1523](https://github.com/extrawurst/gitui/issues/1523))
 * simplify theme overrides [[@cruessler](https://github.com/cruessler)] ([#1367](https://github.com/extrawurst/gitui/issues/1367))
+* restore '←' keybind in diff viewer [[@holly-hacker](https://github.com/holly-hacker)] ([#1729](https://github.com/extrawurst/gitui/issues/1729))
 
 ### Fixes
 * fix commit dialog char count for multibyte characters ([#1726](https://github.com/extrawurst/gitui/issues/1726))

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -864,6 +864,7 @@ impl Component for DiffComponent {
 						.move_right(HorizontalScrollType::Right);
 					Ok(EventState::Consumed)
 				} else if key_match(e, self.key_config.keys.move_left)
+					&& self.horizontal_scroll.get_right() != 0
 				{
 					self.horizontal_scroll
 						.move_right(HorizontalScrollType::Left);

--- a/src/components/inspect_commit.rs
+++ b/src/components/inspect_commit.rs
@@ -158,7 +158,9 @@ impl Component for InspectCommitComponent {
 			}
 
 			if let Event::Key(e) = ev {
-				if key_match(e, self.key_config.keys.exit_popup) {
+				if key_match(e, self.key_config.keys.exit_popup)
+					|| key_match(e, self.key_config.keys.move_left)
+				{
 					if self.diff.focused() {
 						self.details.focus(true);
 						self.diff.focus(false);
@@ -172,9 +174,6 @@ impl Component for InspectCommitComponent {
 				{
 					self.details.focus(false);
 					self.diff.focus(true);
-				} else if key_match(e, self.key_config.keys.move_left)
-				{
-					self.hide_stacked(false);
 				}
 
 				return Ok(EventState::Consumed);

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -688,6 +688,14 @@ impl Status {
 		);
 		out.push(
 			CommandInfo::new(
+				strings::commands::diff_focus_left(&self.key_config),
+				true,
+				(self.visible && focus_on_diff) || force_all,
+			)
+			.order(strings::order::NAV),
+		);
+		out.push(
+			CommandInfo::new(
 				strings::commands::diff_focus_right(&self.key_config),
 				self.can_focus_diff(),
 				(self.visible && !focus_on_diff) || force_all,
@@ -859,7 +867,11 @@ impl Component for Status {
 				} else if key_match(
 					k,
 					self.key_config.keys.exit_popup,
-				) {
+				) || (key_match(
+					k,
+					self.key_config.keys.move_left,
+				) && self.is_focus_on_diff())
+				{
 					self.switch_focus(match self.diff_target {
 						DiffTarget::Stage => Focus::Stage,
 						DiffTarget::WorkingDir => Focus::WorkDir,


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1729.

It changes the following:
- Restore the left-arrow shortcut in the diff view. This is usually a more natural keybind to use when entering the diff view using right-arrow.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors (**NOTE**: I received newline warnings due to my git config)
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog