### PR TITLE
Fix typo in commit.rs

### DIFF
--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -126,7 +126,7 @@ pub fn commit(repo_path: &RepoPath, msg: &str) -> Result<CommitId> {
 
 		// manually advance to the new commit ID
 		// repo.commit does that on its own, repo.commit_signed does not
-		// if there is no head, read default branch or defaul to "master"
+		// if there is no head, read default branch or default to "master"
 		if let Ok(mut head) = repo.head() {
 			head.set_target(commit_id, msg)?;
 		} else {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
- asyncgit/src/sync/commit.rs

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog