### PR TITLE
Improve syntax detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* fix syntax highlighting of files whose syntax cannot be detected from the extension [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
+
 ### Changed
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-* fix syntax highlighting of files whose syntax cannot be detected from the extension [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
-
 ### Changed
+* improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
 
 ## [0.27.0] - 2024-01-14


### PR DESCRIPTION
Currently, gitui prioritizes file extensions for syntax detection. When a file lacks an extension (e.g. `Makefile`), or the extension isn't tied to a specific format (e.g. `.lock`), it disables syntax highlighting.

This PR changes the syntax detecton method to the entire filename and the first line of the file using [`find_syntax_for_file()`](https://docs.rs/syntect/5.2.0/syntect/parsing/struct.SyntaxSet.html#method.find_syntax_for_file).

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog

#### Screenshots of highlighting `Cargo.lock` and `Makefile` from this repository:
<details>
<summary>Before</summary>

![old1](https://github.com/user-attachments/assets/ee287262-8b77-4d3e-820f-c1457348625d)
![old2](https://github.com/user-attachments/assets/4da47304-562a-46ca-a3f4-ecc3943f3ac1)
</details>

<details>
<summary>After</summary>

![new1](https://github.com/user-attachments/assets/18e91c8d-d3e9-479f-993f-2f3f56502e3e)
![new2](https://github.com/user-attachments/assets/5eca275e-6276-4751-a90e-397e53481e50)
<details>