### PR TITLE
Copy full Commit Hash by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fix hunk (un)staging/reset for # of context lines != 3 ([#1746](https://github.com/extrawurst/gitui/issues/1746))
 * fix delay when opening external editor ([#1506](https://github.com/extrawurst/gitui/issues/1506))
 
+### Changed
+* Copy full Commit Hash by default [[@AmmarAbouZor](https://github.com/AmmarAbouZor)] ([#1836](https://github.com/extrawurst/gitui/issues/1836))
+
 ## [0.23.0] - 2022-06-19
 
 **reset to commit**

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -162,7 +162,7 @@ impl CommitList {
 
 	pub fn copy_commit_hash(&self) -> Result<()> {
 		let marked = self.marked.as_slice();
-		let yank: Option<Cow<str>> = match marked {
+		let yank: Option<String> = match marked {
 			[] => self
 				.items
 				.iter()
@@ -170,10 +170,8 @@ impl CommitList {
 					self.selection
 						.saturating_sub(self.items.index_offset()),
 				)
-				.map(|e| Cow::Borrowed(e.hash_short.as_ref())),
-			[(_idx, commit)] => {
-				Some(commit.get_short_string().into())
-			}
+				.map(|e| e.id.to_string()),
+			[(_idx, commit)] => Some(commit.to_string()),
 			[first, .., last] => {
 				let marked_consecutive =
 					marked.windows(2).all(|w| w[0].0 + 1 == w[1].0);
@@ -181,18 +179,16 @@ impl CommitList {
 				let yank = if marked_consecutive {
 					format!(
 						"{}^..{}",
-						first.1.get_short_string(),
-						last.1.get_short_string()
+						first.1.to_string(),
+						last.1.to_string()
 					)
 				} else {
 					marked
 						.iter()
-						.map(|(_idx, commit)| {
-							commit.get_short_string()
-						})
+						.map(|(_idx, commit)| commit.to_string())
 						.join(" ")
 				};
-				Some(yank.into())
+				Some(yank)
 			}
 		};
 


### PR DESCRIPTION
This Pull Request resolve the discussion #1665 .

It changes the following:
- Copy Commit hash will copy the full hash now instead of the short version of it


I followed the checklist:
- [ ] <s>I added unittests</s>
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog