### PR TITLE
Fix code formatting

### DIFF
--- a/src/keys/symbols.rs
+++ b/src/keys/symbols.rs
@@ -29,7 +29,7 @@ pub struct KeySymbols {
 impl Default for KeySymbols {
 	fn default() -> Self {
 		Self {
-			enter: "\u{23ce}".into(),     //⏎
+            enter: "\u{23ce}".into(),     //⏎
             left: "\u{2190}".into(),      //←
             right: "\u{2192}".into(),     //→
             up: "\u{2191}".into(),        //↑


### PR DESCRIPTION
Hey there, great tool! I noticed this while checking out the defaults. FYI the rest of the file also uses tabs, not sure if that's intentional.

![image](https://github.com/user-attachments/assets/8afb4ca5-1e8e-4731-b71e-8a5fad7960ad)
