### PR TITLE
fix: Ensure topological continuity when yanking commit range as `<oldest>^..<newest>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ![blame-goto-line](assets/blame-goto-line.png)
 
 ### Breaking Changes
-* reverse commit range before yanking marked commits, producing `<oldest>^..<newest>` for consecutive commit ranges. [[@Esgariot](https://github.com/Esgariot)] ([#2441](https://github.com/extrawurst/gitui/pull/2441))
 
 ### Added
 * support choosing checkout branch method when status is not empty [[@fatpandac](https://github.com/fatpandac)] ([#2404](https://github.com/extrawurst/gitui/issues/2404))
@@ -74,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * disable blame and history popup keybinds for untracked files [[@kpbaks](https://github.com/kpbaks)] ([#2489](https://github.com/gitui-org/gitui/pull/2489))
 * overwrites committer on amend of unsigned commits [[@cruessler](https://github.com/cruessler)] ([#2784](https://github.com/gitui-org/gitui/issues/2784))
 * Updated project links to point to `gitui-org` instead of `extrawurst`  [[@vasleymus](https://github.com/vasleymus)] ([#2538](https://github.com/gitui-org/gitui/pull/2538))
+* check if selected range is [topologically continuous](https://git-scm.com/docs/git-log#Documentation/git-log.txt---topo-order) before producing `<oldest>^..<newest>` for yanked commit ranges. [[@Esgariot](https://github.com/Esgariot)] ([#2441](https://github.com/extrawurst/gitui/pull/2441))
 
 ## [0.27.0] - 2025-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **go to line in blame**
 ![blame-goto-line](assets/blame-goto-line.png)
 
+### Breaking Changes
+* reverse commit range before yanking marked commits, producing `<oldest>^..<newest>` for consecutive commit ranges. [[@Esgariot](https://github.com/Esgariot)] ([#2441](https://github.com/extrawurst/gitui/pull/2441))
+
 ### Added
 * support choosing checkout branch method when status is not empty [[@fatpandac](https://github.com/fatpandac)] ([#2404](https://github.com/extrawurst/gitui/issues/2404))
 * support pre-push hook [[@xlai89](https://github.com/xlai89)] ([#1933](https://github.com/extrawurst/gitui/issues/1933))

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -66,8 +66,6 @@ pub use config::{
 };
 pub use diff::get_diff_commit;
 pub use git2::BranchType;
-pub use git2::ResetType;
-pub use git2::Sort;
 pub use hooks::{
 	hooks_commit_msg, hooks_post_commit, hooks_pre_commit,
 	hooks_pre_push, hooks_prepare_commit_msg, HookResult,
@@ -111,6 +109,8 @@ pub use utils::{
 	get_head, get_head_tuple, repo_dir, repo_open_error,
 	stage_add_all, stage_add_file, stage_addremoved, Head,
 };
+
+pub use git2::ResetType;
 
 /// test utils
 #[cfg(test)]

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -24,7 +24,7 @@ mod rebase;
 pub mod remotes;
 mod repository;
 mod reset;
-mod revwalk;
+pub mod revwalk;
 mod reword;
 pub mod sign;
 mod staging;
@@ -91,7 +91,6 @@ pub use remotes::{
 pub(crate) use repository::{gix_repo, repo};
 pub use repository::{RepoPath, RepoPathRef};
 pub use reset::{reset_repo, reset_stage, reset_workdir};
-pub use revwalk::revwalk;
 pub use reword::reword;
 pub use staging::{discard_lines, stage_lines};
 pub use stash::{

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -24,6 +24,7 @@ mod rebase;
 pub mod remotes;
 mod repository;
 mod reset;
+mod revwalk;
 mod reword;
 pub mod sign;
 mod staging;
@@ -65,6 +66,7 @@ pub use config::{
 };
 pub use diff::get_diff_commit;
 pub use git2::BranchType;
+pub use git2::Sort;
 pub use hooks::{
 	hooks_commit_msg, hooks_post_commit, hooks_pre_commit,
 	hooks_pre_push, hooks_prepare_commit_msg, HookResult,
@@ -88,6 +90,7 @@ pub use remotes::{
 pub(crate) use repository::{gix_repo, repo};
 pub use repository::{RepoPath, RepoPathRef};
 pub use reset::{reset_repo, reset_stage, reset_workdir};
+pub use revwalk::revwalk;
 pub use reword::reword;
 pub use staging::{discard_lines, stage_lines};
 pub use stash::{

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -66,6 +66,7 @@ pub use config::{
 };
 pub use diff::get_diff_commit;
 pub use git2::BranchType;
+pub use git2::ResetType;
 pub use git2::Sort;
 pub use hooks::{
 	hooks_commit_msg, hooks_post_commit, hooks_pre_commit,
@@ -111,8 +112,6 @@ pub use utils::{
 	get_head, get_head_tuple, repo_dir, repo_open_error,
 	stage_add_all, stage_add_file, stage_addremoved, Head,
 };
-
-pub use git2::ResetType;
 
 /// test utils
 #[cfg(test)]

--- a/asyncgit/src/sync/revwalk.rs
+++ b/asyncgit/src/sync/revwalk.rs
@@ -1,90 +1,141 @@
 //! git revwalk utils
-use std::ops::{Bound, ControlFlow};
-
-use crate::Result;
-use git2::{Commit, Oid};
-
 use super::{repo, CommitId, RepoPath};
+use crate::Result;
+use git2::Oid;
+use std::ops::ControlFlow;
 
-/// Performs a Git revision walk.
+/// Checks if `commits` range is topologically continuous
 ///
-/// The revwalk is optionally bounded by `start` and `end` commits, sorted according to `sort`.
-/// The revwalk iterator bound by repository's lifetime is exposed through the `iter_fn`.
-pub fn revwalk<R>(
-	repo_path: &RepoPath,
-	start: Bound<&CommitId>,
-	end: Bound<&CommitId>,
-	sort: git2::Sort,
-	iter_fn: impl FnOnce(
-		&mut (dyn Iterator<Item = Result<Oid>>),
-	) -> Result<R>,
-) -> Result<R> {
-	let repo = repo(repo_path)?;
-	let mut revwalk = repo.revwalk()?;
-	revwalk.set_sorting(sort)?;
-	let start = resolve(&repo, start)?;
-	let end = resolve(&repo, end)?;
-
-	if let Some(s) = start {
-		revwalk.hide(s.id())?;
-	}
-	if let Some(e) = end {
-		revwalk.push(e.id())?;
-	}
-	{
-		#![allow(clippy::let_and_return)]
-		let ret = iter_fn(&mut revwalk.map(|r| {
-			r.map_err(|x| crate::Error::Generic(x.to_string()))
-		}));
-		ret
-	}
-}
-
-fn resolve<'r>(
-	repo: &'r git2::Repository,
-	commit: Bound<&CommitId>,
-) -> Result<Option<Commit<'r>>> {
-	match commit {
-		Bound::Included(c) => {
-			let commit = repo.find_commit(c.get_oid())?;
-			Ok(Some(commit))
-		}
-		Bound::Excluded(s) => {
-			let commit = repo.find_commit(s.get_oid())?;
-			let res = (commit.parent_count() == 1)
-				.then(|| commit.parent(0))
-				.transpose()?;
-			Ok(res)
-		}
-		Bound::Unbounded => Ok(None),
-	}
-}
-
-/// Checks if `commits` range is continuous under `sort` flags.
+/// Supports only linear paths - presence of merge commits results in `false`.
 pub fn is_continuous(
 	repo_path: &RepoPath,
-	sort: git2::Sort,
 	commits: &[CommitId],
 ) -> Result<bool> {
 	match commits {
 		[] | [_] => Ok(true),
-		[start, .., end] => revwalk(
-			repo_path,
-			Bound::Excluded(start),
-			Bound::Included(end),
-			sort,
-			|revwalk| match revwalk.zip(commits).try_fold(
+		commits => {
+			let repo = repo(repo_path)?;
+			let mut revwalk = repo.revwalk()?;
+			revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+			revwalk.simplify_first_parent()?;
+			revwalk.push(commits[0].get_oid())?;
+			let revwalked: Vec<Oid> =
+				revwalk
+					.take(commits.len())
+					.collect::<std::result::Result<Vec<_>, _>>()?;
+
+			if revwalked.len() != commits.len() {
+				return Ok(false);
+			}
+
+			match revwalked.iter().zip(commits).try_fold(
 				Ok(true),
-				|acc, (r, c)| match r
-					.map(CommitId::new)
-					.and_then(|r| acc.map(|acc| acc && (&r == c)))
+				|acc, (r, c)| match acc
+					.map(|acc| acc && (&(CommitId::from(*r)) == c))
 				{
-					Ok(true) => ControlFlow::Continue(Ok(true)),
+					ok @ Ok(true) => ControlFlow::Continue(ok),
 					otherwise => ControlFlow::Break(otherwise),
 				},
 			) {
 				ControlFlow::Continue(v) | ControlFlow::Break(v) => v,
-			},
-		),
+			}
+		}
+	}
+}
+#[cfg(test)]
+mod tests_is_continuous {
+	use crate::sync::{
+		checkout_commit, commit, merge_commit,
+		revwalk::is_continuous, tests::repo_init_empty, RepoPath,
+	};
+
+	#[test]
+	fn test_linear_commits_are_continuous() {
+		// * c3 (HEAD)
+		// * c2
+		// * c1
+		// * c0 (root)
+
+		let (_td, repo) = repo_init_empty().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+		let _c0 = commit(repo_path, "commit 0").unwrap();
+		let c1 = commit(repo_path, "commit 1").unwrap();
+		let c2 = commit(repo_path, "commit 2").unwrap();
+		let c3 = commit(repo_path, "commit 3").unwrap();
+
+		let result = is_continuous(repo_path, &[c3, c2, c1]).unwrap();
+		assert!(result, "linear commits should be continuous");
+
+		let result = is_continuous(repo_path, &[c2]).unwrap();
+		assert!(result, "single commit should be continuous");
+
+		let result = is_continuous(repo_path, &[]).unwrap();
+		assert!(result, "empty range should be continuous");
+	}
+
+	#[test]
+	fn test_merge_commits_break_continuity() {
+		// *   c4 (HEAD)
+		// |\
+		// | * c3
+		// * | c2
+		// |/
+		// * c1
+		// * c0 (root)
+
+		let (_td, repo) = repo_init_empty().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		let _c0 = commit(repo_path, "commit 0").unwrap();
+		let c1 = commit(repo_path, "commit 1").unwrap();
+		let c2 = commit(repo_path, "commit 2").unwrap();
+
+		checkout_commit(repo_path, c1).unwrap();
+		let c3 = commit(repo_path, "commit 3").unwrap();
+
+		let c4 =
+			merge_commit(repo_path, "commit 4", &[c2, c3]).unwrap();
+
+		let result = is_continuous(repo_path, &[c4, c2, c1]).unwrap();
+		assert!(
+			!result,
+			"range including merge should not be continuous"
+		);
+
+		let result = is_continuous(repo_path, &[c2, c1]).unwrap();
+		assert!(
+			result,
+			"linear range before merge should be continuous"
+		);
+	}
+
+	#[test]
+	fn test_non_continuous_commits() {
+		// * c4 (HEAD)
+		// * c3
+		// * c2
+		// * c1
+		// * c0 (root)
+
+		let (_td, repo) = repo_init_empty().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		let _c0 = commit(repo_path, "commit 0").unwrap();
+		let c1 = commit(repo_path, "commit 1").unwrap();
+		let c2 = commit(repo_path, "commit 2").unwrap();
+		let c3 = commit(repo_path, "commit 3").unwrap();
+		let c4 = commit(repo_path, "commit 4").unwrap();
+
+		let result = is_continuous(repo_path, &[c4, c3, c1]).unwrap();
+		assert!(!result, "commit range with gap should return false");
+
+		let result = is_continuous(repo_path, &[c1, c2, c3]).unwrap();
+		assert!(!result, "wrong order should return false");
 	}
 }

--- a/asyncgit/src/sync/revwalk.rs
+++ b/asyncgit/src/sync/revwalk.rs
@@ -5,11 +5,10 @@ use git2::{Commit, Oid};
 
 use super::{repo, CommitId, RepoPath};
 
-/// Performs a Git revision walk on `repo_path`, optionally bounded by `start` and `end` commits,
-/// sorted according to `sort`. The revwalk iterator bound by repository's lifetime is exposed through
-/// the `iter_fn`.
+/// Performs a Git revision walk.
 ///
-///
+/// The revwalk is optionally bounded by `start` and `end` commits, sorted according to `sort`.
+/// The revwalk iterator bound by repository's lifetime is exposed through the `iter_fn`.
 pub fn revwalk<R>(
 	repo_path: &RepoPath,
 	start: Bound<&CommitId>,
@@ -31,10 +30,13 @@ pub fn revwalk<R>(
 	if let Some(e) = end {
 		revwalk.push(e.id())?;
 	}
-	let ret = iter_fn(&mut revwalk.map(|r| {
-		r.map_err(|x| crate::Error::Generic(x.to_string()))
-	}));
-	ret
+	{
+		#![allow(clippy::let_and_return)]
+		let ret = iter_fn(&mut revwalk.map(|r| {
+			r.map_err(|x| crate::Error::Generic(x.to_string()))
+		}));
+		ret
+	}
 }
 
 fn resolve<'r>(

--- a/asyncgit/src/sync/revwalk.rs
+++ b/asyncgit/src/sync/revwalk.rs
@@ -2,7 +2,6 @@
 use super::{repo, CommitId, RepoPath};
 use crate::Result;
 use git2::Oid;
-use std::ops::ControlFlow;
 
 /// Checks if `commits` range is topologically continuous
 ///
@@ -27,17 +26,11 @@ pub fn is_continuous(
 				return Ok(false);
 			}
 
-			match revwalked.iter().zip(commits).try_fold(
-				Ok(true),
-				|acc, (r, c)| match acc
-					.map(|acc| acc && (&(CommitId::from(*r)) == c))
-				{
-					ok @ Ok(true) => ControlFlow::Continue(ok),
-					otherwise => ControlFlow::Break(otherwise),
+			Ok(revwalked.iter().zip(commits).all(
+				|(oid, commit_id)| {
+					&(CommitId::from(*oid)) == commit_id
 				},
-			) {
-				ControlFlow::Continue(v) | ControlFlow::Break(v) => v,
-			}
+			))
 		}
 	}
 }

--- a/asyncgit/src/sync/revwalk.rs
+++ b/asyncgit/src/sync/revwalk.rs
@@ -17,7 +17,6 @@ pub fn is_continuous(
 			let repo = repo(repo_path)?;
 			let mut revwalk = repo.revwalk()?;
 			revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
-			revwalk.simplify_first_parent()?;
 			revwalk.push(commits[0].get_oid())?;
 			let revwalked: Vec<Oid> =
 				revwalk
@@ -90,7 +89,7 @@ mod tests_is_continuous {
 		let repo_path: &RepoPath =
 			&root.as_os_str().to_str().unwrap().into();
 
-		let _c0 = commit(repo_path, "commit 0").unwrap();
+		let c0 = commit(repo_path, "commit 0").unwrap();
 		let c1 = commit(repo_path, "commit 1").unwrap();
 		let c2 = commit(repo_path, "commit 2").unwrap();
 
@@ -106,7 +105,13 @@ mod tests_is_continuous {
 			"range including merge should not be continuous"
 		);
 
-		let result = is_continuous(repo_path, &[c2, c1]).unwrap();
+		let result = is_continuous(repo_path, &[c4, c3, c1]).unwrap();
+		assert!(
+			!result,
+			"range including merge should not be continuous (following second parent commit)"
+		);
+
+		let result = is_continuous(repo_path, &[c2, c1, c0]).unwrap();
 		assert!(
 			result,
 			"linear range before merge should be continuous"

--- a/asyncgit/src/sync/revwalk.rs
+++ b/asyncgit/src/sync/revwalk.rs
@@ -1,0 +1,58 @@
+use std::ops::Bound;
+
+use crate::Result;
+use git2::{Commit, Oid};
+
+use super::{repo, CommitId, RepoPath};
+
+/// Performs a Git revision walk on `repo_path`, optionally bounded by `start` and `end` commits,
+/// sorted according to `sort`. The revwalk iterator bound by repository's lifetime is exposed through
+/// the `iter_fn`.
+///
+///
+pub fn revwalk<R>(
+	repo_path: &RepoPath,
+	start: Bound<&CommitId>,
+	end: Bound<&CommitId>,
+	sort: git2::Sort,
+	iter_fn: impl FnOnce(
+		&mut (dyn Iterator<Item = Result<Oid>>),
+	) -> Result<R>,
+) -> Result<R> {
+	let repo = repo(repo_path)?;
+	let mut revwalk = repo.revwalk()?;
+	revwalk.set_sorting(sort)?;
+	let start = resolve(&repo, start)?;
+	let end = resolve(&repo, end)?;
+
+	if let Some(s) = start {
+		revwalk.hide(s.id())?;
+	}
+	if let Some(e) = end {
+		revwalk.push(e.id())?;
+	}
+	let ret = iter_fn(&mut revwalk.map(|r| {
+		r.map_err(|x| crate::Error::Generic(x.to_string()))
+	}));
+	ret
+}
+
+fn resolve<'r>(
+	repo: &'r git2::Repository,
+	commit: Bound<&CommitId>,
+) -> Result<Option<Commit<'r>>> {
+	match commit {
+		Bound::Included(c) => {
+			let commit = repo.find_commit(c.get_oid())?;
+			Ok(Some(commit))
+		}
+		Bound::Excluded(s) => {
+			let commit = repo.find_commit(s.get_oid())?;
+			let res = (commit.parent_count() == 1)
+				.then(|| commit.parent(0))
+				.transpose()?;
+			Ok(res)
+		}
+		Bound::Unbounded => Ok(None),
+	}
+}

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -15,7 +15,7 @@ use crate::{
 use anyhow::Result;
 use asyncgit::sync::{
 	self, checkout_commit, revwalk, BranchDetails, BranchInfo,
-	CommitId, RepoPathRef, Sort, Tags,
+	CommitId, RepoPathRef, Tags,
 };
 use chrono::{DateTime, Local};
 use crossterm::event::Event;
@@ -144,7 +144,6 @@ impl CommitList {
 			[latest, .., earliest]
 				if revwalk::is_continuous(
 					&self.repo.borrow(),
-					Sort::TOPOLOGICAL,
 					&self.marked.iter().map(|x| x.1).collect_vec(),
 				)? =>
 			{

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -1046,35 +1046,4 @@ mod tests {
 			))
 		);
 	}
-
-	#[test]
-	#[ignore = "needs real repository to run test. Will be moved to revwalk module."]
-	fn test_copy_commit_range_marked() {
-		let cl = build_commit_list_with_some_commits();
-		let cl = CommitList {
-			marked: build_marked_from_indices(&cl, &[4, 5, 6, 7]),
-			..cl
-		};
-		assert_eq!(
-			cl.concat_selected_commit_ids().unwrap(),
-			Some(String::from("0000000000000000000000000000000000000005^..0000000000000000000000000000000000000002"))
-		);
-	}
-
-	#[test]
-	#[ignore = "needs real repository to run test. Will be moved to revwalk module."]
-	fn test_copy_commit_random_marked() {
-		let cl = build_commit_list_with_some_commits();
-		let cl = CommitList {
-			marked: build_marked_from_indices(&cl, &[4, 7]),
-			..cl
-		};
-		assert_eq!(
-			cl.concat_selected_commit_ids().unwrap(),
-			Some(String::from(concat!(
-				"0000000000000000000000000000000000000002 ",
-				"0000000000000000000000000000000000000005"
-			)))
-		);
-	}
 }

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -141,6 +141,14 @@ impl CommitList {
 						.saturating_sub(self.items.index_offset()),
 				)
 				.map(|e| e.id.to_string()),
+			[latest, .., earliest]
+				if self
+					.marked()
+					.windows(2)
+					.all(|w| w[0].0 + 1 == w[1].0) =>
+			{
+				Some(format!("{}^..{}", earliest.1, latest.1))
+			}
 			marked => Some(
 				marked
 					.iter()
@@ -1045,12 +1053,7 @@ mod tests {
 		};
 		assert_eq!(
 			cl.concat_selected_commit_ids(),
-			Some(String::from(concat!(
-				"0000000000000000000000000000000000000002 ",
-				"0000000000000000000000000000000000000003 ",
-				"0000000000000000000000000000000000000004 ",
-				"0000000000000000000000000000000000000005"
-			)))
+			Some(String::from("0000000000000000000000000000000000000005^..0000000000000000000000000000000000000002"))
 		);
 	}
 


### PR DESCRIPTION
Produce `<oldest>^..<newest>` when yanking consecutive range.
Now, given consecutive marked selection, gitui's selection matches
`git log`'s output in commit range.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2246.

It changes the following:

Produce `<oldest>^..<newest>` when yanking consecutive range.
Now, given consecutive marked selection, gitui's selection matches
`git log`'s output in commit range.

I followed the checklist:
- [x] I added unittests
- [ ] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog
