### PR TITLE
Allow customizing line break visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* `theme.ron` now supports customizing line break symbol ([#1894](https://github.com/extrawurst/gitui/issues/1894))
+
 ## [0.24.3] - 2023-09-09
 
 ### Fixes

--- a/THEMES.md
+++ b/THEMES.md
@@ -31,3 +31,21 @@ Notes:
 * using a color like `yellow` might appear in whatever your terminal/theme defines for `yellow`
 * valid colors can be found in tui-rs' [Color](https://docs.rs/tui/0.12.0/tui/style/enum.Color.html) struct. 
 * all customizable theme elements can be found in [`style.rs` in the `impl Default for Theme` block](https://github.com/extrawurst/gitui/blob/master/src/ui/style.rs#L305)
+
+## Customizing line breaks
+
+If you want to change how the line break is displayed in the diff, you can also specify `line_break` in your `theme.ron`:
+
+```
+(
+    line_break: Some("¶"),
+)
+```
+
+Note that if you want to turn it off, you should use a blank string:
+
+```
+(
+    line_break: Some(""),
+)
+```

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -462,7 +462,7 @@ impl DiffComponent {
 
 		let content =
 			if !is_content_line && line.content.as_ref().is_empty() {
-				String::from(strings::symbol::LINE_BREAK)
+				theme.line_break()
 			} else {
 				tabs_to_spaces(line.content.as_ref().to_string())
 			};

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
 		let quit_state = run_app(
 			app_start,
 			repo_path.clone(),
-			theme,
+			theme.clone(),
 			key_config.clone(),
 			&input,
 			updater,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -42,7 +42,6 @@ pub mod symbol {
 	pub const CHECKMARK: &str = "\u{2713}"; //✓
 	pub const SPACE: &str = "\u{02FD}"; //˽
 	pub const EMPTY_SPACE: &str = " ";
-	pub const LINE_BREAK: &str = "¶";
 	pub const FOLDER_ICON_COLLAPSED: &str = "\u{25b8}"; //▸
 	pub const FOLDER_ICON_EXPANDED: &str = "\u{25be}"; //▾
 	pub const EMPTY_STR: &str = "";

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -8,7 +8,7 @@ use struct_patch::Patch;
 
 pub type SharedTheme = Rc<Theme>;
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Patch)]
+#[derive(Serialize, Deserialize, Debug, Clone, Patch)]
 #[patch_derive(Serialize, Deserialize)]
 pub struct Theme {
 	selected_tab: Color,
@@ -32,6 +32,7 @@ pub struct Theme {
 	push_gauge_fg: Color,
 	tag_fg: Color,
 	branch_fg: Color,
+	line_break: String,
 }
 
 impl Theme {
@@ -192,6 +193,10 @@ impl Theme {
 		Style::default().fg(self.danger_fg)
 	}
 
+	pub fn line_break(&self) -> String {
+		self.line_break.clone()
+	}
+
 	pub fn commandbar(&self, enabled: bool, line: usize) -> Style {
 		if enabled {
 			Style::default().fg(self.command_fg)
@@ -278,7 +283,7 @@ impl Theme {
 	// This is supposed to be called when theme.ron doesn't already exists.
 	fn save_patch(&self, theme_path: &PathBuf) -> Result<()> {
 		let mut file = File::create(theme_path)?;
-		let patch = self.into_patch_by_diff(Self::default());
+		let patch = self.clone().into_patch_by_diff(Self::default());
 		let data = to_string_pretty(&patch, PrettyConfig::default())?;
 
 		file.write_all(data.as_bytes())?;
@@ -336,6 +341,7 @@ impl Default for Theme {
 			push_gauge_fg: Color::Reset,
 			tag_fg: Color::LightMagenta,
 			branch_fg: Color::LightYellow,
+			line_break: "¶".to_string(),
 		}
 	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1894.

It changes the following:
- Add `line_break` to `Theme`.
- Printing a line break will now consult the theme.

I followed the checklist:
- [X] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [X] I added an appropriate item to the changelog
