### PR TITLE
Remove redundant `to_str()` conversion

### DIFF
--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -76,9 +76,7 @@ impl SyntaxText {
 			scope_time!("syntax_highlighting.0");
 			let plain_text = || SYNTAX_SET.find_syntax_plain_text();
 			let syntax = SYNTAX_SET
-				.find_syntax_for_file(
-					file_path.to_str().unwrap_or_default(),
-				)
+				.find_syntax_for_file(file_path)
 				.unwrap_or_else(|e| {
 					log::error!("Could not read the file to detect its syntax: {e}");
 					Some(plain_text())


### PR DESCRIPTION
The previously used function could only take `&str` as its argument, and I blindly copied it over here. This should've been part of #2524, sorry.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog