### PR TITLE
Commit summary length hints (warning at 50, error at 72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * do not allow tag when `tag.gpgsign` enabled [[@TeFiLeDo](https://github.com/TeFiLeDo)] ([#1915](https://github.com/extrawurst/gitui/pull/1915))
+* update commit summary length hints [[@ochirerkhembayar](https://github.com/OchirErkhembayar)] ([#1635](https://github.com/extrawurst/gitui/issues/1635))
 
 ## [0.24.3] - 2023-09-09
 

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -61,7 +61,8 @@ pub struct CommitComponent {
 	verify: bool,
 }
 
-const FIRST_LINE_LIMIT: usize = 50;
+const MESSAGE_WARNING_LIMIT: usize = 50;
+const MESSAGE_ERROR_LIMIT: usize = 72;
 
 impl CommitComponent {
 	///
@@ -123,11 +124,17 @@ impl CommitComponent {
 			.map(str::len)
 			.unwrap_or_default();
 
-		if first_line > FIRST_LINE_LIMIT {
+		if first_line > MESSAGE_WARNING_LIMIT {
 			let msg = strings::commit_first_line_warning(first_line);
 			let msg_length: u16 = msg.len().cast();
-			let w =
-				Paragraph::new(msg).style(self.theme.text_danger());
+			let w = {
+				let theme = if first_line > MESSAGE_ERROR_LIMIT {
+					self.theme.text_danger()
+				} else {
+					self.theme.text_warning()
+				};
+				Paragraph::new(msg).style(theme)
+			};
 
 			let rect = {
 				let mut rect = self.input.get_area();

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -28,6 +28,7 @@ pub struct Theme {
 	commit_time: Color,
 	commit_author: Color,
 	danger_fg: Color,
+	warning_fg: Color,
 	push_gauge_bg: Color,
 	push_gauge_fg: Color,
 	tag_fg: Color,
@@ -193,6 +194,10 @@ impl Theme {
 		Style::default().fg(self.danger_fg)
 	}
 
+	pub fn text_warning(&self) -> Style {
+		Style::default().fg(self.warning_fg)
+	}
+
 	pub fn line_break(&self) -> String {
 		self.line_break.clone()
 	}
@@ -337,6 +342,7 @@ impl Default for Theme {
 			commit_time: Color::LightCyan,
 			commit_author: Color::Green,
 			danger_fg: Color::Red,
+			warning_fg: Color::Yellow,
 			push_gauge_bg: Color::Blue,
 			push_gauge_fg: Color::Reset,
 			tag_fg: Color::LightMagenta,


### PR DESCRIPTION
This Pull Request fixes/closes #1635.

It changes the following:
- Added a warning_text to styles
- Updated warning for commit message to display yellow text at 50 glyphs and red text at 72 glyphs instead of just red at 50

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog