### PR TITLE
filetreelist: exclude demo.gif from published crates

### DIFF
--- a/filetreelist/Cargo.toml
+++ b/filetreelist/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 categories = ["command-line-utilities"]
 keywords = ["gui", "cli", "terminal", "ui", "tui"]
+exclude = ["/demo.gif"]
 
 [dependencies]
 thiserror = "1.0"


### PR DESCRIPTION
This reduces download size for the crate from ~900 kB to ~10 kB.

I didn't file an issue because that feels redundant for the single-line metadata change proposed here (and most of the checklist in the PR template doesn't apply either).
