### PR TITLE
Make MsgPopup scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * re-enable clippy `missing_const_for_fn` linter warning and added const to functions where applicable ([#2116](https://github.com/extrawurst/gitui/issues/2116))
-* Make info and error message popups scrollable ([#1138](https://github.com/extrawurst/gitui/issues/1138))
+* Make info and error message popups scrollable [[@MichaelAug](https://github.com/MichaelAug)] ([#1138](https://github.com/extrawurst/gitui/issues/1138))
 
 ## [0.25.1] - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * re-enable clippy `missing_const_for_fn` linter warning and added const to functions where applicable ([#2116](https://github.com/extrawurst/gitui/issues/2116))
+* Make info and error message popups scrollable ([#1138](https://github.com/extrawurst/gitui/issues/1138))
 
 ## [0.25.1] - 2024-02-23
 

--- a/src/popups/msg.rs
+++ b/src/popups/msg.rs
@@ -49,17 +49,22 @@ impl DrawableComponent for MsgPopup {
 			.lines()
 			.map(str::len)
 			.max()
-			.expect("Expected at least one line in the message")
+			.unwrap_or(0)
 			.saturating_add(BORDER_WIDTH.into())
 			.clamp(MINIMUM_WIDTH.into(), max_width.into())
 			.try_into()
 			.expect("can't fail because we're clamping to u16 value");
 
-		self.current_width.set(width);
 
-		let wrapped_msg = bwrap::wrap!(
+		let area =
+			ui::centered_rect_absolute(width, POPUP_HEIGHT, f.size());
+
+		self.current_width.set(area.width);
+
+		// Wrap lines and break words if there is not enough space
+		let wrapped_msg = bwrap::wrap_maybrk!(
 			&self.msg,
-			width.saturating_sub(BORDER_WIDTH).into()
+			area.width.saturating_sub(BORDER_WIDTH).into()
 		);
 
 		let msg_lines: Vec<String> =
@@ -84,9 +89,6 @@ impl DrawableComponent for MsgPopup {
 				)])
 			})
 			.collect::<Vec<Line>>();
-
-		let area =
-			ui::centered_rect_absolute(width, POPUP_HEIGHT, f.size());
 
 		f.render_widget(Clear, area);
 		f.render_widget(

--- a/src/popups/msg.rs
+++ b/src/popups/msg.rs
@@ -1,5 +1,3 @@
-use std::cell::Cell;
-
 use crate::components::{
 	visibility_blocking, CommandBlocking, CommandInfo, Component,
 	DrawableComponent, EventState, ScrollType, VerticalScroll,
@@ -28,7 +26,6 @@ pub struct MsgPopup {
 	theme: SharedTheme,
 	key_config: SharedKeyConfig,
 	scroll: VerticalScroll,
-	current_width: Cell<u16>,
 }
 
 const POPUP_HEIGHT: u16 = 25;
@@ -55,11 +52,8 @@ impl DrawableComponent for MsgPopup {
 			.try_into()
 			.expect("can't fail because we're clamping to u16 value");
 
-
 		let area =
 			ui::centered_rect_absolute(width, POPUP_HEIGHT, f.size());
-
-		self.current_width.set(area.width);
 
 		// Wrap lines and break words if there is not enough space
 		let wrapped_msg = bwrap::wrap_maybrk!(
@@ -183,7 +177,6 @@ impl MsgPopup {
 			theme: env.theme.clone(),
 			key_config: env.key_config.clone(),
 			scroll: VerticalScroll::new(),
-			current_width: Cell::new(0),
 		}
 	}
 


### PR DESCRIPTION
This Pull Request fixes/closes #1138.

It changes the following:
- Adds scrolling for tag annotations by adding scrolling to MsgPopups which are used to display tag annotations.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog