### PR TITLE
fix: index out of bounds when blaming a file ending with a blank line

### DIFF
--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -572,7 +572,8 @@ impl BlameFilePopup {
 			.iter()
 			.map(|l| l.1.clone())
 			.collect::<Vec<_>>();
-		let text = tabs_to_spaces(raw_lines.join("\n"));
+		let mut text = tabs_to_spaces(raw_lines.join("\n"));
+		text.push('\n');
 
 		job.spawn(AsyncSyntaxJob::new(
 			text,


### PR DESCRIPTION

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2130.

It changes the following:
- Fix index out-of-bound error when blaming a file ending with a blank line

**More details**:

The highlighting procedure works on a single line. It called `str::lines` to split the code into lines. The `str::lines` used `split_inclusive` internally, which omits the ending blank line (https://github.com/rust-lang/rust/issues/111457). So, to overcome that, I added a blank line to the unstyled blame text.

I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [ ] I added an appropriate item to the changelog