### PR TITLE
strip debug symbols in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ members = ["asyncgit", "filetreelist", "git2-hooks", "git2-testing", "scopetime"
 lto = true
 opt-level = 'z'   # Optimize for size.
 codegen-units = 1
+strip = "debuginfo"
 
 # make debug build as fast as release 
 # usage of utf8 encoding inside tui 


### PR DESCRIPTION
based on: https://kobzol.github.io/rust/cargo/2024/01/23/making-rust-binaries-smaller-by-default.html