### PR TITLE
Print a nicer error when failing to create the cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 * resolve `core.hooksPath` relative to `GIT_WORK_TREE` [[@naseschwarz](https://github.com/naseschwarz)] ([#2571](https://github.com/gitui-org/gitui/issues/2571))
 * yanking commit ranges no longer generates incorrect dotted range notations, but lists each individual commit [[@naseschwarz](https://github.com/naseschwarz)] (https://github.com/gitui-org/gitui/issues/2576)
+* print slightly nicer errors when failing to create a directory [[@linkmauve](https://github.com/linkmauve)] (https://github.com/gitui-org/gitui/pull/2728)
 
 ## [0.27.0] - 2024-01-14
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -159,7 +159,12 @@ fn get_app_cache_path() -> Result<PathBuf> {
 		.ok_or_else(|| anyhow!("failed to find os cache dir."))?;
 
 	path.push("gitui");
-	fs::create_dir_all(&path)?;
+	fs::create_dir_all(&path).with_context(|| {
+		format!(
+			"failed to create cache directory: {}",
+			path.display()
+		)
+	})?;
 	Ok(path)
 }
 


### PR DESCRIPTION
When the config or cache directories fail to get created for whichever reason, we currently exit gitui with a pretty undescriptive error.

This at least prints the relevant path so that the user can attempt to fix them.

Fixes #2652.

This Pull Request fixes/closes #2652.

It changes the following:
- Prints the directory path to stderr when it fails to get created.

I followed the checklist:
- [ ] I added unittests (not relevant)
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog