### PR TITLE
Add support for copy/cut/paste to textinput box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["git", "gui", "cli", "terminal", "ui"]
 
 [dependencies]
 anyhow = "1.0"
+arboard = "3.3.1"
 asyncgit = { path = "./asyncgit", version = "0.24", default-features = false }
 backtrace = "0.3"
 bitflags = "2.4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,9 +54,10 @@ use std::{
 	cell::{Cell, RefCell},
 	path::{Path, PathBuf},
 	rc::Rc,
+	sync::atomic::AtomicBool,
 };
 use unicode_width::UnicodeWidthStr;
-
+pub static ENABLE_HARD_EXIT: AtomicBool = AtomicBool::new(true);
 #[derive(Clone)]
 pub enum QuitState {
 	None,
@@ -546,7 +547,10 @@ impl App {
 
 	fn check_hard_exit(&mut self, ev: &Event) -> bool {
 		if let Event::Key(e) = ev {
-			if key_match(e, self.key_config.keys.exit) {
+			if ENABLE_HARD_EXIT
+				.load(std::sync::atomic::Ordering::Relaxed)
+				&& key_match(e, self.key_config.keys.exit)
+			{
 				self.do_quit = QuitState::Close;
 				return true;
 			}

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -122,6 +122,9 @@ pub struct KeysList {
 	pub commit_history_next: GituiKeyEvent,
 	pub commit: GituiKeyEvent,
 	pub newline: GituiKeyEvent,
+	pub edit_cut: GituiKeyEvent,
+	pub edit_copy: GituiKeyEvent,
+	pub edit_paste: GituiKeyEvent,
 }
 
 #[rustfmt::skip]
@@ -213,6 +216,9 @@ impl Default for KeysList {
 			commit_history_next: GituiKeyEvent::new(KeyCode::Char('n'),  KeyModifiers::CONTROL),
 			commit: GituiKeyEvent::new(KeyCode::Char('d'),  KeyModifiers::CONTROL),
 			newline: GituiKeyEvent::new(KeyCode::Enter,  KeyModifiers::empty()),
+			edit_cut: GituiKeyEvent::new(KeyCode::Char('x'),  KeyModifiers::CONTROL),
+			edit_copy: GituiKeyEvent::new(KeyCode::Char('c'),  KeyModifiers::CONTROL),
+			edit_paste: GituiKeyEvent::new(KeyCode::Char('v'),  KeyModifiers::CONTROL),
 		}
 	}
 }


### PR DESCRIPTION
PR for #2057 

Notes:
- I added arboard for clipboard read (I need read) and write. I should probably replace the clipboard read code that you already have
- arboard uses a license that you dont approve in deny.toml
- I added key defs , they default to ctrl-c, ctrl-x, ctrl-v
- for ctrl-c I added code to turn off ctrl-c = exit while the textbox is displayed

Paste is complicated
- on windows no matter how hard you try you cannot get windows terminal to not capture ctrl-v, there are bugs open to MSFT on it but nobody has done anything about it
- windows then just types the text into the screen for you. Thats mainly OK but not in the case where you try to paste multiple lines. In the default gitui configuration, where Enter means commit, when windows types the newline (when pasting multiple lines) gitui commits . Which is a surprise and it took me a while to work out what was going on. 
- This is an issue without this PR. Pasting multiple lines using the OS functionality - same happens on a mac using command v
- this PR enters the text, including line breaks into the textarea, if it gets the key combination
- command - v still blindly types into the box on mac, ctrl-v works fine
- ctrl-v on windows does the same thing (blind type) - I have tested that ctrl-p (in key config) works fine.
- on linux ctrl-v seems to work fine, the PR sees the keystroke and does the right thing

