### PR TITLE
[poc] feat: dull tab behind popup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,16 @@
             "program": "${workspaceRoot}/target/debug/gitui",
             "args": [],
             "cwd": "${workspaceRoot}",
-        }
+        },
+        {
+            "name": "Attach to cargo run of executable 'gitui'",
+            "type": "lldb",
+            "request": "attach",
+            "program": "${workspaceFolder}/target/debug/gitui",
+            "stopOnEntry": false,
+            "sourceLanguages": [
+                "rust"
+            ],
+        },
     ]
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,10 @@ use crate::{
 	strings::{self, ellipsis_trim_start, order},
 	tabs::{FilesTab, Revlog, StashList, Stashing, Status},
 	try_or_popup,
-	ui::style::{SharedTheme, Theme},
+	ui::{
+		mask,
+		style::{SharedTheme, Theme},
+	},
 	AsyncAppNotification, AsyncNotification,
 };
 use anyhow::{bail, Result};
@@ -294,6 +297,15 @@ impl App {
 				3 => self.stashing_tab.draw(f, chunks_main[1])?,
 				4 => self.stashlist_tab.draw(f, chunks_main[1])?,
 				_ => bail!("unknown tab"),
+			}
+
+			if self.any_popup_visible() {
+				// "Tints" the background whenever a popup is open.
+				// NB: Order is important. We manipulate the entire layout chunk
+				//     assigned to the tab, without the knowledge of where the
+				//     popup is located. Thus, we must tint before drawing the
+				//     popup.
+				mask::draw_mask(f, chunks_main[1]);
 			}
 		}
 

--- a/src/ui/mask.rs
+++ b/src/ui/mask.rs
@@ -1,0 +1,31 @@
+use ratatui::style::{Color, Style};
+use ratatui::widgets::Widget;
+use ratatui::Frame;
+use ratatui::{buffer::Buffer, layout::Rect};
+
+struct Mask;
+
+impl Widget for Mask {
+	fn render(self, area: Rect, buf: &mut Buffer) {
+		for y in area.top()..area.bottom() {
+			for x in area.left()..area.right() {
+				if let Some(cell) = buf.cell_mut((x, y)) {
+					// TODO(prprabhu): What do we want here?
+					// Question 1: Set background color vs foreground color
+					// Question 2: What color should we set to? The total number
+					//   of colors available to us across all backends is
+					//   limited, and we can't really tint the theme colors due
+					//   to the limited number of colors available.
+					// Question 3: Should we pick a reasonable color and add it
+					//   to the theme?
+					cell.set_style(Style::default().fg(Color::Gray));
+				}
+			}
+		}
+	}
+}
+
+pub fn draw_mask(frame: &mut Frame, rect: Rect) {
+	let mask = Mask;
+	frame.render_widget(mask, rect);
+}

--- a/src/ui/mask.rs
+++ b/src/ui/mask.rs
@@ -18,7 +18,9 @@ impl Widget for Mask {
 					//   to the limited number of colors available.
 					// Question 3: Should we pick a reasonable color and add it
 					//   to the theme?
-					cell.set_style(Style::default().fg(Color::Gray));
+					cell.set_style(
+						Style::default().fg(Color::DarkGray),
+					);
 				}
 			}
 		}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod mask;
 mod reflow;
 mod scrollbar;
 mod scrolllist;


### PR DESCRIPTION
A proof-of-concept implementation for feature #2829 

After this change, the tabs behind popups use grayed out foreground to better focus user's attention onto the popup.

This PR needs at least the following before it can be merged:
- Agreement on the approach (discussion on the tracking issue).
- Extend theme so users can configure the muted foreground color chosen for masking.
- Other items in the checklist below.

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog