### PR TITLE
Add test for AsyncLog respecting GIT_DIR

### DIFF
--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -331,6 +331,7 @@ mod tests {
 	use std::time::Duration;
 
 	use crossbeam_channel::unbounded;
+	use serial_test::serial;
 	use tempfile::TempDir;
 
 	use crate::sync::tests::{debug_cmd_print, repo_init};
@@ -371,6 +372,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn test_env_variables() {
 		let (_td, repo) = repo_init().unwrap();
 		let git_dir = repo.path();


### PR DESCRIPTION
This is a follow-up to #2301. It adds a test for `AsyncLog::fetch_helper_without_filter` respecting `GIT_DIR`. The docs to `std::env::set_var` say that it is only safe to be used in single-threaded programs. Could this ever become an issue? On my machine, `make check` was green.

(Creating snapshot tests running the `gitui` binary has proven to be rather challenging. So far, I have not found a crate that would work with `enable_raw_mode` which is why I decided to open this PR.)
