### PR TITLE
refactor: replace `Default` for clarity

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -129,9 +129,9 @@ impl Environment {
 		use crossbeam_channel::unbounded;
 		Self {
 			queue: Queue::new(),
-			theme: Default::default(),
-			key_config: Default::default(),
-			repo: RefCell::new(RepoPath::Path(Default::default())),
+			theme: Rc::default(),
+			key_config: Rc::default(),
+			repo: RefCell::new(RepoPath::Path(PathBuf::default())),
 			options: Rc::new(RefCell::new(Options::test_env())),
 			sender_git: unbounded().0,
 			sender_app: unbounded().0,

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -957,7 +957,7 @@ mod tests {
 		let diff_line = DiffLine {
 			content: "".into(),
 			line_type: DiffLineType::Add,
-			position: Default::default(),
+			position: DiffLinePosition::default(),
 		};
 
 		{

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,8 +37,8 @@ impl Options {
 	pub fn test_env() -> Self {
 		use asyncgit::sync::RepoPath;
 		Self {
-			repo: RefCell::new(RepoPath::Path(Default::default())),
-			data: Default::default(),
+			repo: RefCell::new(RepoPath::Path(PathBuf::default())),
+			data: OptionsData::default(),
 		}
 	}
 }

--- a/src/ui/reflow.rs
+++ b/src/ui/reflow.rs
@@ -248,7 +248,7 @@ mod test {
 		text: &str,
 		text_area_width: u16,
 	) -> (Vec<String>, Vec<u16>) {
-		let style = Default::default();
+		let style = ratatui::style::Style::default();
 		let mut styled = UnicodeSegmentation::graphemes(text, true)
 			.map(|g| StyledGrapheme { symbol: g, style });
 		let mut composer: Box<dyn LineComposer> = match which {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This pull request replaces `Default::default()` with T::default() where T is the type of the default value, to make it more clear which default we are using.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog