### PR TITLE
Preload commit message when undoing last commit

### DIFF
--- a/src/popups/commit.rs
+++ b/src/popups/commit.rs
@@ -477,6 +477,11 @@ impl CommitPopup {
 
 		Ok(msg)
 	}
+
+	/// Set commit message text (e.g., for preloading after undo)
+	pub fn set_commit_msg(&mut self, msg: String) {
+		self.input.set_text(msg);
+	}
 }
 
 impl DrawableComponent for CommitPopup {


### PR DESCRIPTION
## Summary
- Retrieves the commit message from HEAD before performing undo
- Preloads the message into the commit popup after undoing
- Improves UX by allowing easy re-committing with the same or modified message

## Test plan
- [ ] Perform a commit
- [ ] Undo the last commit
- [ ] Verify the commit message appears in the commit popup
- [ ] Test that the message can be edited and re-committed
- [ ] Test that closing the popup with Escape preserves the message