### PR TITLE
Allow commiting using template commit message (closes #1921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These defaults require some adoption from existing users but feel more natural t
 
 ### Changed
 * do not allow tagging when `tag.gpgsign` enabled until gpg-signing is [supported](https://github.com/extrawurst/gitui/issues/97) [[@TeFiLeDo](https://github.com/TeFiLeDo)] ([#1915](https://github.com/extrawurst/gitui/pull/1915))
+* allow commiting changes with template commit message ([#1921](https://github.com/extrawurst/gitui/issues/1921)).
 
 ### Fixes
 * stash window empty after file history popup closes ([#1986](https://github.com/extrawurst/gitui/issues/1986))

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -306,7 +306,7 @@ impl CommitComponent {
 	}
 
 	fn can_commit(&self) -> bool {
-		!self.is_empty() && self.is_changed()
+		!self.is_empty() || self.is_template_default()
 	}
 
 	fn can_amend(&self) -> bool {
@@ -322,6 +322,10 @@ impl CommitComponent {
 	fn is_changed(&self) -> bool {
 		Some(self.input.get_text().trim())
 			!= self.commit_template.as_ref().map(|s| s.trim())
+	}
+
+	fn is_template_default(&self) -> bool {
+		self.commit_template.is_some()
 	}
 
 	fn amend(&mut self) -> Result<()> {

--- a/src/components/commit.rs
+++ b/src/components/commit.rs
@@ -306,7 +306,7 @@ impl CommitComponent {
 	}
 
 	fn can_commit(&self) -> bool {
-		!self.is_empty() || self.is_template_default()
+		!self.is_empty()
 	}
 
 	fn can_amend(&self) -> bool {
@@ -322,10 +322,6 @@ impl CommitComponent {
 	fn is_changed(&self) -> bool {
 		Some(self.input.get_text().trim())
 			!= self.commit_template.as_ref().map(|s| s.trim())
-	}
-
-	fn is_template_default(&self) -> bool {
-		self.commit_template.is_some()
 	}
 
 	fn amend(&mut self) -> Result<()> {


### PR DESCRIPTION
This Pull Request fixes/closes #1921.

It changes the following:
- Removes the check that the commit message is different from the template message
-

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [ ] I tested the overall application.
I tested the commit part only.
- [x] I added an appropriate item to the changelog