### PR TITLE
Improve test for env variables

### DIFF
--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -331,6 +331,7 @@ mod tests {
 	use std::time::Duration;
 
 	use crossbeam_channel::unbounded;
+	use serial_test::serial;
 	use tempfile::TempDir;
 
 	use crate::sync::tests::{debug_cmd_print, repo_init};
@@ -371,6 +372,7 @@ mod tests {
 	}
 
 	#[test]
+	#[serial]
 	fn test_env_variables() {
 		let (_td, repo) = repo_init().unwrap();
 		let git_dir = repo.path();

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -369,7 +369,7 @@ mod tests {
 			&tx_git,
 		);
 
-		assert!(result.is_ok());
+		assert_eq!(result.unwrap(), ());
 	}
 
 	#[test]
@@ -402,6 +402,6 @@ mod tests {
 
 		std::env::remove_var("GIT_DIR");
 
-		assert!(result.is_ok());
+		assert_eq!(result.unwrap(), ());
 	}
 }

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -341,6 +341,7 @@ mod tests {
 	use super::AsyncLogResult;
 
 	#[test]
+	#[serial]
 	fn test_smoke_in_subdir() {
 		let (_td, repo) = repo_init().unwrap();
 		let root = repo.path().parent().unwrap();


### PR DESCRIPTION
This is a follow-up to #2387. It changes the original PR in the following way:

- It marks another test in the same file as `#[serial]`.
- It unwraps `result` in both tests to get more information in case either test fails on CI.
