### PR TITLE
add support for external ssh signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * support for `Copy Path` action in WSL [[@johnDeSilencio](https://github.com/johnDeSilencio)] ([#2413](https://github.com/extrawurst/gitui/pull/2413))
 * help popup scrollbar [[@wugeer](https://github.com/wugeer)] ([#2388](https://github.com/extrawurst/gitui/pull/2388))
 
+### Added
+* Support for ssh signing via external system binaries. See `gpg.ssh.program` configuration.
+
 ### Fixes
 * respect env vars like `GIT_CONFIG_GLOBAL` ([#2298](https://github.com/extrawurst/gitui/issues/2298))
 * Set `CREATE_NO_WINDOW` flag when executing Git hooks on Windows ([#2371](https://github.com/extrawurst/gitui/pull/2371))

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 ssh-key = { version = "0.6.7", features = ["crypto", "encryption"] }
 thiserror = "2.0"
 unicode-truncate = "2.0"
+tempfile = "3"
 url = "2.5"
 
 [dev-dependencies]

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -173,7 +173,7 @@ enum SSHProgram {
 
 impl SSHProgram {
 	pub fn new(config: &git2::Config) -> Self {
-		match config.get_string("gpg.ssh.program") {
+		match dbg!(config.get_string("gpg.ssh.program")) {
 			Err(_) => Self::Default,
 			Ok(ssh_program) => {
 				if ssh_program.is_empty() {
@@ -189,13 +189,13 @@ impl SSHProgram {
 		config: &git2::Config,
 	) -> Result<Box<dyn Sign>, SignBuilderError> {
 		match self {
-			SSHProgram::Default => {
+			Self::Default => {
 				let ssh_signer = ConfigAccess(config)
 					.signing_key()
 					.and_then(SSHSign::new)?;
 				Ok(Box::new(ssh_signer))
 			}
-			SSHProgram::SystemBin(exec_path) => {
+			Self::SystemBin(exec_path) => {
 				let key = ConfigAccess(config).signing_key()?;
 				Ok(Box::new(ExternalBinSSHSign::new(exec_path, key)))
 			}
@@ -333,9 +333,10 @@ enum KeyPathOrLiteral {
 
 impl KeyPathOrLiteral {
 	fn new(buf: PathBuf) -> Self {
-		match buf.is_file() {
-			true => KeyPathOrLiteral::KeyPath(buf),
-			false => KeyPathOrLiteral::Literal(buf),
+		if buf.is_file() {
+			Self::KeyPath(buf)
+		} else {
+			Self::Literal(buf)
 		}
 	}
 }
@@ -346,8 +347,7 @@ impl Display for KeyPathOrLiteral {
 		f: &mut std::fmt::Formatter<'_>,
 	) -> std::fmt::Result {
 		let buf = match self {
-			Self::Literal(x) => x,
-			Self::KeyPath(x) => x,
+			Self::KeyPath(x) | Self::Literal(x) => x,
 		};
 		f.write_fmt(format_args!("{}", buf.display()))
 	}
@@ -378,7 +378,7 @@ impl ExternalBinSSHSign {
 		#[cfg(test)]
 		let signing_key = key_path.to_string();
 
-		ExternalBinSSHSign {
+		Self {
 			program_path,
 			key_path,
 			#[cfg(test)]
@@ -490,7 +490,7 @@ impl SSHSign {
 				})
 		} else {
 			Err(SignBuilderError::SSHSigningKey(
-				format!("Currently, we only support a pair of ssh key in disk. Found {:?}", key),
+				format!("Currently, we only support a pair of ssh key in disk. Found {key:?}"),
 			))
 		}
 	}
@@ -630,7 +630,7 @@ mod tests {
 
 		{
 			let mut config = repo.config()?;
-			config.set_str("gpg.program", "ssh")?;
+			config.set_str("gpg.format", "ssh")?;
 			config.set_str("user.signingKey", "/tmp/key.pub")?;
 			config.set_str("gpg.ssh.program", "/bin/cat")?;
 		}
@@ -638,7 +638,7 @@ mod tests {
 		let sign =
 			SignBuilder::from_gitconfig(&repo, &repo.config()?)?;
 
-		assert_eq!("/bin/cat", sign.program());
+		assert_eq!("cat", sign.program());
 		assert_eq!("/tmp/key.pub", sign.signing_key());
 
 		Ok(())

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -173,7 +173,7 @@ enum SSHProgram {
 
 impl SSHProgram {
 	pub fn new(config: &git2::Config) -> Self {
-		match dbg!(config.get_string("gpg.ssh.program")) {
+		match config.get_string("gpg.ssh.program") {
 			Err(_) => Self::Default,
 			Ok(ssh_program) => {
 				if ssh_program.is_empty() {

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -623,4 +623,24 @@ mod tests {
 
 		Ok(())
 	}
+
+	#[test]
+	fn test_external_ssh_binary() -> Result<()> {
+		let (_tmp_dir, repo) = repo_init_empty()?;
+
+		{
+			let mut config = repo.config()?;
+			config.set_str("gpg.program", "ssh")?;
+			config.set_str("user.signingKey", "/tmp/key.pub")?;
+			config.set_str("gpg.ssh.program", "/bin/cat")?;
+		}
+
+		let sign =
+			SignBuilder::from_gitconfig(&repo, &repo.config()?)?;
+
+		assert_eq!("/bin/cat", sign.program());
+		assert_eq!("/tmp/key.pub", sign.signing_key());
+
+		Ok(())
+	}
 }

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -1,7 +1,9 @@
 //! Sign commit data.
 
+use git2::Config;
 use ssh_key::{HashAlg, LineEnding, PrivateKey};
-use std::path::PathBuf;
+use std::{fmt::Display, path::PathBuf};
+use tempfile::NamedTempFile;
 
 /// Error type for [`SignBuilder`], used to create [`Sign`]'s
 #[derive(thiserror::Error, Debug)]
@@ -156,34 +158,78 @@ impl SignBuilder {
 				String::from("x509"),
 			)),
 			"ssh" => {
-				let ssh_signer = config
-					.get_string("user.signingKey")
-					.ok()
-					.and_then(|key_path| {
-						key_path.strip_prefix('~').map_or_else(
-							|| Some(PathBuf::from(&key_path)),
-							|ssh_key_path| {
-								dirs::home_dir().map(|home| {
-									home.join(
-										ssh_key_path
-											.strip_prefix('/')
-											.unwrap_or(ssh_key_path),
-									)
-								})
-							},
-						)
-					})
-					.ok_or_else(|| {
-						SignBuilderError::SSHSigningKey(String::from(
-							"ssh key setting absent",
-						))
-					})
-					.and_then(SSHSign::new)?;
-				let signer: Box<dyn Sign> = Box::new(ssh_signer);
-				Ok(signer)
+				let program = SSHProgram::new(config);
+				program.into_signer(config)
 			}
 			_ => Err(SignBuilderError::InvalidFormat(format)),
 		}
+	}
+}
+
+enum SSHProgram {
+	Default,
+	SystemBin(PathBuf),
+}
+
+impl SSHProgram {
+	pub fn new(config: &git2::Config) -> Self {
+		match config.get_string("gpg.ssh.program") {
+			Err(_) => Self::Default,
+			Ok(ssh_program) => {
+				if ssh_program.is_empty() {
+					return Self::Default;
+				}
+				Self::SystemBin(PathBuf::from(ssh_program))
+			}
+		}
+	}
+
+	fn into_signer(
+		self,
+		config: &git2::Config,
+	) -> Result<Box<dyn Sign>, SignBuilderError> {
+		match self {
+			SSHProgram::Default => {
+				let ssh_signer = ConfigAccess(config)
+					.signing_key()
+					.and_then(SSHSign::new)?;
+				Ok(Box::new(ssh_signer))
+			}
+			SSHProgram::SystemBin(exec_path) => {
+				let key = ConfigAccess(config).signing_key()?;
+				Ok(Box::new(ExternalBinSSHSign::new(exec_path, key)))
+			}
+		}
+	}
+}
+
+/// wrapper struct for convenience methods over [Config]
+struct ConfigAccess<'a>(&'a Config);
+
+impl<'a> ConfigAccess<'a> {
+	pub fn signing_key(&self) -> Result<PathBuf, SignBuilderError> {
+		self.0
+			.get_string("user.signingKey")
+			.ok()
+			.and_then(|key_path| {
+				key_path.strip_prefix('~').map_or_else(
+					|| Some(PathBuf::from(&key_path)),
+					|ssh_key_path| {
+						dirs::home_dir().map(|home| {
+							home.join(
+								ssh_key_path
+									.strip_prefix('/')
+									.unwrap_or(ssh_key_path),
+							)
+						})
+					},
+				)
+			})
+			.ok_or_else(|| {
+				SignBuilderError::SSHSigningKey(String::from(
+					"ssh key setting absent",
+				))
+			})
 	}
 }
 
@@ -280,6 +326,144 @@ pub struct SSHSign {
 	secret_key: PrivateKey,
 }
 
+enum KeyPathOrLiteral {
+	Literal(PathBuf),
+	KeyPath(PathBuf),
+}
+
+impl KeyPathOrLiteral {
+	fn new(buf: PathBuf) -> Self {
+		match buf.is_file() {
+			true => KeyPathOrLiteral::KeyPath(buf),
+			false => KeyPathOrLiteral::Literal(buf),
+		}
+	}
+}
+
+impl Display for KeyPathOrLiteral {
+	fn fmt(
+		&self,
+		f: &mut std::fmt::Formatter<'_>,
+	) -> std::fmt::Result {
+		let buf = match self {
+			Self::Literal(x) => x,
+			Self::KeyPath(x) => x,
+		};
+		f.write_fmt(format_args!("{}", buf.display()))
+	}
+}
+
+/// Struct which allows for signing via an external binary
+pub struct ExternalBinSSHSign {
+	program_path: PathBuf,
+	key_path: KeyPathOrLiteral,
+	#[cfg(test)]
+	program: String,
+	#[cfg(test)]
+	signing_key: String,
+}
+
+impl ExternalBinSSHSign {
+	/// constructs a new instance of the external ssh signer
+	pub fn new(program_path: PathBuf, key_path: PathBuf) -> Self {
+		#[cfg(test)]
+		let program: String = program_path
+			.file_name()
+			.unwrap_or_default()
+			.to_string_lossy()
+			.into_owned();
+
+		let key_path = KeyPathOrLiteral::new(key_path);
+
+		#[cfg(test)]
+		let signing_key = key_path.to_string();
+
+		ExternalBinSSHSign {
+			program_path,
+			key_path,
+			#[cfg(test)]
+			program,
+			#[cfg(test)]
+			signing_key,
+		}
+	}
+}
+
+impl Sign for ExternalBinSSHSign {
+	fn sign(
+		&self,
+		commit: &[u8],
+	) -> Result<(String, Option<String>), SignError> {
+		use std::io::Write;
+		use std::process::{Command, Stdio};
+
+		if cfg!(target_os = "windows") {
+			return Err(SignError::Spawn("External binary signing is only supported on Unix based systems".into()));
+		}
+
+		let mut file = NamedTempFile::new()
+			.map_err(|e| SignError::Spawn(e.to_string()))?;
+
+		let key = match &self.key_path {
+			KeyPathOrLiteral::Literal(x) => {
+				write!(file, "{}", x.display()).map_err(|e| {
+					SignError::WriteBuffer(e.to_string())
+				})?;
+				file.path()
+			}
+			KeyPathOrLiteral::KeyPath(x) => x.as_path(),
+		};
+
+		let mut c = Command::new(&self.program_path);
+		c.stdin(Stdio::piped())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.arg("-Y")
+			.arg("sign")
+			.arg("-n")
+			.arg("git")
+			.arg("-f")
+			.arg(key);
+
+		let mut child =
+			c.spawn().map_err(|e| SignError::Spawn(e.to_string()))?;
+
+		let mut stdin = child.stdin.take().ok_or(SignError::Stdin)?;
+
+		stdin
+			.write_all(commit)
+			.map_err(|e| SignError::WriteBuffer(e.to_string()))?;
+		drop(stdin);
+
+		let output = child
+			.wait_with_output()
+			.map_err(|e| SignError::Output(e.to_string()))?;
+
+		if !output.status.success() {
+			return Err(SignError::Shellout(format!(
+				"failed to sign data, program '{}' exited non-zero: {}",
+				&self.program_path.display(),
+				std::str::from_utf8(&output.stderr).unwrap_or("[error could not be read from stderr]")
+			)));
+		}
+
+		let signed_commit = std::str::from_utf8(&output.stdout)
+			.map_err(|e| SignError::Shellout(e.to_string()))?;
+
+		Ok((signed_commit.to_string(), None))
+	}
+
+	#[cfg(test)]
+	fn program(&self) -> &String {
+		&self.program
+	}
+
+	#[cfg(test)]
+	fn signing_key(&self) -> &String {
+		&self.signing_key
+	}
+}
+
 impl SSHSign {
 	/// Create new [`SSHDiskKeySign`] for sign.
 	pub fn new(mut key: PathBuf) -> Result<Self, SignBuilderError> {
@@ -306,7 +490,7 @@ impl SSHSign {
 				})
 		} else {
 			Err(SignBuilderError::SSHSigningKey(
-				String::from("Currently, we only support a pair of ssh key in disk."),
+				format!("Currently, we only support a pair of ssh key in disk. Found {:?}", key),
 			))
 		}
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2188.

It changes the following:
- Adds support for external bin signing with ssh keys


EDIT: I have added a test for the new feature, let me know if this is not sufficient or what to change, its a bit hard to test external binaries.

I ran make check without errors _except_ for the python check, I don't have python on my system which I'm guessing is the cause of the failure

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog