### PR TITLE
Use `gitoxide` in `get_commits_info` and `get_commit_info`

### DIFF
--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -1,5 +1,8 @@
 use super::{get_commits_info, CommitId, RepoPath};
-use crate::{error::Result, sync::repository::repo};
+use crate::{
+	error::Result,
+	sync::{gix_repo, repository::repo},
+};
 use scopetime::scope_time;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -58,9 +61,7 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 		}
 	};
 
-	let gix_repo: gix::Repository =
-				gix::ThreadSafeRepository::discover_with_environment_overrides(repo_path.gitpath())
-						.map(Into::into)?;
+	let gix_repo: gix::Repository = gix_repo(repo_path)?;
 	let platform = gix_repo.references()?;
 	for mut reference in (platform.tags()?).flatten() {
 		let commit = reference.peel_to_commit();


### PR DESCRIPTION
- Implement `From<gix::ObjectId>` for `CommitId`
- Use `gitoxide` in `get_commits_info` and `get_commit_info`

This PR changes `get_commits_info` and `get_commit_info` to use `gitoxide` under the hood. It does not explicitly change any behaviour, although there possibly are subtle differences that I’m not aware of.

This implementation doesn’t log an error when either `author` or `committer` cannot be resolved using `mailmap` as the underlying implementation returns `Option<Signature>` instead of `Result<Signature>`. If you want, I can change that, though.

I decided to duplicate the logic of `get_message` into `gix_get_message`, using a prefix for the time both implementations are required.

I did not attempt to re-organize any of the code. My plan is to convert more functions to `gitoxide` before making any changes in that direction.

I followed the checklist:

- [x] I ran `make check` without errors
- [x] I tested the overall application
