### PR TITLE
Split cargo group into cargo-minor and cargo-patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,11 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   groups:
-    cargo:
+    cargo-minor:
       patterns: ["*"]
+      update-types:
+        - 'minor'
+    cargo-patch:
+      patterns: ["*"]
+      update-types:
+        - 'patch'


### PR DESCRIPTION
The most recent Dependabot PR, #2717, has run into a few issues some of which I was able to solve, some of which I wasn’t.

The issues currently preventing the PR from being green are related to `cargo deny` not allowing duplicate versions of dependencies.

This PR is an attempt at mitigating the impact of this issue. It splits the `cargo` group into 2 groups, `cargo-minor` and `cargo-patch`. My hope is that the `cargo-patch` group will more often be green without human intervention, thus enabling us to fast-track merging patch updates.

The `cargo-minor` group, on the other hand, will become smaller, thus making it easier for us to review and potentially handle updates by hand.

What do you think?
