### PR TITLE
Don't stop status iter on error, log warning instead

### DIFF
--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -202,7 +202,11 @@ pub fn get_status(
 			let iter = status.into_index_worktree_iter(Vec::new())?;
 
 			for item in iter {
-				let item = item?;
+				let Ok(item) = item else {
+					log::warn!("[status] the status iter returned an error for an item: {item:?}");
+
+					continue;
+				};
 
 				let status = item.summary().map(Into::into);
 


### PR DESCRIPTION
This is a workaround for #2820. The reported issue is that, under very specific circumstances that involve a symlink and a submodule (see the linked issue for details), the status tab is empty. This is due to the fact that the status iter that collects individual status items exits early when it encounters an error. In that instance, all other status items are discarded and `get_status` returns just a single error.

This PR changes the iter to discard errors, but log a warning using `log::warn!` instead. `get_status` will then report all status items that didn’t error. That could potentially be confusing as the UI will not show any indicator that anything has gone wrong, but that seems an acceptable short-term trade-off, compared to showing nothing at all.
