### PR TITLE
Support "Copy Path" operation in WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Set `CREATE_NO_WINDOW` flag when executing Git hooks on Windows ([#2371](https://github.com/extrawurst/gitui/pull/2371))
 
 ### Added
+* support for "Copy Path" action in WSL [[@johnDeSilencio](https://github.com/johnDeSilencio)] ([#2413](https://github.com/extrawurst/gitui/pull/2413))
 * help popup scrollbar [[@wugeer](https://github.com/wugeer)](https://github.com/extrawurst/gitui/pull/2388))
 * add popups for viewing, adding, updating and removing remotes [[@robin-thoene](https://github.com/robin-thoene)] ([#2172](https://github.com/extrawurst/gitui/issues/2172))
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -54,13 +54,13 @@ fn exec_copy_with_args(
 // based on this comment: https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
 fn is_wsl() -> bool {
-    if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
-        if let Ok(s) = std::str::from_utf8(&b) {
-            let a = s.to_ascii_lowercase();
-            return a.contains("microsoft") || a.contains("wsl");
-        }
-    }
-    false
+	if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
+		if let Ok(s) = std::str::from_utf8(&b) {
+			let a = s.to_ascii_lowercase();
+			return a.contains("microsoft") || a.contains("wsl");
+		}
+	}
+	false
 }
 
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -49,6 +49,20 @@ fn exec_copy_with_args(
 	}
 }
 
+// Implementation taken from https://crates.io/crates/wsl.
+// Using /proc/sys/kernel/osrelease as an authoratative source
+// based on this comment: https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
+#[cfg(all(target_family = "unix", not(target_os = "macos")))]
+fn is_wsl() -> bool {
+    if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
+        if let Ok(s) = std::str::from_utf8(&b) {
+            let a = s.to_ascii_lowercase();
+            return a.contains("microsoft") || a.contains("wsl");
+        }
+    }
+    false
+}
+
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
 pub fn copy_string(text: &str) -> Result<()> {
 	if std::env::var("WAYLAND_DISPLAY").is_ok() {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -69,6 +69,10 @@ pub fn copy_string(text: &str) -> Result<()> {
 		return exec_copy_with_args("wl-copy", &[], text, false);
 	}
 
+	if is_wsl() {
+		return exec_copy_with_args("clip.exe", &[], text, false);
+	}
+
 	if exec_copy_with_args(
 		"xclip",
 		&["-selection", "clipboard"],


### PR DESCRIPTION
This PR adds support for the "Copy Path" operation in the "Files" tab when running in WSL.

For those like myself who are accessing WSL from a terminal, there is no X server, so `xclip` won't work. However, my Ubuntu WSL image at work still has `xclip` installed, which `gitui` detects and uses, causing `gitui` to freeze. I have to kill `gitui` at that point.

This PR checks if we are running in WSL by examining the description of the kernel in the OS release file, `/proc/sys/kernel/osrelease`. If `gitui` is running in WSL, we copy the path to the Windows clipboard using the `clip.exe` utility.

I followed the checklist:
- [ ] I added unittests (I didn't see any other unit tests in `clipboard.rs`, so I didn't try to add any here)
- [X] I ran `make check` without errors (proof: [output.txt](https://github.com/user-attachments/files/17581691/output.txt))
- [X] I tested the overall application (see below)
- [X] I added an appropriate item to the changelog (put in the `Added` subsection under `Unreleased`)

![gitui](https://github.com/user-attachments/assets/1242922c-9b39-4eba-a8d2-e5930efffd7d)
