### PR TITLE
Remove unused clippy warning suppression (missing_const_for_fn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* re-enable clippy `missing_const_for_fn` linter warning
+
 ## [0.25.1] - 2024-02-23
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* re-enable clippy `missing_const_for_fn` linter warning
+* re-enable clippy `missing_const_for_fn` linter warning and added const to functions where applicable ([#2116](https://github.com/extrawurst/gitui/issues/2116))
 
 ## [0.25.1] - 2024-02-23
 

--- a/asyncgit/src/sync/commit_details.rs
+++ b/asyncgit/src/sync/commit_details.rs
@@ -82,8 +82,6 @@ pub struct CommitDetails {
 
 impl CommitDetails {
 	///
-	#[allow(clippy::missing_const_for_fn)]
-	// clippy doesn't realise indexing a String is not const
 	pub fn short_hash(&self) -> &str {
 		&self.hash[0..7]
 	}

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -20,8 +20,6 @@ pub struct Tag {
 
 impl Tag {
 	///
-	#[allow(clippy::missing_const_for_fn)]
-	// clippy doesn't realise allocating a String is not const
 	pub fn new(name: &str) -> Self {
 		Self {
 			name: name.into(),

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -296,7 +296,6 @@ impl CommitList {
 		self.current_size.get()
 	}
 
-	#[allow(clippy::missing_const_for_fn)]
 	fn selection_max(&self) -> usize {
 		self.commits.len().saturating_sub(1)
 	}
@@ -664,7 +663,6 @@ impl CommitList {
 		})
 	}
 
-	#[allow(clippy::missing_const_for_fn)]
 	fn relative_selection(&self) -> usize {
 		self.selection.saturating_sub(self.items.index_offset())
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@
 	clippy::bool_to_int_with_if,
 	clippy::module_name_repetitions
 )]
-// high number of false positives on nightly (as of Oct 2022 with 1.66.0-nightly)
-#![allow(clippy::missing_const_for_fn)]
 
 //TODO:
 // #![deny(clippy::expect_used)]

--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -45,11 +45,11 @@ impl SyntaxFileBlame {
 		&self.file_blame.path
 	}
 
-	fn commit_id(&self) -> &CommitId {
+	const fn commit_id(&self) -> &CommitId {
 		&self.file_blame.commit_id
 	}
 
-	fn lines(&self) -> &Vec<(Option<BlameHunk>, String)> {
+	const fn lines(&self) -> &Vec<(Option<BlameHunk>, String)> {
 		&self.file_blame.lines
 	}
 }
@@ -64,7 +64,7 @@ enum BlameProcess {
 }
 
 impl BlameProcess {
-	fn result(&self) -> Option<&SyntaxFileBlame> {
+	const fn result(&self) -> Option<&SyntaxFileBlame> {
 		match self {
 			Self::GettingBlame(_) => None,
 			Self::SyntaxHighlighting {
@@ -386,7 +386,7 @@ impl BlameFilePopup {
 	}
 
 	///
-	pub fn any_work_pending(&self) -> bool {
+	pub const fn any_work_pending(&self) -> bool {
 		self.blame.is_some()
 			&& !matches!(self.blame, Some(BlameProcess::Result(_)))
 	}

--- a/src/popups/log_search.rs
+++ b/src/popups/log_search.rs
@@ -267,7 +267,7 @@ impl LogSearchPopupPopup {
 		]
 	}
 
-	fn option_selected(&self) -> bool {
+	const fn option_selected(&self) -> bool {
 		!matches!(self.selection, Selection::EnterText)
 	}
 

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -342,7 +342,7 @@ impl Revlog {
 		}
 	}
 
-	fn is_in_search_mode(&self) -> bool {
+	const fn is_in_search_mode(&self) -> bool {
 		!matches!(self.search, LogSearch::Off)
 	}
 
@@ -396,7 +396,7 @@ impl Revlog {
 		);
 	}
 
-	fn can_close_search(&self) -> bool {
+	const fn can_close_search(&self) -> bool {
 		self.is_in_search_mode() && !self.is_search_pending()
 	}
 

--- a/src/ui/scrolllist.rs
+++ b/src/ui/scrolllist.rs
@@ -34,7 +34,6 @@ where
 		}
 	}
 
-	#[allow(clippy::missing_const_for_fn)]
 	fn block(mut self, block: Block<'b>) -> Self {
 		self.block = Some(block);
 		self

--- a/src/ui/stateful_paragraph.rs
+++ b/src/ui/stateful_paragraph.rs
@@ -89,7 +89,6 @@ impl<'a> StatefulParagraph<'a> {
 		}
 	}
 
-	#[allow(clippy::missing_const_for_fn)]
 	pub fn block(mut self, block: Block<'a>) -> Self {
 		self.block = Some(block);
 		self

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -143,7 +143,11 @@ impl Theme {
 		self.apply_select(style, selected)
 	}
 
-	fn apply_select(&self, style: Style, selected: bool) -> Style {
+	const fn apply_select(
+		&self,
+		style: Style,
+		selected: bool,
+	) -> Style {
 		if selected {
 			style.bg(self.selection_bg).fg(self.selection_fg)
 		} else {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes [2116](https://github.com/extrawurst/gitui/issues/2116)

It changes the following:
- Clippy now emits the missing_const_for_fn warning
- `const` has been applied in applicable functions

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog