### PR TITLE
Set the terminal title to `gitui ({repo_path})`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* set the terminal title to `gitui ({repo_path})` [[@acuteenvy](https://github.com/acuteenvy)] ([#2462](https://github.com/extrawurst/gitui/issues/2462))
+
 ## [0.27.0] - 2024-01-14
 
 **new: manage remotes**


### PR DESCRIPTION
This Pull Request fixes/closes #2462.

It changes the following:
- Always set the terminal title to `gitui ({repo_path})`.
It looks like this:
![screenshot](https://github.com/user-attachments/assets/f87ad432-7254-4238-98bd-194b83407524)

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog