### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get version
       id: get_version

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,8 +25,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        key: ${{ matrix.os }}-${{ env.cache-name }}-stable
-        shared-key: "shared"
+        shared-key: ${{ matrix.os }}-${{ env.cache-name }}-stable
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,7 @@ jobs:
         cache-name: ci
       with:
         key: ${{ matrix.os }}-${{ env.cache-name }}-stable
+        shared-key: "shared"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,11 +21,9 @@ jobs:
       run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        profile: minimal
-        override: true
         components: clippy
 
     - name: Build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,13 @@ jobs:
       id: get_version
       run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
 
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        key: ${{ matrix.os }}-${{ env.cache-name }}-stable
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         cache-name: ci
       with:
         key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
+        shared-key: "shared"
 
     - name: MacOS Workaround
       if: matrix.os == 'macos-latest'
@@ -97,6 +98,7 @@ jobs:
         cache-name: ci
       with:
         key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+        shared-key: "shared"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -143,6 +145,7 @@ jobs:
         cache-name: ci
       with:
         key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+        shared-key: "shared"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        shared-key: ubuntu-latest-${{ env.cache-name }}-stable
+        key: ubuntu-latest-${{ env.cache-name }}-stable
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -220,7 +220,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        shared-key: ubuntu-latest-${{ env.cache-name }}-nightly
+        key: ubuntu-latest-${{ env.cache-name }}-nightly
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        shared-key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -142,7 +142,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        shared-key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         targets: x86_64-unknown-linux-musl
     
-    # The build would fail without manually installing the target. Interestingly enough, this step
-    # prints "component is up to date".
+    # The build would fail without manually installing the target.
     # https://github.com/dtolnay/rust-toolchain/issues/83
     - name: Manually install target
       run: rustup target add x86_64-unknown-linux-musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       env:
         cache-name: ci
-        target: x86_64-unknown-linux-musl
       with:
-        key: ${{ env.target }}-${{ env.cache-name }}-${{ matrix.rust }}
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -142,9 +141,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       env:
         cache-name: ci
-        target: linux-arm
       with:
-        key: ${{ env.cache-name }}-${{ env.cache-name }}-${{ matrix.rust }}
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        shared-key: ubuntu-latest-${{ env.cache-name }}-stable
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -206,6 +214,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        shared-key: ubuntu-latest-${{ env.cache-name }}-nightly
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         cache-name: ci
       with:
         key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
-        prefix-key: "test"
 
     - name: MacOS Workaround
       if: matrix.os == 'macos-latest'
@@ -99,7 +98,6 @@ jobs:
         target: x86_64-unknown-linux-musl
       with:
         key: ${{ env.target }}-${{ env.cache-name }}-${{ matrix.rust }}
-        prefix-key: "test"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -148,7 +146,6 @@ jobs:
         target: linux-arm
       with:
         key: ${{ env.cache-name }}-${{ env.cache-name }}-${{ matrix.rust }}
-        prefix-key: "test"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Restore cargo cache
-      uses: actions/cache@v2
+      uses: Swatinem/rust-cache@v2
       env:
         cache-name: ci
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          ~/.cargo/bin
-          target
-        key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}-${{ hashFiles('Cargo.lock') }}
+        key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: MacOS Workaround
       if: matrix.os == 'macos-latest'
@@ -95,6 +90,15 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
     - uses: actions/checkout@v3
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+        target: x86_64-unknown-linux-musl
+      with:
+        key: ${{ env.target }}-${{ env.cache-name }}-${{ matrix.rust }}
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -131,6 +135,15 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
     - uses: actions/checkout@v3
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+        target: linux-arm
+      with:
+        key: ${{ env.cache-name }}-${{ env.cache-name }}-${{ matrix.rust }}
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
-        shared-key: "shared"
+        shared-key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: MacOS Workaround
       if: matrix.os == 'macos-latest'
@@ -97,8 +96,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
-        shared-key: "shared"
+        shared-key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -144,8 +142,7 @@ jobs:
       env:
         cache-name: ci
       with:
-        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
-        shared-key: "shared"
+        shared-key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore cargo cache
       uses: actions/cache@v2
@@ -97,7 +97,7 @@ jobs:
         rust: [nightly, stable, '1.65']
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -133,7 +133,7 @@ jobs:
         rust: [nightly, stable, '1.65']
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -168,7 +168,7 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -199,7 +199,7 @@ jobs:
     name: udeps
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -217,7 +217,7 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
     name: Changelog Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Extract release notes
       id: extract_release_notes
       uses: ffurrer2/extract-release-notes@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,9 @@ jobs:
       run: cargo clean -p serde_derive -p thiserror
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        default: true
-        override: true
-        profile: minimal
         components: clippy
 
     - name: Build Debug
@@ -99,12 +96,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        default: true
-        override: true
         target: x86_64-unknown-linux-musl
 
     - name: Setup MUSL
@@ -135,12 +129,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        default: true
-        override: true
     - name: Setup ARM toolchain
       run: |
         rustup target add aarch64-unknown-linux-gnu
@@ -170,10 +161,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        override: true
         components: rustfmt
 
     - run: cargo fmt -- --check
@@ -201,10 +191,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: nightly
-        override: true
         
     - name: cargo-udeps
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         cache-name: ci
       with:
         key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
+        prefix-key: "test"
 
     - name: MacOS Workaround
       if: matrix.os == 'macos-latest'
@@ -98,6 +99,7 @@ jobs:
         target: x86_64-unknown-linux-musl
       with:
         key: ${{ env.target }}-${{ env.cache-name }}-${{ matrix.rust }}
+        prefix-key: "test"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -146,6 +148,7 @@ jobs:
         target: linux-arm
       with:
         key: ${{ env.cache-name }}-${{ env.cache-name }}-${{ matrix.rust }}
+        prefix-key: "test"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/audit-check@v1
+    - uses: rustsec/audit-check@v1.4.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
-        target: x86_64-unknown-linux-musl
+        targets: x86_64-unknown-linux-musl
 
     - name: Setup MUSL
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         targets: x86_64-unknown-linux-musl
+    
+    - name: Manually install target
+      run: rustup target add x86_64-unknown-linux-musl
 
     - name: Setup MUSL
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
         toolchain: ${{ matrix.rust }}
         targets: x86_64-unknown-linux-musl
     
+    # The build would fail without manually installing the target. Interestingly enough, this step
+    # prints "component is up to date".
+    # https://github.com/dtolnay/rust-toolchain/issues/83
     - name: Manually install target
       run: rustup target add x86_64-unknown-linux-musl
 


### PR DESCRIPTION
This Pull Request closes #1844.

## Changes

### Fix Warnings

- use `actions/checkout@v3`
- switch from `actions-rs/toolchain` (not maintained) to [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
- switch from `actions-rs/audit-check` (not maintained) to [`rustsec/audit-check`](https://github.com/rustsec/audit-check)

These changes resolved all the warnings.

### Caching

Used [`rust-cache`](https://github.com/Swatinem/rust-cache) as mentioned in the issue.

> **Note** 
> `rust-cache`:
> - caches `.cargo/` and `target/`
> - hashes `Cargo.lock` for the key automatically
>
> hence their removal from the ci script 

I kept the `cache-name` around and added a `target` variable as well.

## Is it any better?

I think the best way to figure that out would be to wait for another commit to be made to master which I can merge to my fork so we can compare the CI times between that and the original.

I forked at https://github.com/extrawurst/gitui/commit/b36ffc9481cbc30000f43e2a7d6c72cb834bb3bd and here's some numbers

- original repo: [27m 21s](https://github.com/extrawurst/gitui/actions/runs/5998812806/usage)
- fork with invalidated cache: [25m 35s](https://github.com/AntoniosBarotsis/gitui/actions/runs/6000180026/usage)
- fork with warm cache: [14m 5s](https://github.com/AntoniosBarotsis/gitui/actions/runs/5999723565/usage)

> In my experience, +- 2 minutes can often just be random noise when it comes to GA

I would guess that the warm cache time is more representative of the change since, well, the original repository should also have a warm cache. But again, a more serious comparison would be to wait for the next commit.

And also not having a wall of warnings makes it easier to spot any that are actually relevant when they appear 😅 

## Other

I also mention this in the `yml` itself but for some reason [there seems to be some issue with the `x86_64-unknown-linux-musl` target and the `dtolnay/rust-toolchain` action](https://github.com/dtolnay/rust-toolchain/issues/83).

Even though the rustup target should be installed, [the subsequent build fails](https://github.com/AntoniosBarotsis/gitui/actions/runs/5999098146/job/16268573800). [I instead install it manually](https://github.com/extrawurst/gitui/commit/8601e6411ab07c40409e65bb34f202f4d5a534f2) which works fine (it is also cached so subsequent runs don't suffer).

Let me know if you have any questions or want any changes made!


Also the last CI run after I changed a comment decided to fail due to a [timeout](https://github.com/AntoniosBarotsis/gitui/actions/runs/6001112261/job/16274588502), I'm guessing because I've been running it quite a few times in the last few hours. Anyway, seems unrelated + i ran the failed task again and it worked fine