### PR TITLE
Add confirmation dialog for undo commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * `theme.ron` now supports customizing line break symbol ([#1894](https://github.com/extrawurst/gitui/issues/1894))
-
+* add confirmation for dialog for undo commit ([#1912](https://github.com/extrawurst/gitui/issues/1912))
+ 
 ## [0.24.3] - 2023-09-09
 
 ### Fixes

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ use crate::{
 	setup_popups,
 	strings::{self, ellipsis_trim_start, order},
 	tabs::{FilesTab, Revlog, StashList, Stashing, Status},
+	try_or_popup,
 	ui::style::{SharedTheme, Theme},
 	AsyncAppNotification, AsyncNotification,
 };
@@ -1081,7 +1082,11 @@ impl App {
 				self.status_tab.abort_rebase();
 			}
 			Action::UndoCommit => {
-				let _ = undo_last_commit(&self.repo.borrow());
+				try_or_popup!(
+					self,
+					"undo commit failed:",
+					undo_last_commit(&self.repo.borrow())
+				);
 			}
 		};
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,7 +31,11 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use asyncgit::{
-	sync::{self, utils::repo_work_dir, RepoPath, RepoPathRef},
+	sync::{
+		self,
+		utils::{repo_work_dir, undo_last_commit},
+		RepoPath, RepoPathRef,
+	},
 	AsyncGitNotification, PushType,
 };
 use crossbeam_channel::Sender;
@@ -1075,6 +1079,9 @@ impl App {
 			}
 			Action::AbortRebase => {
 				self.status_tab.abort_rebase();
+			}
+			Action::UndoCommit => {
+				let _ = undo_last_commit(&self.repo.borrow());
 			}
 		};
 

--- a/src/components/reset.rs
+++ b/src/components/reset.rs
@@ -215,7 +215,7 @@ impl ConfirmComponent {
                 ),
                 Action::UndoCommit => (
                     strings::confirm_title_undo_commit(),
-                    strings:: confirm_msg_undo_commit(),
+                    strings::confirm_msg_undo_commit(),
                 ),
             };
 		}

--- a/src/components/reset.rs
+++ b/src/components/reset.rs
@@ -213,6 +213,10 @@ impl ConfirmComponent {
                     strings::confirm_title_abortrevert(),
                     strings::confirm_msg_revertchanges(),
                 ),
+                Action::UndoCommit => (
+                    strings::confirm_title_undo_commit(),
+                    strings:: confirm_msg_undo_commit(),
+                ),
             };
 		}
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -54,7 +54,7 @@ pub enum Action {
 	AbortMerge,
 	AbortRebase,
 	AbortRevert,
-    UndoCommit,
+	UndoCommit,
 }
 
 #[derive(Debug)]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -54,6 +54,7 @@ pub enum Action {
 	AbortMerge,
 	AbortRebase,
 	AbortRevert,
+    UndoCommit,
 }
 
 #[derive(Debug)]

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -145,6 +145,9 @@ pub fn stash_popup_msg(_key_config: &SharedKeyConfig) -> String {
 pub fn confirm_title_reset() -> String {
 	"Reset".to_string()
 }
+pub fn confirm_title_undo_commit() -> String {
+    "Undo commit".to_string()
+}
 pub fn confirm_title_stashdrop(
 	_key_config: &SharedKeyConfig,
 	multiple: bool,
@@ -202,6 +205,9 @@ pub fn confirm_msg_reset_lines(lines: usize) -> String {
 	format!(
 		"are you sure you want to discard {lines} selected lines?"
 	)
+}
+pub fn confirm_msg_undo_commit() -> String {
+    "confirm undo last commit?".to_string()
 }
 pub fn confirm_msg_stashdrop(
 	_key_config: &SharedKeyConfig,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -146,7 +146,7 @@ pub fn confirm_title_reset() -> String {
 	"Reset".to_string()
 }
 pub fn confirm_title_undo_commit() -> String {
-    "Undo commit".to_string()
+	"Undo commit".to_string()
 }
 pub fn confirm_title_stashdrop(
 	_key_config: &SharedKeyConfig,
@@ -207,7 +207,7 @@ pub fn confirm_msg_reset_lines(lines: usize) -> String {
 	)
 }
 pub fn confirm_msg_undo_commit() -> String {
-    "confirm undo last commit?".to_string()
+	"confirm undo last commit?".to_string()
 }
 pub fn confirm_msg_stashdrop(
 	_key_config: &SharedKeyConfig,

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -610,11 +610,11 @@ impl Status {
 	}
 
 	fn undo_last_commit(&self) {
-		try_or_popup!(
-			self,
-			"undo commit failed:",
-			sync::utils::undo_last_commit(&self.repo.borrow())
-		);
+        self.queue.push(
+            InternalEvent::ConfirmAction(
+                Action::UndoCommit,
+            ),
+        );
 	}
 
 	fn branch_compare(&mut self) {

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -610,11 +610,8 @@ impl Status {
 	}
 
 	fn undo_last_commit(&self) {
-        self.queue.push(
-            InternalEvent::ConfirmAction(
-                Action::UndoCommit,
-            ),
-        );
+		self.queue
+			.push(InternalEvent::ConfirmAction(Action::UndoCommit));
 	}
 
 	fn branch_compare(&mut self) {


### PR DESCRIPTION
It changes the following:
- Adds confirmation dialog for undo commit in staged changes

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog

Closes https://github.com/extrawurst/gitui/issues/1912