### PR TITLE
ai commit summary creation using chat-gpt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2-summarize"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "log",
+ "openai-api-rs",
+ "thiserror",
+]
+
+[[package]]
 name = "git2-testing"
 version = "0.1.0"
 dependencies = [
@@ -1057,6 +1067,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "minreq"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3371dfc7b772c540da1380123674a8e20583aca99907087d990ca58cf44203"
+dependencies = [
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "webpki-roots",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1165,17 @@ checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "openai-api-rs"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead8e910b541f342b445ab68dd52ae24d695abaf781aee2ae933a77ac29ea5de"
+dependencies = [
+ "minreq",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1383,6 +1419,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1461,28 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1446,6 +1518,16 @@ name = "scratch"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "serde"
@@ -1578,6 +1660,12 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1784,6 +1872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1975,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "filetreelist",
  "fuzzy-matcher",
  "gh-emoji",
+ "git2-summarize",
  "indexmap",
  "itertools",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ trace-libgit = ["asyncgit/trace-libgit"]
 vendor-openssl = ["asyncgit/vendor-openssl"]
 
 [workspace]
-members = ["asyncgit", "filetreelist", "git2-hooks", "git2-testing", "scopetime"]
+members = ["asyncgit", "filetreelist", "git2-hooks", "git2-summarize", "git2-testing", "scopetime"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["git", "gui", "cli", "terminal", "ui"]
 [dependencies]
 anyhow = "1.0"
 asyncgit = { path = "./asyncgit", version = "0.24", default-features = false }
+git2-summarize = { path = "./git2-summarize", version = "0.1"}
 backtrace = "0.3"
 bitflags = "1.3"
 bugreport = "0.5"

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -415,11 +415,9 @@ pub fn unified_stage_diff(repo_path: &RepoPath) -> Result<String> {
 			_ => "",
 		};
 
-		output.push_str(&format!(
-			"{}{}",
-			prefix,
-			bytes2string(line.content()).unwrap()
-		));
+		if let Ok(line) = bytes2string(line.content()) {
+			output.push_str(&format!("{prefix}{line}"));
+		}
 
 		true
 	})?;

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -62,7 +62,7 @@ pub use config::{
 	get_config_string, untracked_files_config,
 	ShowUntrackedFilesConfig,
 };
-pub use diff::get_diff_commit;
+pub use diff::{get_diff_commit, unified_stage_diff};
 pub use git2::BranchType;
 pub use hooks::{
 	hooks_commit_msg, hooks_post_commit, hooks_pre_commit, HookResult,

--- a/deny.toml
+++ b/deny.toml
@@ -7,17 +7,23 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
-    "MPL-2.0"
+    "MPL-2.0",
+    "OpenSSL"
 ]
 copyleft = "warn"
 allow-osi-fsf-free = "neither"
 default = "deny"
 confidence-threshold = 0.9
+exceptions = [
+    { name = "unicode-ident", allow = ["Unicode-DFS-2016"], version = "1.0.3" },
+]
 
-[[licenses.exceptions]]
-allow = ["Unicode-DFS-2016"]
-name = "unicode-ident"
-version = "1.0.3"
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [bans]
 multiple-versions = "deny"

--- a/git2-summarize/Cargo.toml
+++ b/git2-summarize/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "git2-summarize"
+version = "0.1.0"
+authors = ["extrawurst <mail@rusticorn.com>"]
+edition = "2021"
+description = "use openai gpt to summarize git2 diffs"
+homepage = "https://github.com/extrawurst/gitui"
+repository = "https://github.com/extrawurst/gitui"
+documentation = "https://docs.rs/git2-summarize/"
+readme = "README.md"
+license = "MIT"
+categories = ["development-tools"]
+keywords = ["git"]
+
+[dependencies]
+git2 = ">=0.17"
+log = "0.4"
+thiserror = "1.0"
+openai-api-rs = "2.1"

--- a/git2-summarize/LICENSE.md
+++ b/git2-summarize/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/git2-summarize/README.md
+++ b/git2-summarize/README.md
@@ -1,0 +1,3 @@
+# git2-summarize
+
+this uses open ai chat-gpt to summarize a git diff

--- a/git2-summarize/examples/simple.diff
+++ b/git2-summarize/examples/simple.diff
@@ -1,0 +1,49 @@
+diff --git a/git2-hooks/src/lib.rs b/git2-hooks/src/lib.rs
+index 0cf5ac8..042ac87 100644
+--- a/git2-hooks/src/lib.rs
++++ b/git2-hooks/src/lib.rs
+@@ -27,6 +27,7 @@ use git2::Repository;
+ pub const HOOK_POST_COMMIT: &str = "post-commit";
+ pub const HOOK_PRE_COMMIT: &str = "pre-commit";
+ pub const HOOK_COMMIT_MSG: &str = "commit-msg";
++pub const HOOK_PRE_PUSH: &str = "pre-push";
+ 
+ const HOOK_COMMIT_MSG_TEMP_FILE: &str = "COMMIT_EDITMSG";
+ 
+@@ -152,6 +153,36 @@ pub fn hooks_post_commit(
+ 	hook.run_hook(&[])
+ }
+ 
++/// see [`hooks_pre_push`]
++pub enum PrePushHookLocalRef<'a> {
++	Delete,
++	Ref {
++		local_ref: &'a str,
++		local_obj_name: &'a str,
++	},
++}
++
++/// see https://git-scm.com/docs/githooks#_pre_push
++///
++/// # Arguments
++///
++/// * `remote_obj_name` - pass `None` if foreign ref not yet exists
++pub fn hooks_pre_push(
++	repo: &Repository,
++	other_paths: Option<&[&str]>,
++	local_ref: PrePushHookLocalRef,
++	remote_ref: &str,
++	remote_obj_name: Option<&str>,
++) -> Result<HookResult> {
++	let hook = HookPaths::new(repo, other_paths, HOOK_PRE_PUSH)?;
++
++	if !hook.found() {
++		return Ok(HookResult::NoHookFound);
++	}
++
++	hook.run_hook(&[])
++}
++
+ #[cfg(test)]
+ mod tests {
+ 	use super::*;

--- a/git2-summarize/examples/simple.rs
+++ b/git2-summarize/examples/simple.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+fn main() {
+	let diff = include_str!("simple.diff");
+
+	let summary = git2_summarize::git_diff_summarize_old(
+		&env::var("OPENAI_API_KEY").unwrap(),
+		diff,
+	)
+	.unwrap();
+
+	println!("{summary}");
+}

--- a/git2-summarize/examples/simple.rs
+++ b/git2-summarize/examples/simple.rs
@@ -3,9 +3,10 @@ use std::env;
 fn main() {
 	let diff = include_str!("simple.diff");
 
-	let summary = git2_summarize::git_diff_summarize_old(
+	let summary = git2_summarize::git_diff_summarize(
 		&env::var("OPENAI_API_KEY").unwrap(),
 		diff,
+		50,
 	)
 	.unwrap();
 

--- a/git2-summarize/src/lib.rs
+++ b/git2-summarize/src/lib.rs
@@ -1,0 +1,85 @@
+//!	Uses Open API GPT-3 to summarize unified git diffs
+
+use openai_api_rs::v1::{
+	api::Client,
+	chat_completion::{self, ChatCompletionRequest},
+	common::GPT3_5_TURBO,
+	completion::{self, CompletionRequest},
+};
+
+/// Uses old GPT3_TEXT_DAVINCI_003 model to generate message
+///
+///  # Arguments
+///
+/// * `api_key` - open api key
+/// * `diff` - expects a diff formatted as a unified diff
+pub fn git_diff_summarize_old(
+	api_key: &str,
+	diff: &str,
+) -> Result<String, String> {
+	let client = Client::new(api_key.to_string());
+
+	let req = CompletionRequest::new(
+        completion::GPT3_TEXT_DAVINCI_003.to_string(),
+        format!("Generate a Git commit message based on the following summary: {}\n\nCommit message: ",diff),
+    )
+    .max_tokens(500)
+    .temperature(0.5)
+    .n(1);
+
+	let result = client.completion(req).map_err(|e| e.message)?;
+	Ok(result
+		.choices
+		.get(0)
+		.ok_or_else(|| String::from("choises empty"))?
+		.text
+		.clone())
+}
+
+/// Uses GPT3_5_TURBO model to generate message using chat completion API
+///
+///  # Arguments
+///
+/// * `api_key` - open api key
+/// * `diff` - expects a diff formatted as a unified diff
+pub fn git_diff_summarize(
+	api_key: &str,
+	diff: &str,
+	line_length: usize,
+) -> Result<String, String> {
+	let client = Client::new(api_key.to_string());
+
+	let prompt = format!(
+		r#"You are a smart git commit message creator software.
+		Now you are going to create a git commit message.
+		The commit messages you generate aim to explain why the changes were introduced.
+		Write a one-sentence message no longer than {line_length} characters, followed by two newline characters.
+		Create a commit message for these changes:\n{}
+		"#,
+		diff
+	);
+
+	let req = ChatCompletionRequest::new(
+		GPT3_5_TURBO.to_string(),
+		vec![chat_completion::ChatCompletionMessage {
+			role: chat_completion::MessageRole::system,
+			content: prompt,
+			name: None,
+			function_call: None,
+		}],
+	)
+	.max_tokens(200);
+
+	let result =
+		client.chat_completion(req).map_err(|e| e.message)?;
+
+	Ok(result
+		.choices
+		.get(0)
+		.ok_or_else(|| String::from("response.choises empty"))?
+		.message
+		.content
+		.as_ref()
+		.ok_or_else(|| String::from("choise[0].message empty"))?
+		.clone())
+}

--- a/git2-summarize/src/lib.rs
+++ b/git2-summarize/src/lib.rs
@@ -1,40 +1,10 @@
-//!	Uses Open API GPT-3 to summarize unified git diffs
+//! Uses Open API GPT-3 to summarize unified git diffs
 
 use openai_api_rs::v1::{
 	api::Client,
 	chat_completion::{self, ChatCompletionRequest},
 	common::GPT3_5_TURBO,
-	completion::{self, CompletionRequest},
 };
-
-/// Uses old GPT3_TEXT_DAVINCI_003 model to generate message
-///
-///  # Arguments
-///
-/// * `api_key` - open api key
-/// * `diff` - expects a diff formatted as a unified diff
-pub fn git_diff_summarize_old(
-	api_key: &str,
-	diff: &str,
-) -> Result<String, String> {
-	let client = Client::new(api_key.to_string());
-
-	let req = CompletionRequest::new(
-        completion::GPT3_TEXT_DAVINCI_003.to_string(),
-        format!("Generate a Git commit message based on the following summary: {}\n\nCommit message: ",diff),
-    )
-    .max_tokens(500)
-    .temperature(0.5)
-    .n(1);
-
-	let result = client.completion(req).map_err(|e| e.message)?;
-	Ok(result
-		.choices
-		.get(0)
-		.ok_or_else(|| String::from("choises empty"))?
-		.text
-		.clone())
-}
 
 /// Uses GPT3_5_TURBO model to generate message using chat completion API
 ///

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -367,7 +367,7 @@ impl CommitComponent {
 			}
 
 			match git2_summarize::git_diff_summarize(
-				&api_key,
+				api_key,
 				&unified_diff,
 				FIRST_LINE_LIMIT,
 			) {

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -59,6 +59,7 @@ pub struct CommitComponent {
 	commit_msg_history_idx: usize,
 	options: SharedOptions,
 	verify: bool,
+	open_ai_token: Option<String>,
 }
 
 const FIRST_LINE_LIMIT: usize = 50;
@@ -90,6 +91,7 @@ impl CommitComponent {
 			commit_msg_history_idx: 0,
 			options,
 			verify: true,
+			open_ai_token: std::env::var("OPENAI_API_KEY").ok(),
 		}
 	}
 
@@ -352,6 +354,30 @@ impl CommitComponent {
 			self.input.set_text(signed_msg);
 		}
 	}
+
+	fn commit_summarize(&mut self) -> Result<()> {
+		use std::result::Result::Ok;
+
+		if let Some(api_key) = self.open_ai_token.as_ref() {
+			let mut unified_diff =
+				sync::unified_stage_diff(&self.repo.borrow())?;
+
+			while unified_diff.len() > 3500 {
+				unified_diff.pop();
+			}
+
+			match git2_summarize::git_diff_summarize(
+				&api_key,
+				&unified_diff,
+				FIRST_LINE_LIMIT,
+			) {
+				Ok(msg) => self.input.set_text(msg),
+				Err(e) => bail!(e),
+			};
+		}
+
+		Ok(())
+	}
 	fn toggle_verify(&mut self) {
 		self.verify = !self.verify;
 	}
@@ -539,6 +565,14 @@ impl Component for CommitComponent {
 				self.options.borrow().has_commit_msg_history(),
 				true,
 			));
+
+			out.push(CommandInfo::new(
+				strings::commands::commit_msg_summarize(
+					&self.key_config,
+				),
+				self.open_ai_token.is_some(),
+				true,
+			));
 		}
 
 		visibility_blocking(self)
@@ -596,6 +630,15 @@ impl Component for CommitComponent {
 					self.key_config.keys.toggle_signoff,
 				) {
 					self.signoff_commit();
+				} else if key_match(
+					e,
+					self.key_config.keys.commit_msg_summarize,
+				) {
+					try_or_popup!(
+						self,
+						"commit summary error:",
+						self.commit_summarize()
+					);
 				}
 				// stop key event propagation
 				return Ok(EventState::Consumed);

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -120,6 +120,7 @@ pub struct KeysList {
 	pub view_submodule_parent: GituiKeyEvent,
 	pub update_submodule: GituiKeyEvent,
 	pub commit_history_next: GituiKeyEvent,
+	pub commit_msg_summarize: GituiKeyEvent,
 }
 
 #[rustfmt::skip]
@@ -209,6 +210,7 @@ impl Default for KeysList {
 			view_submodule_parent: GituiKeyEvent::new(KeyCode::Char('p'),  KeyModifiers::empty()),
 			update_submodule: GituiKeyEvent::new(KeyCode::Char('u'),  KeyModifiers::empty()),
 			commit_history_next: GituiKeyEvent::new(KeyCode::Char('n'),  KeyModifiers::CONTROL),
+			commit_msg_summarize: GituiKeyEvent::new(KeyCode::Char('g'),  KeyModifiers::CONTROL),
 		}
 	}
 }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -965,6 +965,19 @@ pub mod commands {
 			CMD_GROUP_COMMIT_POPUP,
 		)
 	}
+	pub fn commit_msg_summarize(
+		key_config: &SharedKeyConfig,
+	) -> CommandText {
+		CommandText::new(
+			format!(
+				"Summarize [{}]",
+				key_config
+					.get_hint(key_config.keys.commit_msg_summarize),
+			),
+			"use openai chat-gpt to generate commit message",
+			CMD_GROUP_COMMIT_POPUP,
+		)
+	}
 	pub fn commit_enter(key_config: &SharedKeyConfig) -> CommandText {
 		CommandText::new(
 			format!(


### PR DESCRIPTION
Right now this is not optimized for long diffs. 

ideas: 
- [ ] feed it less context if diff gets >4k
- [ ] feed list of files touched first and then diffs and cut at 4k point