### PR TITLE
fix: File selector should jump back and highlight unstaged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+* After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
+
 ## [0.27.0] - 2024-01-14
 
 **new: manage remotes**

--- a/src/popups/commit.rs
+++ b/src/popups/commit.rs
@@ -218,6 +218,7 @@ impl CommitPopup {
 
 			self.hide();
 			self.queue.push(InternalEvent::Update(NeedsUpdate::ALL));
+			self.queue.push(InternalEvent::StatusLastFileMoved);
 			self.input.clear();
 		}
 


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2476.

It changes the following:
-  src/popups/commit.rs

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog