### PR TITLE
Cargo Clippy Errors Fixed

### DIFF
--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -756,7 +756,7 @@ mod tests {
 		if let Some(ta) = &mut comp.textarea {
 			let txt = ta.lines();
 			assert_eq!(txt[0].len(), 1);
-			assert_eq!(txt[0].as_bytes()[0], 'a' as u8);
+			assert_eq!(txt[0].as_bytes()[0], b'a');
 		}
 	}
 

--- a/src/components/utils/filetree.rs
+++ b/src/components/utils/filetree.rs
@@ -404,9 +404,9 @@ mod tests {
 		)
 		.unwrap();
 
-		assert_eq!(res.multiple_items_at_path(0), false);
-		assert_eq!(res.multiple_items_at_path(1), false);
-		assert_eq!(res.multiple_items_at_path(2), true);
+		assert!(!res.multiple_items_at_path(0));
+		assert!(!res.multiple_items_at_path(1));
+		assert!(res.multiple_items_at_path(2));
 	}
 
 	#[test]

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -509,10 +509,7 @@ mod tests {
 				false, //
 			]
 		);
-		assert_eq!(
-			res.is_visible_index(res.selection.unwrap()),
-			true
-		);
+		assert!(res.is_visible_index(res.selection.unwrap()));
 		assert_eq!(res.selection, Some(0));
 	}
 

--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -197,8 +197,7 @@ impl Component for BlameFilePopup {
 		let has_result = self
 			.blame
 			.as_ref()
-			.map(|blame| blame.result().is_some())
-			.unwrap_or_default();
+			.is_some_and(|blame| blame.result().is_some());
 		if self.is_visible() || force_all {
 			out.push(
 				CommandInfo::new(

--- a/src/ui/reflow.rs
+++ b/src/ui/reflow.rs
@@ -445,7 +445,7 @@ mod test {
 				"mnopab cdefghi j",
 				"klmno",
 			]
-		)
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
This Pull Request fixes/closes #2142.

rustc 1.77 made changes to clippy that makes cargo clippy fail on master branch, this pull request fixes the errors.

It changes the following:
- Ran cargo clippy --fix
- Ran cargo fmt

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog