### PR TITLE
Update the installation instructions on openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ sudo emerge --sync dm9pZCAq
 sudo emerge dev-vcs/gitui::dm9pZCAq
 ```
 
-##### [openSUSE](https://software.opensuse.org/package/gitui) (Tumbleweed)
+##### [openSUSE](https://software.opensuse.org/package/gitui)
 
 ```sh
 sudo zypper install gitui


### PR DESCRIPTION
It changes the following:
- Update the installation instructions on openSUSE. In addition to the Tumbleweed, since openSUSE Leap 15.5, gitui is available in the official repository.[^1]

[^1]: <https://build.opensuse.org/package/show/openSUSE:Leap:15.5/gitui>