### PR TITLE
fix: 2114. Going to Files from Details -> Inspect or Diff is not working

### DIFF
--- a/src/popups/inspect_commit.rs
+++ b/src/popups/inspect_commit.rs
@@ -23,6 +23,8 @@ use ratatui::{
 	Frame,
 };
 
+use super::FileTreeOpen;
+
 #[derive(Clone, Debug)]
 pub struct InspectCommitOpen {
 	pub commit_id: CommitId,
@@ -169,6 +171,24 @@ impl Component for InspectCommitPopup {
 				} else if key_match(e, self.key_config.keys.move_left)
 				{
 					self.hide_stacked(false);
+				} else if key_match(
+					e,
+					self.key_config.keys.open_file_tree,
+				) {
+					if let Some(commit_id) = self
+						.open_request
+						.as_ref()
+						.map(|open_commit| open_commit.commit_id)
+					{
+						self.hide_stacked(true);
+						self.queue.push(InternalEvent::OpenPopup(
+							StackablePopupOpen::FileTree(
+								FileTreeOpen::new(commit_id),
+							),
+						));
+						return Ok(EventState::Consumed);
+					}
+					return Ok(EventState::NotConsumed);
 				}
 
 				return Ok(EventState::Consumed);


### PR DESCRIPTION
This Pull Request fixes/closes #2114.

The changes done are just reverting the deleted lines from https://github.com/extrawurst/gitui/commit/7dcf93e0b279a7f09a98b44fee88430afa09e149.

There was an idea to open a file at revision using a temp file. Let's discuss it further so I can add it to this PR.

It changes the following:
- new event processed (open_file_tree) in InspectCommitPopup (while inspecting a commit)

I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [ ] I added an appropriate item to the changelog