### PR TITLE
feat(sign): add support for external ssh signing

### DIFF
--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -29,6 +29,7 @@ rayon-core = "1.12"
 scopetime = { path = "../scopetime", version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
 ssh-key = { version = "0.6.6", features = ["crypto", "encryption"] }
+tempfile = "3"
 thiserror = "1.0"
 unicode-truncate = "1.0"
 url = "2.5"

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -187,13 +187,13 @@ impl SSHProgram {
 		config: &git2::Config,
 	) -> Result<Box<dyn Sign>, SignBuilderError> {
 		match self {
-			SSHProgram::Default => {
+			Self::Default => {
 				let ssh_signer = ConfigAccess(config)
 					.signing_key()
 					.and_then(SSHSign::new)?;
 				Ok(Box::new(ssh_signer))
 			}
-			SSHProgram::SystemBin(exec_path) => {
+			Self::SystemBin(exec_path) => {
 				let key = ConfigAccess(config).signing_key()?;
 				Ok(Box::new(ExternalBinSSHSign::new(exec_path, key)))
 			}
@@ -331,9 +331,10 @@ enum KeyPathOrLiteral {
 
 impl KeyPathOrLiteral {
 	fn new(buf: PathBuf) -> Self {
-		match buf.is_file() {
-			true => KeyPathOrLiteral::KeyPath(buf),
-			false => KeyPathOrLiteral::Literal(buf),
+		if buf.is_file() {
+			Self::KeyPath(buf)
+		} else {
+			Self::Literal(buf)
 		}
 	}
 }
@@ -344,8 +345,7 @@ impl Display for KeyPathOrLiteral {
 		f: &mut std::fmt::Formatter<'_>,
 	) -> std::fmt::Result {
 		let buf = match self {
-			Self::Literal(x) => x,
-			Self::KeyPath(x) => x,
+			Self::KeyPath(x) | Self::Literal(x) => x,
 		};
 		f.write_fmt(format_args!("{}", buf.display()))
 	}
@@ -376,7 +376,7 @@ impl ExternalBinSSHSign {
 		#[cfg(test)]
 		let signing_key = key_path.to_string();
 
-		ExternalBinSSHSign {
+		Self {
 			program_path,
 			key_path,
 			#[cfg(test)]
@@ -488,7 +488,7 @@ impl SSHSign {
 				})
 		} else {
 			Err(SignBuilderError::SSHSigningKey(
-				format!("Currently, we only support a pair of ssh key in disk. Found {:?}", key),
+				format!("Currently, we only support a pair of ssh key in disk. Found {key:?}"),
 			))
 		}
 	}

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -365,11 +365,7 @@ impl ExternalBinSSHSign {
 	/// constructs a new instance of the external ssh signer
 	pub fn new(program_path: PathBuf, key_path: PathBuf) -> Self {
 		#[cfg(test)]
-		let program: String = program_path
-			.file_name()
-			.unwrap_or_default()
-			.to_string_lossy()
-			.into_owned();
+		let program: String = program_path.to_string_lossy().to_string();
 
 		let key_path = KeyPathOrLiteral::new(key_path);
 
@@ -618,6 +614,29 @@ mod tests {
 
 		assert_eq!("ssh", sign.program());
 		assert_eq!("/tmp/key.pub", sign.signing_key());
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_ssh_external_program_configs() -> Result<()> {
+		let (_tmp_dir, repo) = repo_init_empty()?;
+
+		{
+			let mut config = repo.config()?;
+			config.set_str("gpg.format", "ssh")?;
+			config.set_str(
+				"gpg.ssh.program",
+				"/Applications/program",
+			)?;
+			config.set_str("user.signingKey", "ssh-ed25519")?;
+		}
+
+		let sign =
+			SignBuilder::from_gitconfig(&repo, &repo.config()?)?;
+
+		assert_eq!("/Applications/program", sign.program());
+		assert_eq!("ssh-ed25519", sign.signing_key());
 
 		Ok(())
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2188, #2198.

It changes the following:
- Adds support for external bin signing with ssh keys

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check`
> thread 'tests::test_pre_commit_py' panicked at git2-hooks/src/lib.rs:471:9:
assertion failed: res.is_ok()
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog