### PR TITLE
Add UI snapshot test for simple case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f45c79b3b9413932fc255f2c19ca0d48eaab72c4ea1913bafaebf289cbc099f2"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +140,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-svg"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962f6d5681926dbe5503b71057202d6723a33abe464c983b1d160bca3095a3bb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-lossy",
+ "html-escape",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1131,6 +1153,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "simplelog",
+ "snapbox",
  "struct-patch",
  "syntect",
  "tempfile",
@@ -1688,6 +1711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2222,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "p256"
@@ -2821,6 +2869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +2904,34 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snapbox"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027c936207f85d10d015e21faf5c676c7e08c453ed371adf55c0874c443ca77a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-svg",
+ "libc",
+ "normalize-line-endings",
+ "os_pipe",
+ "serde_json",
+ "similar",
+ "snapbox-macros",
+ "wait-timeout",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16569f53ca23a41bb6f62e0a5084aa1661f4814a67fa33696a79073e03a664af"
+dependencies = [
+ "anstream",
+]
 
 [[package]]
 name = "spin"
@@ -3218,6 +3300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3322,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ which = "6.0"
 [dev-dependencies]
 env_logger = "0.11"
 pretty_assertions = "1.4"
+snapbox = { version = "0.6.16", features = ["cmd", "term-svg"] }
 tempfile = "3"
 
 [build-dependencies]

--- a/tests/fixtures/empty_dir.svg
+++ b/tests/fixtures/empty_dir.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>invalid path</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>please run gitui inside of a non-bare git repository</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+use snapbox::{cmd::Command, data::DataFormat, Data};
+use tempfile::TempDir;
+
+#[test]
+fn test_empty_dir() {
+	let path: &Path = Path::new("tests/fixtures/empty_dir.svg");
+
+	let empty_dir = TempDir::new().unwrap();
+
+	Command::new("gitui")
+		.current_dir(empty_dir.path())
+		.assert()
+		.success()
+		.stderr_eq(Data::read_from(path, Some(DataFormat::TermSvg)));
+}

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,6 +1,10 @@
 use std::path::Path;
 
-use snapbox::{cmd::Command, data::DataFormat, Data};
+use snapbox::{
+	cmd::{cargo_bin, Command},
+	data::DataFormat,
+	Data,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -9,7 +13,7 @@ fn test_empty_dir() {
 
 	let empty_dir = TempDir::new().unwrap();
 
-	Command::new("gitui")
+	Command::new(cargo_bin!("gitui"))
 		.current_dir(empty_dir.path())
 		.assert()
 		.success()


### PR DESCRIPTION
This is a PR for a branch that I have been working on a couple of weeks ago. I did not want this to get lost, so I decided to open a PR, in particular because I discovered there were some open questions with respect to UI tests.

I think this works really well for cases where the program exits with an error message.

I found it quite challenging, though, when it comes to testing an application interactively because `snapbox`, the library that powers the snapshot test, isn’t designed for that use case. There’s potentially ways to work around that via environment variables or command line arguments, but before I go down that route, I first wanted to get your opinion on whether you think it’s worth putting more effort into this. I still think if we can get this to work, we’d have the option to write truly useful high-level regression tests of which I’m a big fan. What do you think? @extrawurst

2024-09-24: I’ll add more context and fix the failing test soon.
