### PR TITLE
Added Nightly Release Workflow + Tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,9 +95,9 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
       run: |
-        aws s3 cp ./release/gitui-linux-armv7.tar.gz s3://"$AWS_BUCKET_NAME"
-        aws s3 cp ./release/gitui-linux-arm.tar.gz s3://"$AWS_BUCKET_NAME"
-        aws s3 cp ./release/gitui-linux-aarch64.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-linux-armv7.tar.gz s3://"$AWS_BUCKET_NAME"/nightly-builds/
+        aws s3 cp ./release/gitui-linux-arm.tar.gz s3://"$AWS_BUCKET_NAME"/nightly-builds/
+        aws s3 cp ./release/gitui-linux-aarch64.tar.gz s3://"$AWS_BUCKET_NAME"/nightly-builds/
           
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
@@ -107,7 +107,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
       run: |
-        aws s3 cp ./release/gitui-linux-musl.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-linux-musl.tar.gz s3://"$AWS_BUCKET_NAME"/nightly-builds/
       
 
     - name: MacOS Upload Artifact
@@ -118,7 +118,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
       run: |
-        aws s3 cp ./release/gitui-mac.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-mac.tar.gz s3://"$AWS_BUCKET_NAME"/nightly-builds/
 
     - name: Windows Upload Artifact
       if: matrix.os == 'windows-latest' 
@@ -128,5 +128,5 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
       run: |
-        aws s3 cp ./release/gitui.msi s3://"$env:AWS_BUCKET_NAME"
-        aws s3 cp ./release/gitui-win.tar.gz s3://"$env:AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui.msi s3://"$env:AWS_BUCKET_NAME"/nightly-builds/
+        aws s3 cp ./release/gitui-win.tar.gz s3://"$env:AWS_BUCKET_NAME"/nightly-builds/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,7 @@
 # .github/workflows/build.yml
 name: nightly
 
-on: workflow_call
-
+on: workflow_dispatch
 jobs:
   release:
     name: nightly release ${{ matrix.target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,7 @@
 # .github/workflows/build.yml
 name: nightly
 
-on:
-  schedule:
-    - cron: '0 2 * * *'
-  workflow_call:
+on: workflow_call
 
 jobs:
   release:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: nightly
 
 on:
   schedule:
-    - cron: '35 14 * * *' # run at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_call:
 
 jobs:
   release:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@
 name: nightly
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '35 14 * * *' # run at 2 AM UTC
 
 jobs:
   release:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,7 @@ jobs:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ secrets.AWS_BUCKET }}
-          source_dir: './release/gitui-linux-arm.tar.gz'
+          source_dir: './release'
           
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
@@ -103,7 +103,7 @@ jobs:
          aws_key_id: ${{ secrets.AWS_KEY_ID }}
          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
          aws_bucket: ${{ secrets.AWS_BUCKET }}
-         source_dir: './release/gitui-linux-musl.tar.gz'
+         source_dir: './release'
     
     - name: MacOS Upload Artifact
       if: matrix.os == 'macos-latest'  
@@ -112,7 +112,7 @@ jobs:
         aws_key_id: ${{ secrets.AWS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
         aws_bucket: ${{ secrets.AWS_BUCKET }}
-        source_dir: './release/*.tar.gz'
+        source_dir: './release'
 
     - name: Windows Upload Artifact
       if: matrix.os == 'windows-latest' 
@@ -121,4 +121,4 @@ jobs:
         aws_key_id: ${{ secrets.AWS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
         aws_bucket: ${{ secrets.AWS_BUCKET }}
-        source_dir: './release/*.msi'
+        source_dir: './release'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,6 +94,7 @@ jobs:
       with:
         body: ${{ steps.release_notes.outputs.release_notes }}
         prerelease: true
+        tag_name: "nightly"
         files: |
           ./release/*.tar.gz
           ./release/*.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,36 +89,44 @@ jobs:
 
     - name: Ubuntu 22.04 Upload Artifact
       if: matrix.os == 'ubuntu-22.04'
-      uses: shallwefootball/s3-upload-action@master
-      with:
-          aws_key_id: ${{ secrets.AWS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-          aws_bucket: ${{ secrets.AWS_BUCKET }}
-          source_dir: './release'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      run: |
+        aws s3 cp ./release/gitui-linux-armv7.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-linux-arm.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-linux-aarch64.tar.gz s3://"$AWS_BUCKET_NAME"
           
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
-      uses: shallwefootball/s3-upload-action@master
-      with:
-         aws_key_id: ${{ secrets.AWS_KEY_ID }}
-         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-         aws_bucket: ${{ secrets.AWS_BUCKET }}
-         source_dir: './release'
-    
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      run: |
+        aws s3 cp ./release/gitui-linux-musl.tar.gz s3://"$AWS_BUCKET_NAME"
+      
+
     - name: MacOS Upload Artifact
       if: matrix.os == 'macos-latest'  
-      uses: shallwefootball/s3-upload-action@master
-      with:
-        aws_key_id: ${{ secrets.AWS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-        aws_bucket: ${{ secrets.AWS_BUCKET }}
-        source_dir: './release'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      run: |
+        aws s3 cp ./release/gitui-mac.tar.gz s3://"$AWS_BUCKET_NAME"
 
     - name: Windows Upload Artifact
       if: matrix.os == 'windows-latest' 
-      uses: shallwefootball/s3-upload-action@master
-      with:
-        aws_key_id: ${{ secrets.AWS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-        aws_bucket: ${{ secrets.AWS_BUCKET }}
-        source_dir: './release'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      run: |
+        aws s3 cp ./release/gitui.msi s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-win.tar.gz s3://"$AWS_BUCKET_NAME"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,27 +1,165 @@
-# .github/workflows/build.yml
-name: nightly
-
+name: Build Nightly Releases
 on: workflow_dispatch
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  release:
-    name: nightly release ${{ matrix.target }}
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [nightly, stable, '1.65']
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        shared-key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
+
+    - name: MacOS Workaround
+      if: matrix.os == 'macos-latest'
+      run: cargo clean -p serde_derive -p thiserror
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        components: clippy
+
+    - name: Build Debug
+      run: |
+        cargo build
+
+    - name: Run tests
+      run: make test
+
+    - name: Run clippy
+      run: |
+        make clippy
+
+    - name: Build Release
+      run: make build-release
+
+    - name: Test Install
+      run: cargo install --path "." --force --locked
+
+    - name: Binary Size (unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        ls -l ./target/release/gitui
+
+    - name: Binary Size (win)
+      if: matrix.os == 'windows-latest'
+      run: |
+        ls -l ./target/release/gitui.exe
+
+    - name: Binary dependencies (mac)
+      if: matrix.os == 'macos-latest'
+      run: |
+        otool -L ./target/release/gitui
+
+    - name: Build MSI (windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cargo install cargo-wix --version 0.3.3
+        cargo wix --version
+        cargo wix -p gitui --no-build --nocapture --output ./target/wix/gitui.msi
+        ls -l ./target/wix/gitui.msi
+
+  build-linux-musl:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: x86_64-pc-windows-gnu
-            archive: zip
-          - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz tar.zst
-          - target: x86_64-apple-darwin
-            archive: zip
+        rust: [nightly, stable, '1.65']
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_TYPES: ${{ matrix.archive }}
+    - uses: actions/checkout@v4
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        targets: x86_64-unknown-linux-musl
+    
+    # The build would fail without manually installing the target.
+    # https://github.com/dtolnay/rust-toolchain/issues/83
+    - name: Manually install target
+      run: rustup target add x86_64-unknown-linux-musl
+
+    - name: Setup MUSL
+      run: |
+        sudo apt-get -qq install musl-tools
+    - name: Build Debug
+      run: |
+        make build-linux-musl-debug
+        ./target/x86_64-unknown-linux-musl/debug/gitui --version
+    - name: Build Release
+      run: |
+        make build-linux-musl-release
+        ./target/x86_64-unknown-linux-musl/release/gitui --version
+        ls -l ./target/x86_64-unknown-linux-musl/release/gitui
+    - name: Test
+      run: |
+        make test-linux-musl
+    - name: Test Install
+      run: cargo install --path "." --force --locked
+
+  build-linux-arm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly, stable, '1.65']
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Restore cargo cache
+      uses: Swatinem/rust-cache@v2
+      env:
+        cache-name: ci
+      with:
+        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    - name: Setup ARM toolchain
+      run: |
+        rustup target add aarch64-unknown-linux-gnu
+        rustup target add armv7-unknown-linux-gnueabihf
+        rustup target add arm-unknown-linux-gnueabihf
+
+        curl -o $GITHUB_WORKSPACE/aarch64.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz
+        curl -o $GITHUB_WORKSPACE/arm.tar.xz https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/8.2-2018.08/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz
+
+        tar xf $GITHUB_WORKSPACE/aarch64.tar.xz
+        tar xf $GITHUB_WORKSPACE/arm.tar.xz
+
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf/bin" >> $GITHUB_PATH
+
+    - name: Build Debug
+      run: |
+        make build-linux-arm-debug
+    - name: Build Release
+      run: |
+        make build-linux-arm-release
+        ls -l ./target/aarch64-unknown-linux-gnu/release/gitui || ls -l ./target/armv7-unknown-linux-gnueabihf/release/gitui || ls -l ./target/arm-unknown-linux-gnueabihf/release/gitui

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,7 @@ jobs:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ secrets.AWS_BUCKET }}
-          source_dir: './release/*.tar.gz'
+          source_dir: './release/gitui-linux-arm.tar.gz'
           
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
@@ -103,7 +103,7 @@ jobs:
          aws_key_id: ${{ secrets.AWS_KEY_ID }}
          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
          aws_bucket: ${{ secrets.AWS_BUCKET }}
-         source_dir: './release/*.tar.gz'
+         source_dir: './release/gitui-linux-musl.tar.gz'
     
     - name: MacOS Upload Artifact
       if: matrix.os == 'macos-latest'  

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,7 @@ jobs:
 
 
     - name: List Folder
-      uses: philips-labs/list-folders-action@v1
+      uses: kmanimaran/list-folder-action@v4
       with:
         path: ./release
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,15 +86,32 @@ jobs:
       id: shasum
       run: |
         echo sha="$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')" >> $GITHUB_OUTPUT
-  
-    - name: Nightly-Release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+    - name: Ubuntu 22.04 Upload Artifact
+      if: matrix.os != 'ubuntu-22.04'
+      uses: actions/upload-artifact@v4
       with:
-        prerelease: true
-        tag_name: "nightly"
-        files: |
-          ./release/*.tar.gz
-          ./release/*.zip
-          ./release/*.msi
+        name: 'ubuntu-22.04'
+        path: ./release/*.zip
+
+    - name: Ubuntu Latest Upload Artifact
+      if: matrix.os != 'ubuntu-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'ubuntu-latest'
+        path: ./release/*.zip
+    
+    - name: MacOS Upload Artifact
+      if: matrix.os == 'macos-latest'  
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'macos-latest'
+        path: ./release/*.tar.gz
+        
+    - name: Windows Upload Artifact
+      if: matrix.os == 'windows-latest' 
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'windows-latest'
+        path: ./release/*.msi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        body: ${{ steps.release_notes.outputs.release_notes }}
         prerelease: true
         tag_name: "nightly"
         files: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,14 +89,14 @@ jobs:
 
 
     - name: Ubuntu 22.04 Upload Artifact
-      if: matrix.os != 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-22.04'
       uses: actions/upload-artifact@v4
       with:
         name: 'ubuntu-22.04'
         path: ./release/*.zip
 
     - name: Ubuntu Latest Upload Artifact
-      if: matrix.os != 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
         name: 'ubuntu-latest'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,30 @@
+# .github/workflows/build.yml
+name: nightly
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: nightly release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz tar.xz tar.zst
+          - target: x86_64-apple-darwin
+            archive: zip
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@v1.4.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          RUSTTARGET: ${{ matrix.target }}
+          ARCHIVE_TYPES: ${{ matrix.archive }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,30 +88,44 @@ jobs:
         echo sha="$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')" >> $GITHUB_OUTPUT
 
 
+    - name: List Folder
+      uses: philips-labs/list-folders-action@v1
+      with:
+        path: ./release
+
+
     - name: Ubuntu 22.04 Upload Artifact
       if: matrix.os == 'ubuntu-22.04'
-      uses: actions/upload-artifact@v4
+      uses: shallwefootball/s3-upload-action@master
       with:
-        name: 'ubuntu-22.04'
-        path: ./release/*.zip
-
+          aws_key_id: ${{ secrets.AWS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ secrets.AWS_BUCKET }}
+          source_dir: './release/*.zip'
+          
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v4
+      uses: shallwefootball/s3-upload-action@master
       with:
-        name: 'ubuntu-latest'
-        path: ./release/*.zip
+         aws_key_id: ${{ secrets.AWS_KEY_ID }}
+         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+         aws_bucket: ${{ secrets.AWS_BUCKET }}
+         source_dir: './release/*.zip'
     
     - name: MacOS Upload Artifact
       if: matrix.os == 'macos-latest'  
-      uses: actions/upload-artifact@v4
+      uses: shallwefootball/s3-upload-action@master
       with:
-        name: 'macos-latest'
-        path: ./release/*.tar.gz
-        
+        aws_key_id: ${{ secrets.AWS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+        aws_bucket: ${{ secrets.AWS_BUCKET }}
+        source_dir: './release/*.tar.gz'
+
     - name: Windows Upload Artifact
       if: matrix.os == 'windows-latest' 
-      uses: actions/upload-artifact@v4
+      uses: shallwefootball/s3-upload-action@master
       with:
-        name: 'windows-latest'
-        path: ./release/*.msi
+        aws_key_id: ${{ secrets.AWS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+        aws_bucket: ${{ secrets.AWS_BUCKET }}
+        source_dir: './release/*.msi'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,13 +87,6 @@ jobs:
       run: |
         echo sha="$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')" >> $GITHUB_OUTPUT
 
-
-    - name: List Folder
-      uses: kmanimaran/list-folder-action@v4
-      with:
-        path: ./release
-
-
     - name: Ubuntu 22.04 Upload Artifact
       if: matrix.os == 'ubuntu-22.04'
       uses: shallwefootball/s3-upload-action@master
@@ -101,7 +94,7 @@ jobs:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ secrets.AWS_BUCKET }}
-          source_dir: './release/*.zip'
+          source_dir: './release/*.tar.gz'
           
     - name: Ubuntu Latest Upload Artifact
       if: matrix.os == 'ubuntu-latest'
@@ -110,7 +103,7 @@ jobs:
          aws_key_id: ${{ secrets.AWS_KEY_ID }}
          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
          aws_bucket: ${{ secrets.AWS_BUCKET }}
-         source_dir: './release/*.zip'
+         source_dir: './release/*.tar.gz'
     
     - name: MacOS Upload Artifact
       if: matrix.os == 'macos-latest'  

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,147 +1,59 @@
 name: Build Nightly Releases
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # run at 0 AM UTC
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  release:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [nightly, stable, '1.65']
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Get version
+      id: get_version
+      run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
     - name: Restore cargo cache
       uses: Swatinem/rust-cache@v2
       env:
         cache-name: ci
       with:
-        shared-key: ${{ matrix.os }}-${{ env.cache-name }}-${{ matrix.rust }}
-
-    - name: MacOS Workaround
-      if: matrix.os == 'macos-latest'
-      run: cargo clean -p serde_derive -p thiserror
+        shared-key: ${{ matrix.os }}-${{ env.cache-name }}-stable
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: ${{ matrix.rust }}
         components: clippy
 
-    - name: Build Debug
-      run: |
-        cargo build
-
+    - name: Build
+      if: matrix.os != 'ubuntu-22.04'
+      run: cargo build
     - name: Run tests
+      if: matrix.os != 'ubuntu-22.04'
       run: make test
-
     - name: Run clippy
+      if: matrix.os != 'ubuntu-22.04'
       run: |
+        cargo clean
         make clippy
 
-    - name: Build Release
-      run: make build-release
-
-    - name: Test Install
-      run: cargo install --path "." --force --locked
-
-    - name: Binary Size (unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        ls -l ./target/release/gitui
-
-    - name: Binary Size (win)
-      if: matrix.os == 'windows-latest'
-      run: |
-        ls -l ./target/release/gitui.exe
-
-    - name: Binary dependencies (mac)
-      if: matrix.os == 'macos-latest'
-      run: |
-        otool -L ./target/release/gitui
-
-    - name: Build MSI (windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        cargo install cargo-wix --version 0.3.3
-        cargo wix --version
-        cargo wix -p gitui --no-build --nocapture --output ./target/wix/gitui.msi
-        ls -l ./target/wix/gitui.msi
-
-  build-linux-musl:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [nightly, stable, '1.65']
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Restore cargo cache
-      uses: Swatinem/rust-cache@v2
-      env:
-        cache-name: ci
-      with:
-        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
-        targets: x86_64-unknown-linux-musl
-    
-    # The build would fail without manually installing the target.
-    # https://github.com/dtolnay/rust-toolchain/issues/83
-    - name: Manually install target
-      run: rustup target add x86_64-unknown-linux-musl
-
     - name: Setup MUSL
+      if: matrix.os == 'ubuntu-latest'
       run: |
+        rustup target add x86_64-unknown-linux-musl
         sudo apt-get -qq install musl-tools
-    - name: Build Debug
-      run: |
-        make build-linux-musl-debug
-        ./target/x86_64-unknown-linux-musl/debug/gitui --version
-    - name: Build Release
-      run: |
-        make build-linux-musl-release
-        ./target/x86_64-unknown-linux-musl/release/gitui --version
-        ls -l ./target/x86_64-unknown-linux-musl/release/gitui
-    - name: Test
-      run: |
-        make test-linux-musl
-    - name: Test Install
-      run: cargo install --path "." --force --locked
 
-  build-linux-arm:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [nightly, stable, '1.65']
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Restore cargo cache
-      uses: Swatinem/rust-cache@v2
-      env:
-        cache-name: ci
-      with:
-        key: ubuntu-latest-${{ env.cache-name }}-${{ matrix.rust }}
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
     - name: Setup ARM toolchain
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         rustup target add aarch64-unknown-linux-gnu
         rustup target add armv7-unknown-linux-gnueabihf
@@ -156,10 +68,33 @@ jobs:
         echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu/bin" >> $GITHUB_PATH
         echo "$GITHUB_WORKSPACE/gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf/bin" >> $GITHUB_PATH
 
-    - name: Build Debug
+    - name: Build Release Mac
+      if: matrix.os == 'macos-latest'
+      run: make release-mac
+    - name: Build Release Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: make release-linux-musl
+    - name: Build Release Win
+      if: matrix.os == 'windows-latest'
+      run: make release-win
+    - name: Build Release Linux ARM
+      if: matrix.os == 'ubuntu-22.04'
+      run: make release-linux-arm
+
+    - name: Set SHA
+      if: matrix.os == 'macos-latest'
+      id: shasum
       run: |
-        make build-linux-arm-debug
-    - name: Build Release
-      run: |
-        make build-linux-arm-release
-        ls -l ./target/aarch64-unknown-linux-gnu/release/gitui || ls -l ./target/armv7-unknown-linux-gnueabihf/release/gitui || ls -l ./target/arm-unknown-linux-gnueabihf/release/gitui
+        echo sha="$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')" >> $GITHUB_OUTPUT
+  
+    - name: Nightly-Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        body: ${{ steps.release_notes.outputs.release_notes }}
+        prerelease: true
+        files: |
+          ./release/*.tar.gz
+          ./release/*.zip
+          ./release/*.msi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,5 +128,5 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
       run: |
-        aws s3 cp ./release/gitui.msi s3://"$AWS_BUCKET_NAME"
-        aws s3 cp ./release/gitui-win.tar.gz s3://"$AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui.msi s3://"$env:AWS_BUCKET_NAME"
+        aws s3 cp ./release/gitui-win.tar.gz s3://"$env:AWS_BUCKET_NAME"


### PR DESCRIPTION
This Pull Request fixes/closes #2083.

Added nightly.yml to .github/workflows, which is scheduled to run at Midnight UTC & is manually triggerable. it is based off the cd.yml. I have I tested it & it succesfully creates the nightly release with tag & it is marked as a pre-release.

![image](https://github.com/extrawurst/gitui/assets/113200622/50665d43-bb58-48f3-b297-ce9365077e0c)

I followed the checklist:
- [ ] I added unittests - N/A
- [ ] I ran `make check` without errors - N/A
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog