### PR TITLE
make diff line-break visualisation "¶" optional

### DIFF
--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -462,7 +462,7 @@ impl DiffComponent {
 
 		let content =
 			if !is_content_line && line.content.as_ref().is_empty() {
-				String::from(strings::symbol::LINE_BREAK)
+				theme.line_break()
 			} else {
 				tabs_to_spaces(line.content.as_ref().to_string())
 			};

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -43,6 +43,7 @@ pub mod symbol {
 	pub const SPACE: &str = "\u{02FD}"; //˽
 	pub const EMPTY_SPACE: &str = " ";
 	pub const LINE_BREAK: &str = "¶";
+	pub const NO_LINE_BREAK: &str = "";
 	pub const FOLDER_ICON_COLLAPSED: &str = "\u{25b8}"; //▸
 	pub const FOLDER_ICON_EXPANDED: &str = "\u{25be}"; //▾
 	pub const EMPTY_STR: &str = "";

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -1,3 +1,4 @@
+use crate::strings;
 use anyhow::Result;
 use asyncgit::{DiffLineType, StatusItemType};
 use ratatui::style::{Color, Modifier, Style};
@@ -32,6 +33,7 @@ pub struct Theme {
 	push_gauge_fg: Color,
 	tag_fg: Color,
 	branch_fg: Color,
+	line_break_visible: bool,
 }
 
 impl Theme {
@@ -263,6 +265,14 @@ impl Theme {
 		Style::default().fg(Color::Yellow)
 	}
 
+	pub fn line_break(&self) -> String {
+		if self.line_break_visible {
+			String::from(strings::symbol::LINE_BREAK)
+		} else {
+			String::from(strings::symbol::NO_LINE_BREAK)
+		}
+	}
+
 	fn load_patch(theme_path: &PathBuf) -> Result<ThemePatch> {
 		let file = File::open(theme_path)?;
 
@@ -336,6 +346,7 @@ impl Default for Theme {
 			push_gauge_fg: Color::Reset,
 			tag_fg: Color::LightMagenta,
 			branch_fg: Color::LightYellow,
+			line_break_visible: true,
 		}
 	}
 }


### PR DESCRIPTION
This Pull Request fixes/closes #1894.

It changes the following:
- adds a line_break_visible theme option (default true)
- shows the ¶ only if enabled

I tried to follow the spirit of the project but I'm new to rust so please take a closer look :)

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog