### PR TITLE
Set `CREATE_NO_WINDOW` flag when executing Git hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * respect env vars like `GIT_CONFIG_GLOBAL` ([#2298](https://github.com/extrawurst/gitui/issues/2298))
+* Set `CREATE_NO_WINDOW` flag when executing Git hooks on Windows ([#2371](https://github.com/extrawurst/gitui/pull/2371))
 
 ### Added
 * add popups for viewing, adding, updating and removing remotes [[@robin-thoene](https://github.com/robin-thoene)] ([#2172](https://github.com/extrawurst/gitui/issues/2172))

--- a/git2-hooks/src/hookspath.rs
+++ b/git2-hooks/src/hookspath.rs
@@ -203,6 +203,16 @@ fn find_default_unix_shell() -> Option<PathBuf> {
 }
 
 trait CommandExt {
+	/// The process is a console application that is being run without a
+	/// console window. Therefore, the console handle for the application is
+	/// not set.
+	///
+	/// This flag is ignored if the application is not a console application,
+	/// or if it used with either `CREATE_NEW_CONSOLE` or `DETACHED_PROCESS`.
+	///
+	/// See: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+	const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 	fn with_no_window(&mut self) -> &mut Self;
 }
 
@@ -216,7 +226,7 @@ impl CommandExt for Command {
 		#[cfg(windows)]
 		{
 			use std::os::windows::process::CommandExt;
-			self.creation_flags(0x0800_0000);
+			self.creation_flags(Self::CREATE_NO_WINDOW);
 		}
 
 		self

--- a/git2-hooks/src/hookspath.rs
+++ b/git2-hooks/src/hookspath.rs
@@ -213,8 +213,12 @@ impl CommandExt for Command {
 	/// `CREATE_NO_WINDOW` flag.
 	#[inline]
 	fn with_no_window(&mut self) -> &mut Self {
-		use std::os::windows::process::CommandExt;
 		#[cfg(windows)]
-		self.creation_flags(0x0800_0000)
+		{
+			use std::os::windows::process::CommandExt;
+			self.creation_flags(0x0800_0000);
+		}
+
+		self
 	}
 }

--- a/git2-hooks/src/hookspath.rs
+++ b/git2-hooks/src/hookspath.rs
@@ -210,7 +210,7 @@ trait CommandExt {
 	/// This flag is ignored if the application is not a console application,
 	/// or if it used with either `CREATE_NEW_CONSOLE` or `DETACHED_PROCESS`.
 	///
-	/// See: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+	/// See: <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>
 	const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 	fn with_no_window(&mut self) -> &mut Self;


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request makes changes to accommodate GUI functionality in GitButler (see: https://github.com/gitbutlerapp/gitbutler/issues/4982).

It changes the following:
- Set the `CREATE_NO_WINDOW` flag when executing Git hooks on Windows.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog