### PR TITLE
Automatic publishing to Winget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -121,3 +121,12 @@ jobs:
         formula-name: gitui
         # https://github.com/mislav/bump-homebrew-formula-action/issues/58
         formula-path: Formula/g/gitui.rb
+
+    - name: Bump Winget
+      if: "matrix.os == 'windows-latest' && !contains(github.ref, '-')"
+      uses: vedantmgoyal2009/winget-releaser@v2
+      with:
+        identifier: StephanDilly.gitui
+        version: ${{ steps.get-version.outputs.version }}
+        token: ${{ secrets.WINGET_TOKEN }}
+        installers-regex: "./release/*.msi"


### PR DESCRIPTION
This pull request fixes/closes #2186.

@extrawurst, the default is to use the repo_owner but you can use a different account aswell if you want.

steps left (more [details](https://github.com/vedantmgoyal9/winget-releaser)):  
- add a classic personal access token with the "public_repo" scope as WINGET_TOKEN to the secrets
 - Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
   - Use [Pull App ](https://github.com/apps/pull) to keep the fork up to date


It changes the following:
- add a step to cd,yml to create a new PR in [winget-pkgs](https://github.com/microsoft/winget-pkgs) on a new release
- configure dependabot to also check Github actions.
