### PR TITLE
Support choosing checkout branch method when status is not empty

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.rs]
+indent_style = tab

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -195,3 +195,23 @@ pub fn get_status(
 
 	Ok(res)
 }
+
+/// discard all changes in the working directory
+pub fn discard_status(repo_path: &RepoPath) -> Result<bool> {
+	let repo = repo(repo_path)?;
+	let statuses = repo.statuses(None)?;
+
+	for status in statuses.iter() {
+		if status.status().is_wt_modified()
+			|| status.status().is_wt_new()
+		{
+			let oid = repo.head()?.target().unwrap();
+			let obj = repo.find_object(oid, None)?;
+
+			repo.checkout_tree(&obj, None)?;
+			repo.reset(&obj, git2::ResetType::Hard, None)?;
+		}
+	}
+
+	Ok(true)
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,16 +10,16 @@ use crate::{
 	options::{Options, SharedOptions},
 	popup_stack::PopupStack,
 	popups::{
-		AppOption, BlameFilePopup, BranchListPopup, CommitPopup,
-		CompareCommitsPopup, ConfirmPopup, CreateBranchPopup,
-		CreateRemotePopup, ExternalEditorPopup, FetchPopup,
-		FileRevlogPopup, FuzzyFindPopup, HelpPopup,
-		InspectCommitPopup, LogSearchPopupPopup, MsgPopup,
-		OptionsPopup, PullPopup, PushPopup, PushTagsPopup,
-		RemoteListPopup, RenameBranchPopup, RenameRemotePopup,
-		ResetPopup, RevisionFilesPopup, StashMsgPopup,
-		SubmodulesListPopup, TagCommitPopup, TagListPopup,
-		UpdateRemoteUrlPopup, CheckoutOptionPopup
+		AppOption, BlameFilePopup, BranchListPopup,
+		CheckoutOptionPopup, CommitPopup, CompareCommitsPopup,
+		ConfirmPopup, CreateBranchPopup, CreateRemotePopup,
+		ExternalEditorPopup, FetchPopup, FileRevlogPopup,
+		FuzzyFindPopup, HelpPopup, InspectCommitPopup,
+		LogSearchPopupPopup, MsgPopup, OptionsPopup, PullPopup,
+		PushPopup, PushTagsPopup, RemoteListPopup, RenameBranchPopup,
+		RenameRemotePopup, ResetPopup, RevisionFilesPopup,
+		StashMsgPopup, SubmodulesListPopup, TagCommitPopup,
+		TagListPopup, UpdateRemoteUrlPopup,
 	},
 	queue::{
 		Action, AppTabs, InternalEvent, NeedsUpdate, Queue,
@@ -98,7 +98,7 @@ pub struct App {
 	submodule_popup: SubmodulesListPopup,
 	tags_popup: TagListPopup,
 	reset_popup: ResetPopup,
-  checkout_option_popup: CheckoutOptionPopup,
+	checkout_option_popup: CheckoutOptionPopup,
 	cmdbar: RefCell<CommandBar>,
 	tab: usize,
 	revlog: Revlog,
@@ -219,7 +219,7 @@ impl App {
 			stashing_tab: Stashing::new(&env),
 			stashlist_tab: StashList::new(&env),
 			files_tab: FilesTab::new(&env),
-      checkout_option_popup: CheckoutOptionPopup::new(&env),
+			checkout_option_popup: CheckoutOptionPopup::new(&env),
 			tab: 0,
 			queue: env.queue,
 			theme: env.theme,
@@ -495,7 +495,7 @@ impl App {
 			fetch_popup,
 			tag_commit_popup,
 			reset_popup,
-      checkout_option_popup,
+			checkout_option_popup,
 			create_branch_popup,
 			create_remote_popup,
 			rename_remote_popup,
@@ -536,7 +536,7 @@ impl App {
 			submodule_popup,
 			tags_popup,
 			reset_popup,
-      checkout_option_popup,
+			checkout_option_popup,
 			create_branch_popup,
 			rename_branch_popup,
 			revision_files_popup,
@@ -908,10 +908,10 @@ impl App {
 			}
 			InternalEvent::CommitSearch(options) => {
 				self.revlog.search(options);
-			},
-      InternalEvent::CheckoutOption(branch, is_local) => {
-        self.checkout_option_popup.open(branch, is_local)?;
-      }
+			}
+			InternalEvent::CheckoutOption(branch, is_local) => {
+				self.checkout_option_popup.open(branch, is_local)?;
+			}
 		};
 
 		Ok(flags)

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,7 +19,7 @@ use crate::{
 		RemoteListPopup, RenameBranchPopup, RenameRemotePopup,
 		ResetPopup, RevisionFilesPopup, StashMsgPopup,
 		SubmodulesListPopup, TagCommitPopup, TagListPopup,
-		UpdateRemoteUrlPopup,
+		UpdateRemoteUrlPopup, CheckoutOptionPopup
 	},
 	queue::{
 		Action, AppTabs, InternalEvent, NeedsUpdate, Queue,
@@ -98,6 +98,7 @@ pub struct App {
 	submodule_popup: SubmodulesListPopup,
 	tags_popup: TagListPopup,
 	reset_popup: ResetPopup,
+  checkout_option_popup: CheckoutOptionPopup,
 	cmdbar: RefCell<CommandBar>,
 	tab: usize,
 	revlog: Revlog,
@@ -218,6 +219,7 @@ impl App {
 			stashing_tab: Stashing::new(&env),
 			stashlist_tab: StashList::new(&env),
 			files_tab: FilesTab::new(&env),
+      checkout_option_popup: CheckoutOptionPopup::new(&env),
 			tab: 0,
 			queue: env.queue,
 			theme: env.theme,
@@ -493,6 +495,7 @@ impl App {
 			fetch_popup,
 			tag_commit_popup,
 			reset_popup,
+      checkout_option_popup,
 			create_branch_popup,
 			create_remote_popup,
 			rename_remote_popup,
@@ -533,6 +536,7 @@ impl App {
 			submodule_popup,
 			tags_popup,
 			reset_popup,
+      checkout_option_popup,
 			create_branch_popup,
 			rename_branch_popup,
 			revision_files_popup,
@@ -904,7 +908,10 @@ impl App {
 			}
 			InternalEvent::CommitSearch(options) => {
 				self.revlog.search(options);
-			}
+			},
+      InternalEvent::CheckoutOption(branch, is_local) => {
+        self.checkout_option_popup.open(branch, is_local)?;
+      }
 		};
 
 		Ok(flags)

--- a/src/popups/branchlist.rs
+++ b/src/popups/branchlist.rs
@@ -610,7 +610,7 @@ impl BranchListPopup {
 		} else {
 			self.queue.push(InternalEvent::CheckoutOption(
 				selected_branch.clone(),
-        self.local.clone()
+				self.local.clone(),
 			));
 		}
 

--- a/src/popups/checkout_option.rs
+++ b/src/popups/checkout_option.rs
@@ -1,0 +1,307 @@
+use crate::components::{
+	visibility_blocking, CommandBlocking, CommandInfo, Component,
+	DrawableComponent, EventState,
+};
+use crate::queue::{InternalEvent, NeedsUpdate};
+use crate::try_or_popup;
+use crate::{
+	app::Environment,
+	keys::{key_match, SharedKeyConfig},
+	queue::Queue,
+	strings,
+	ui::{self, style::SharedTheme},
+};
+use anyhow::{Ok, Result};
+use asyncgit::sync::branch::checkout_remote_branch;
+use asyncgit::sync::status::discard_status;
+use asyncgit::sync::RepoPath;
+use asyncgit::sync::{
+	checkout_branch, stash_apply, stash_save, BranchInfo,
+};
+use crossterm::event::Event;
+use ratatui::{
+	layout::{Alignment, Rect},
+	text::{Line, Span},
+	widgets::{Block, Borders, Clear, Paragraph},
+	Frame,
+};
+
+#[derive(PartialEq, Clone, Copy)]
+enum CheckoutOptions {
+	StashAndReapply,
+	Unchange,
+	Discard,
+}
+
+const fn type_to_string(
+	kind: CheckoutOptions,
+) -> (&'static str, &'static str) {
+	const CHECKOUT_OPTION_STASH_AND_REAPPLY: &str =
+		" 🟢 Stash and reapply changes";
+	const CHECKOUT_OPTION_UNCHANGE: &str = " 🟡 Keep local changes";
+	const CHECKOUT_OPTION_DISCARD: &str =
+		" 🔴 Discard all local changes";
+
+	match kind {
+		CheckoutOptions::StashAndReapply => {
+			("Stash and reapply", CHECKOUT_OPTION_STASH_AND_REAPPLY)
+		}
+		CheckoutOptions::Unchange => {
+			("Don't change", CHECKOUT_OPTION_UNCHANGE)
+		}
+		CheckoutOptions::Discard => {
+			("Discard", CHECKOUT_OPTION_DISCARD)
+		}
+	}
+}
+
+pub struct CheckoutOptionPopup {
+	queue: Queue,
+	repo: RepoPath,
+	local: bool,
+	branch: Option<BranchInfo>,
+	option: CheckoutOptions,
+	visible: bool,
+	key_config: SharedKeyConfig,
+	theme: SharedTheme,
+}
+
+impl CheckoutOptionPopup {
+	///
+	pub fn new(env: &Environment) -> Self {
+		Self {
+			queue: env.queue.clone(),
+			repo: env.repo.borrow().clone(),
+			local: false,
+			branch: None,
+			option: CheckoutOptions::StashAndReapply,
+			visible: false,
+			key_config: env.key_config.clone(),
+			theme: env.theme.clone(),
+		}
+	}
+
+	fn get_text(&self, _width: u16) -> Vec<Line> {
+		let mut txt: Vec<Line> = Vec::with_capacity(10);
+
+		txt.push(Line::from(vec![
+			Span::styled(
+				String::from("Switch to: "),
+				self.theme.text(true, false),
+			),
+			Span::styled(
+				self.branch.as_ref().unwrap().name.clone(),
+				self.theme.commit_hash(false),
+			),
+		]));
+
+		let (kind_name, kind_desc) = type_to_string(self.option);
+
+		txt.push(Line::from(vec![
+			Span::styled(
+				String::from("How: "),
+				self.theme.text(true, false),
+			),
+			Span::styled(kind_name, self.theme.text(true, true)),
+			Span::styled(kind_desc, self.theme.text(true, false)),
+		]));
+
+		txt
+	}
+
+	///
+	pub fn open(
+		&mut self,
+		branch: BranchInfo,
+		is_local: bool,
+	) -> Result<()> {
+		self.show()?;
+
+		self.branch = Some(branch);
+		self.local = is_local;
+
+		Ok(())
+	}
+
+	fn checkout(&self) -> Result<()> {
+		if self.local {
+			checkout_branch(
+				&self.repo,
+				&self.branch.as_ref().unwrap().name,
+			)?
+		} else {
+			checkout_remote_branch(
+				&self.repo,
+				&self.branch.as_ref().unwrap(),
+			)?;
+		}
+
+		Ok(())
+	}
+
+	fn handle_event(&mut self) -> Result<()> {
+		match self.option {
+			CheckoutOptions::StashAndReapply => {
+				let stash_id = stash_save(
+					&self.repo,
+					Some("Checkout auto stash"),
+					true,
+					false,
+				)?;
+				self.checkout()?;
+				stash_apply(&self.repo, stash_id, false)?;
+			}
+			CheckoutOptions::Unchange => {
+        self.checkout()?;
+			}
+			CheckoutOptions::Discard => {
+				discard_status(&self.repo)?;
+				self.checkout()?;
+			}
+		}
+
+		self.queue.push(InternalEvent::Update(NeedsUpdate::ALL));
+		self.queue.push(InternalEvent::SelectBranch);
+		self.hide();
+
+		Ok(())
+	}
+
+	fn change_kind(&mut self, incr: bool) {
+		self.option = if incr {
+			match self.option {
+				CheckoutOptions::StashAndReapply => {
+					CheckoutOptions::Unchange
+				}
+				CheckoutOptions::Unchange => CheckoutOptions::Discard,
+				CheckoutOptions::Discard => {
+					CheckoutOptions::StashAndReapply
+				}
+			}
+		} else {
+			match self.option {
+				CheckoutOptions::StashAndReapply => {
+					CheckoutOptions::Discard
+				}
+				CheckoutOptions::Unchange => {
+					CheckoutOptions::StashAndReapply
+				}
+				CheckoutOptions::Discard => CheckoutOptions::Unchange,
+			}
+		};
+	}
+}
+
+impl DrawableComponent for CheckoutOptionPopup {
+	fn draw(&self, f: &mut Frame, area: Rect) -> Result<()> {
+		if self.is_visible() {
+			const SIZE: (u16, u16) = (55, 4);
+			let area =
+				ui::centered_rect_absolute(SIZE.0, SIZE.1, area);
+
+			let width = area.width;
+
+			f.render_widget(Clear, area);
+			f.render_widget(
+				Paragraph::new(self.get_text(width))
+					.block(
+						Block::default()
+							.borders(Borders::ALL)
+							.title(Span::styled(
+								"Checkout options",
+								self.theme.title(true),
+							))
+							.border_style(self.theme.block(true)),
+					)
+					.alignment(Alignment::Left),
+				area,
+			);
+		}
+
+		Ok(())
+	}
+}
+
+impl Component for CheckoutOptionPopup {
+	fn commands(
+		&self,
+		out: &mut Vec<CommandInfo>,
+		force_all: bool,
+	) -> CommandBlocking {
+		if self.is_visible() || force_all {
+			out.push(
+				CommandInfo::new(
+					strings::commands::close_popup(&self.key_config),
+					true,
+					true,
+				)
+				.order(1),
+			);
+
+			out.push(
+				CommandInfo::new(
+					strings::commands::reset_commit(&self.key_config),
+					true,
+					true,
+				)
+				.order(1),
+			);
+
+			out.push(
+				CommandInfo::new(
+					strings::commands::reset_type(&self.key_config),
+					true,
+					true,
+				)
+				.order(1),
+			);
+		}
+
+		visibility_blocking(self)
+	}
+
+	fn event(
+		&mut self,
+		event: &crossterm::event::Event,
+	) -> Result<EventState> {
+		if self.is_visible() {
+			if let Event::Key(key) = &event {
+				if key_match(key, self.key_config.keys.exit_popup) {
+					self.hide();
+				} else if key_match(
+					key,
+					self.key_config.keys.move_down,
+				) {
+					self.change_kind(true);
+				} else if key_match(key, self.key_config.keys.move_up)
+				{
+					self.change_kind(false);
+				} else if key_match(key, self.key_config.keys.enter) {
+					try_or_popup!(
+						self,
+						"checkout error:",
+						self.handle_event()
+					);
+				}
+			}
+
+			return Ok(EventState::Consumed);
+		}
+
+		Ok(EventState::NotConsumed)
+	}
+
+	fn is_visible(&self) -> bool {
+		self.visible
+	}
+
+	fn hide(&mut self) {
+		self.visible = false;
+	}
+
+	fn show(&mut self) -> Result<()> {
+		self.visible = true;
+
+		Ok(())
+	}
+}

--- a/src/popups/checkout_option.rs
+++ b/src/popups/checkout_option.rs
@@ -152,7 +152,7 @@ impl CheckoutOptionPopup {
 				stash_apply(&self.repo, stash_id, false)?;
 			}
 			CheckoutOptions::Unchange => {
-        self.checkout()?;
+				self.checkout()?;
 			}
 			CheckoutOptions::Discard => {
 				discard_status(&self.repo)?;

--- a/src/popups/checkout_option.rs
+++ b/src/popups/checkout_option.rs
@@ -14,10 +14,8 @@ use crate::{
 use anyhow::{Ok, Result};
 use asyncgit::sync::branch::checkout_remote_branch;
 use asyncgit::sync::status::discard_status;
-use asyncgit::sync::RepoPath;
-use asyncgit::sync::{
-	checkout_branch, stash_apply, stash_save, BranchInfo,
-};
+use asyncgit::sync::{checkout_branch, stash_save, BranchInfo};
+use asyncgit::sync::{stash_pop, RepoPath};
 use crossterm::event::Event;
 use ratatui::{
 	layout::{Alignment, Rect},
@@ -149,7 +147,7 @@ impl CheckoutOptionPopup {
 					false,
 				)?;
 				self.checkout()?;
-				stash_apply(&self.repo, stash_id, false)?;
+				stash_pop(&self.repo, stash_id)?;
 			}
 			CheckoutOptions::Unchange => {
 				self.checkout()?;

--- a/src/popups/mod.rs
+++ b/src/popups/mod.rs
@@ -27,6 +27,7 @@ mod submodules;
 mod tag_commit;
 mod taglist;
 mod update_remote_url;
+mod checkout_option;
 
 pub use blame_file::{BlameFileOpen, BlameFilePopup};
 pub use branchlist::BranchListPopup;
@@ -57,6 +58,7 @@ pub use submodules::SubmodulesListPopup;
 pub use tag_commit::TagCommitPopup;
 pub use taglist::TagListPopup;
 pub use update_remote_url::UpdateRemoteUrlPopup;
+pub use checkout_option::CheckoutOptionPopup;
 
 use crate::ui::style::Theme;
 use ratatui::{

--- a/src/popups/mod.rs
+++ b/src/popups/mod.rs
@@ -1,5 +1,6 @@
 mod blame_file;
 mod branchlist;
+mod checkout_option;
 mod commit;
 mod compare_commits;
 mod confirm;
@@ -27,10 +28,10 @@ mod submodules;
 mod tag_commit;
 mod taglist;
 mod update_remote_url;
-mod checkout_option;
 
 pub use blame_file::{BlameFileOpen, BlameFilePopup};
 pub use branchlist::BranchListPopup;
+pub use checkout_option::CheckoutOptionPopup;
 pub use commit::CommitPopup;
 pub use compare_commits::CompareCommitsPopup;
 pub use confirm::ConfirmPopup;
@@ -58,7 +59,6 @@ pub use submodules::SubmodulesListPopup;
 pub use tag_commit::TagCommitPopup;
 pub use taglist::TagListPopup;
 pub use update_remote_url::UpdateRemoteUrlPopup;
-pub use checkout_option::CheckoutOptionPopup;
 
 use crate::ui::style::Theme;
 use ratatui::{

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use asyncgit::{
 	sync::{
-		diff::DiffLinePosition, CommitId, LogFilterSearchOptions,
+		diff::DiffLinePosition, BranchInfo, CommitId,
+		LogFilterSearchOptions,
 	},
 	PushType,
 };
@@ -157,6 +158,8 @@ pub enum InternalEvent {
 	RewordCommit(CommitId),
 	///
 	CommitSearch(LogFilterSearchOptions),
+	///
+	CheckoutOption(BranchInfo, bool),
 }
 
 /// single threaded simple queue for components to communicate with each other


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2404.

It changes the following:
- support choosing checkout branch method when status is not empty
- add .editorconfig file

![image](https://github.com/user-attachments/assets/625f1eb8-908d-473f-979e-3c52f0b41f26)


I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [ ] I added an appropriate item to the changelog