### PR TITLE
syntect additional file type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 * bump yanked dependency `bumpalo` to fix build from source ([#2087](https://github.com/extrawurst/gitui/issues/2087))
 * pin `ratatui` version to fix building without locked `cargo install gitui` ([#2090](https://github.com/extrawurst/gitui/issues/2090))
+* add syntax highlighting support for more file types, e.g. Typescript, TOML, etc. ([#2005](https://github.com/extrawurst/gitui/issues/2005))
 
 ## [0.25.0] - 2024-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 * bump yanked dependency `bumpalo` to fix build from source ([#2087](https://github.com/extrawurst/gitui/issues/2087))
 * pin `ratatui` version to fix building without locked `cargo install gitui` ([#2090](https://github.com/extrawurst/gitui/issues/2090))
-* add syntax highlighting support for more file types, e.g. Typescript, TOML, etc. ([#2005](https://github.com/extrawurst/gitui/issues/2005))
+* add syntax highlighting support for more file types, e.g. Typescript, TOML, etc. [[@martihomssoler]](https://github.com/martihomssoler) ([#2005](https://github.com/extrawurst/gitui/issues/2005))
 
 ## [0.25.0] - 2024-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 * bump yanked dependency `bumpalo` to fix build from source ([#2087](https://github.com/extrawurst/gitui/issues/2087))
 * pin `ratatui` version to fix building without locked `cargo install gitui` ([#2090](https://github.com/extrawurst/gitui/issues/2090))
-* add syntax highlighting support for more file types, e.g. Typescript, TOML, etc. [[@martihomssoler]](https://github.com/martihomssoler) ([#2005](https://github.com/extrawurst/gitui/issues/2005))
+* add syntax highlighting support for more file types, e.g. Typescript, TOML, etc. [[@martihomssoler](https://github.com/martihomssoler)] ([#2005](https://github.com/extrawurst/gitui/issues/2005))
 
 ## [0.25.0] - 2024-02-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "tui-textarea",
+ "two-face",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -1745,6 +1746,17 @@ dependencies = [
  "crossterm",
  "ratatui",
  "unicode-width",
+]
+
+[[package]]
+name = "two-face"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37bed2135b2459c7eefba72c906d374697eb15949c205f2f124e3636a46b5eeb"
+dependencies = [
+ "once_cell",
+ "serde",
+ "syntect",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ syntect = { version = "5.2", default-features = false, features = [
     "default-themes",
     "html",
 ] }
+two-face = { version = "0.3.0", default-features = false }
 tui-textarea = "0.4.0"
 unicode-segmentation = "1.11"
 unicode-truncate = "0.2"
@@ -71,8 +72,8 @@ maintenance = { status = "actively-developed" }
 default = ["ghemoji", "regex-fancy", "trace-libgit", "vendor-openssl"]
 ghemoji = ["gh-emoji"]
 # regex-* features are mutually exclusive.
-regex-fancy = ["syntect/regex-fancy"]
-regex-onig = ["syntect/regex-onig"]
+regex-fancy = ["syntect/regex-fancy", "two-face/syntect-fancy"]
+regex-onig = ["syntect/regex-onig", "two-face/syntect-onig"]
 timing = ["scopetime/enabled"]
 trace-libgit = ["asyncgit/trace-libgit"]
 vendor-openssl = ["asyncgit/vendor-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ syntect = { version = "5.2", default-features = false, features = [
     "default-themes",
     "html",
 ] }
-two-face = { version = "0.3.0", default-features = false }
 tui-textarea = "0.4.0"
+two-face = { version = "0.3.0", default-features = false }
 unicode-segmentation = "1.11"
 unicode-truncate = "0.2"
 unicode-width = "0.1"

--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -33,7 +33,7 @@ pub struct SyntaxText {
 }
 
 static SYNTAX_SET: Lazy<SyntaxSet> =
-	Lazy::new(SyntaxSet::load_defaults_nonewlines);
+	Lazy::new(two_face::syntax::extra_no_newlines);
 static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
 
 pub struct AsyncProgressBuffer {


### PR DESCRIPTION
This Pull Request fixes/closes https://github.com/extrawurst/gitui/issues/2005.

It changes the following:
- add two-face as dependency to extend syntect supported file types
- add two-face feature flags alongside syntect feature flags
- change default SYNTAX_SET to two_face's default (still no newlines)

I followed the checklist:
- [] I added unittests (not needed)
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [X] I added an appropriate item to the changelog