### PR TITLE
fix: disable blame and history popup for untracked files

### DIFF
--- a/src/components/status_tree.rs
+++ b/src/components/status_tree.rs
@@ -394,11 +394,18 @@ impl Component for StatusTreeComponent {
 		out: &mut Vec<CommandInfo>,
 		force_all: bool,
 	) -> CommandBlocking {
+		let available = self.focused || force_all;
+		let selection = self.selection_file();
+		let selected_is_file = selection.is_some();
+		let tracked = selection.is_some_and(|s| {
+			!matches!(s.status, StatusItemType::New)
+		});
+
 		out.push(
 			CommandInfo::new(
 				strings::commands::navigate_tree(&self.key_config),
 				!self.is_empty(),
-				self.focused || force_all,
+				available,
 			)
 			.order(order::NAV),
 		);
@@ -406,8 +413,8 @@ impl Component for StatusTreeComponent {
 		out.push(
 			CommandInfo::new(
 				strings::commands::blame_file(&self.key_config),
-				self.selection_file().is_some(),
-				self.focused || force_all,
+				selected_is_file && tracked,
+				available,
 			)
 			.order(order::RARE_ACTION),
 		);
@@ -417,8 +424,8 @@ impl Component for StatusTreeComponent {
 				strings::commands::open_file_history(
 					&self.key_config,
 				),
-				self.selection_file().is_some(),
-				self.focused || force_all,
+				selected_is_file && tracked,
+				available,
 			)
 			.order(order::RARE_ACTION),
 		);
@@ -426,8 +433,8 @@ impl Component for StatusTreeComponent {
 		out.push(
 			CommandInfo::new(
 				strings::commands::edit_item(&self.key_config),
-				self.selection_file().is_some(),
-				self.focused || force_all,
+				selected_is_file,
+				available,
 			)
 			.order(order::RARE_ACTION),
 		);
@@ -435,8 +442,8 @@ impl Component for StatusTreeComponent {
 		out.push(
 			CommandInfo::new(
 				strings::commands::copy_path(&self.key_config),
-				self.selection_file().is_some(),
-				self.focused || force_all,
+				selected_is_file,
+				available,
 			)
 			.order(order::RARE_ACTION),
 		);
@@ -448,30 +455,53 @@ impl Component for StatusTreeComponent {
 		if self.focused {
 			if let Event::Key(e) = ev {
 				return if key_match(e, self.key_config.keys.blame) {
-					if let Some(status_item) = self.selection_file() {
-						self.hide();
-						self.queue.push(InternalEvent::OpenPopup(
-							StackablePopupOpen::BlameFile(
-								BlameFileOpen {
-									file_path: status_item.path,
-									commit_id: self.revision,
-									selection: None,
-								},
-							),
-						));
+					match self.selection_file() {
+						Some(status_item)
+							if !matches!(
+								status_item.status,
+								StatusItemType::New
+							) =>
+						{
+							self.hide();
+							self.queue.push(
+								InternalEvent::OpenPopup(
+									StackablePopupOpen::BlameFile(
+										BlameFileOpen {
+											file_path: status_item
+												.path,
+											commit_id: self.revision,
+											selection: None,
+										},
+									),
+								),
+							);
+						}
+						_ => {}
 					}
 					Ok(EventState::Consumed)
 				} else if key_match(
 					e,
 					self.key_config.keys.file_history,
 				) {
-					if let Some(status_item) = self.selection_file() {
-						self.hide();
-						self.queue.push(InternalEvent::OpenPopup(
-							StackablePopupOpen::FileRevlog(
-								FileRevOpen::new(status_item.path),
-							),
-						));
+					match self.selection_file() {
+						Some(status_item)
+							if !matches!(
+								status_item.status,
+								StatusItemType::New
+							) =>
+						{
+							self.hide();
+							self.queue.push(
+								InternalEvent::OpenPopup(
+									StackablePopupOpen::FileRevlog(
+										FileRevOpen::new(
+											status_item.path,
+										),
+									),
+								),
+							);
+						}
+						_ => {}
 					}
 					Ok(EventState::Consumed)
 				} else if key_match(e, self.key_config.keys.edit_file)


### PR DESCRIPTION
An untracked file does not have any history data. Right now when you press `B` for the blame popup or the `H` for the history popup you get an empty popup where the title spins endlessly trying to find the file in the commit history, and show relevant information. This commit 

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

It changes the following:
- disables the two actions in the `StatusTreeComponent`, when the selected item is a file which is not tracked by git.

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog