### PR TITLE
Update README.md add cargo install from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ GitUI is in beta and may contain bugs and missing features. However, for persona
     <img src="https://repology.org/badge/vertical-allrepos/gitui.svg" alt="Packaging status" align="right">
 </a>
 
+### Cargo latest nightly
+
+```sh
+cargo install --git https://github.com/gitui-org/gitui
+```
+
 ### Various Package Managers
 
 <details>


### PR DESCRIPTION
Looks like the last few published versions are failing to build, I could only install gitui using 
`cargo install --git https://github.com/gitui-org/gitui` so thought I'd add it to the README for others to find.