### PR TITLE
Git Config Commit Comments

### DIFF
--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -4,7 +4,9 @@ use crate::{
 	error::Result,
 	sync::{repository::repo, utils::get_head_repo},
 };
-use git2::{ErrorCode, message_prettify, ObjectType, Repository, Signature};
+use git2::{
+	message_prettify, ErrorCode, ObjectType, Repository, Signature,
+};
 use scopetime::scope_time;
 
 ///
@@ -130,7 +132,7 @@ pub fn commit_message_prettify(
 		.get_string("core.commentChar")?
 		.as_bytes()
 		.first()
-		.unwrap()
+		.unwrap_or(&b"#"[0])
 		.to_owned();
 
 	Ok(message_prettify(message, Some(char))?)

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -127,15 +127,13 @@ pub fn commit_message_prettify(
 	repo_path: &RepoPath,
 	message: String,
 ) -> Result<String> {
-	let char = repo(repo_path)?
+	let comment_char = repo(repo_path)?
 		.config()?
 		.get_string("core.commentChar")?
-		.as_bytes()
-		.first()
-		.unwrap_or(&b"#"[0])
-		.to_owned();
+		.chars()
+		.collect::<Vec<char>>()[0] as u8;
 
-	Ok(message_prettify(message, Some(char))?)
+	Ok(message_prettify(message, Some(comment_char))?)
 }
 
 #[cfg(test)]

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -1,9 +1,10 @@
+//! Git Api for Commits
 use super::{CommitId, RepoPath};
 use crate::{
 	error::Result,
 	sync::{repository::repo, utils::get_head_repo},
 };
-use git2::{ErrorCode, ObjectType, Repository, Signature};
+use git2::{ErrorCode, message_prettify, ObjectType, Repository, Signature};
 use scopetime::scope_time;
 
 ///
@@ -117,6 +118,22 @@ pub fn tag_commit(
 	};
 
 	Ok(c)
+}
+
+/// Loads the comment prefix from config & uses it to prettify commit messages
+pub fn commit_message_prettify(
+	repo_path: &RepoPath,
+	message: String,
+) -> Result<String> {
+	let char = repo(repo_path)?
+		.config()?
+		.get_string("core.commentChar")?
+		.as_bytes()
+		.first()
+		.unwrap()
+		.to_owned();
+
+	Ok(message_prettify(message, Some(char))?)
 }
 
 #[cfg(test)]

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -127,11 +127,13 @@ pub fn commit_message_prettify(
 	repo_path: &RepoPath,
 	message: String,
 ) -> Result<String> {
-	let comment_char = repo(repo_path)?
-		.config()?
-		.get_string("core.commentChar")?
-		.chars()
-		.collect::<Vec<char>>()[0] as u8;
+	let comment_char_string =
+		repo(repo_path)?.config()?.get_string("core.commentChar");
+
+	let comment_char =
+		comment_char_string.map_or(b'#', |char_string| {
+			char_string.chars().collect::<Vec<char>>()[0] as u8
+		});
 
 	Ok(message_prettify(message, Some(comment_char))?)
 }

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -132,7 +132,12 @@ pub fn commit_message_prettify(
 
 	let comment_char =
 		comment_char_string.map_or(b'#', |char_string| {
-			char_string.chars().collect::<Vec<char>>()[0] as u8
+			char_string
+				.chars()
+				.collect::<Vec<char>>()
+				.first()
+				.unwrap_or(&char::from('#'))
+				.to_owned() as u8
 		});
 
 	Ok(message_prettify(message, Some(comment_char))?)

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -127,18 +127,11 @@ pub fn commit_message_prettify(
 	repo_path: &RepoPath,
 	message: String,
 ) -> Result<String> {
-	let comment_char_string =
-		repo(repo_path)?.config()?.get_string("core.commentChar");
-
-	let comment_char =
-		comment_char_string.map_or(b'#', |char_string| {
-			char_string
-				.chars()
-				.collect::<Vec<char>>()
-				.first()
-				.unwrap_or(&'#')
-				.to_owned() as u8
-		});
+	let comment_char = repo(repo_path)?
+		.config()?
+		.get_string("core.commentChar")
+		.map(|char_string| char_string.chars().next())?
+		.unwrap_or('#') as u8;
 
 	Ok(message_prettify(message, Some(comment_char))?)
 }

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -136,7 +136,7 @@ pub fn commit_message_prettify(
 				.chars()
 				.collect::<Vec<char>>()
 				.first()
-				.unwrap_or(&char::from('#'))
+				.unwrap_or(&'#')
 				.to_owned() as u8
 		});
 

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod blame;
 pub mod branch;
-mod commit;
+pub mod commit;
 mod commit_details;
 pub mod commit_files;
 mod commit_filter;

--- a/src/popups/commit.rs
+++ b/src/popups/commit.rs
@@ -32,6 +32,7 @@ use std::{
 	path::PathBuf,
 	str::FromStr,
 };
+use asyncgit::sync::commit::commit_message_prettify;
 
 use super::ExternalEditorPopup;
 
@@ -195,7 +196,7 @@ impl CommitPopup {
 		drop(file);
 		std::fs::remove_file(&file_path)?;
 
-		message = message_prettify(message, Some(b'#'))?;
+		message = commit_message_prettify(&self.repo.borrow(), message)?;
 		self.input.set_text(message);
 		self.input.show()?;
 
@@ -254,8 +255,7 @@ impl CommitPopup {
 			}
 		}
 
-		//TODO: honor `core.commentChar`
-		let mut msg = message_prettify(msg, Some(b'#'))?;
+		let mut msg = commit_message_prettify(&self.repo.borrow(), msg)?;
 
 		if verify {
 			// run commit message check hook - can reject commit

--- a/src/popups/commit.rs
+++ b/src/popups/commit.rs
@@ -11,8 +11,9 @@ use crate::{
 	ui::style::SharedTheme,
 };
 use anyhow::{bail, Ok, Result};
+use asyncgit::sync::commit::commit_message_prettify;
 use asyncgit::{
-	cached, message_prettify,
+	cached,
 	sync::{
 		self, get_config_string, CommitId, HookResult,
 		PrepareCommitMsgSource, RepoPathRef, RepoState,
@@ -32,7 +33,6 @@ use std::{
 	path::PathBuf,
 	str::FromStr,
 };
-use asyncgit::sync::commit::commit_message_prettify;
 
 use super::ExternalEditorPopup;
 
@@ -196,7 +196,8 @@ impl CommitPopup {
 		drop(file);
 		std::fs::remove_file(&file_path)?;
 
-		message = commit_message_prettify(&self.repo.borrow(), message)?;
+		message =
+			commit_message_prettify(&self.repo.borrow(), message)?;
 		self.input.set_text(message);
 		self.input.show()?;
 
@@ -255,7 +256,8 @@ impl CommitPopup {
 			}
 		}
 
-		let mut msg = commit_message_prettify(&self.repo.borrow(), msg)?;
+		let mut msg =
+			commit_message_prettify(&self.repo.borrow(), msg)?;
 
 		if verify {
 			// run commit message check hook - can reject commit


### PR DESCRIPTION
This Pull Request fixes/closes #2136.

It changes the following:
- Commits will now follow the git config `core.commentChar` if one is not set it defaults to `#`

Screenshot Evidence
![image](https://github.com/extrawurst/gitui/assets/113200622/0512cb51-fdbe-4029-ae46-fca8b18bd0c2)


I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog