### PR TITLE
Support opening branches popup from all tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * new command-line option to override the default log file path (`--logfile`) [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
 * dx: `make check` checks Cargo.toml dependency ordering using `cargo sort` [[@naseschwarz](https://github.com/naseschwarz)]
 * add `use_selection_fg` to theme file to allow customizing selection foreground color [[@Upsylonbare](https://github.com/Upsylonbare)] ([#2515](https://github.com/gitui-org/gitui/pull/2515))
+* Support opening branches popup from all tabs [[@kpbaks](https://github.com/kpbaks)] ([#2709](https://github.com/gitui-org/gitui/pull/2709))
 
 ### Changed
 * improve error messages [[@acuteenvy](https://github.com/acuteenvy)] ([#2617](https://github.com/gitui-org/gitui/pull/2617))

--- a/src/components/revision_files.rs
+++ b/src/components/revision_files.rs
@@ -446,6 +446,13 @@ impl Component for RevisionFilesComponent {
 				)
 				.order(order::RARE_ACTION),
 			);
+			out.push(CommandInfo::new(
+				strings::commands::open_branch_select_popup(
+					&self.key_config,
+				),
+				true,
+				self.is_visible() || force_all,
+			));
 			tree_nav_cmds(&self.tree, &self.key_config, out);
 		} else {
 			self.current_file.commands(out, force_all);
@@ -522,6 +529,12 @@ impl Component for RevisionFilesComponent {
 						crate::clipboard::copy_string(&file)
 					);
 				}
+				return Ok(EventState::Consumed);
+			} else if key_match(
+				key,
+				self.key_config.keys.select_branch,
+			) {
+				self.queue.push(InternalEvent::SelectBranch);
 				return Ok(EventState::Consumed);
 			} else if !is_tree_focused {
 				return self.current_file.event(event);

--- a/src/tabs/stashing.rs
+++ b/src/tabs/stashing.rs
@@ -199,6 +199,13 @@ impl Component for Stashing {
 				self.visible,
 				self.visible || force_all,
 			));
+			out.push(CommandInfo::new(
+				strings::commands::open_branch_select_popup(
+					&self.key_config,
+				),
+				true,
+				true,
+			));
 		}
 
 		visibility_blocking(self)
@@ -242,6 +249,12 @@ impl Component for Stashing {
 						!self.options.stash_untracked;
 					self.update()?;
 					Ok(EventState::Consumed)
+				} else if key_match(
+					k,
+					self.key_config.keys.select_branch,
+				) {
+					self.queue.push(InternalEvent::SelectBranch);
+					return Ok(EventState::Consumed);
 				} else {
 					Ok(EventState::NotConsumed)
 				};

--- a/src/tabs/stashlist.rs
+++ b/src/tabs/stashlist.rs
@@ -182,6 +182,13 @@ impl Component for StashList {
 				selection_valid,
 				true,
 			));
+			out.push(CommandInfo::new(
+				strings::commands::open_branch_select_popup(
+					&self.key_config,
+				),
+				true,
+				true,
+			));
 		}
 
 		visibility_blocking(self)
@@ -214,6 +221,12 @@ impl Component for StashList {
 					self.key_config.keys.stash_open,
 				) {
 					self.inspect();
+				} else if key_match(
+					k,
+					self.key_config.keys.select_branch,
+				) {
+					self.queue.push(InternalEvent::SelectBranch);
+					return Ok(EventState::Consumed);
 				}
 			}
 		}


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request makes it so pressing <kbd>b</kbd> opens the Branches popup in all 5 tabs, not only Status and Log tab. This keeps the behavior consistent, and makes the program simpler to use, since you do not have to associate being in a subset of the available tabs, in order to open a, what I would consider, global popup.

The <kbd>b</kbd> is not being used in any of the 3 missing tabs, so the change does not conflict with any existing keybinds.

If accepted, I think it would benefit the codebase to have a concept of global keybinds, that are accessible from all tabs, to deduplicate the repeated code to e.g. add a branches keybind.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog