### PR TITLE
Change recommended vim keybinding for "reset file"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+* change recommended `vim`-style key-binding for "reset file changes" to avoid conflict with "undo last commit" [[@callpraths](https://github.com/callpraths)] [[2853](https://github.com/gitui-org/gitui/pull/2853)]
+
 ## [0.28.0] - 2025-12-14
 
 **discard changes on checkout**

--- a/vim_style_key_config.ron
+++ b/vim_style_key_config.ron
@@ -14,7 +14,7 @@
     move_right: Some(( code: Char('l'), modifiers: "")),
     move_up: Some(( code: Char('k'), modifiers: "")),
     move_down: Some(( code: Char('j'), modifiers: "")),
-    
+
     popup_up: Some(( code: Char('p'), modifiers: "CONTROL")),
     popup_down: Some(( code: Char('n'), modifiers: "CONTROL")),
     page_up: Some(( code: Char('b'), modifiers: "CONTROL")),
@@ -26,7 +26,7 @@
 
     edit_file: Some(( code: Char('I'), modifiers: "SHIFT")),
 
-    status_reset_item: Some(( code: Char('U'), modifiers: "SHIFT")),
+    status_reset_item: Some(( code: Char('u'), modifiers: "")),
 
     diff_reset_lines: Some(( code: Char('u'), modifiers: "")),
     diff_stage_lines: Some(( code: Char('s'), modifiers: "")),


### PR DESCRIPTION
This Pull Request fixes/closes #2704

Avoids a hindenbug due to two interpretations of `Shift+U`
- It is the default key-binding to "undo last commit"
- It is the key binding for "reset file" in the recommended `vim`-style bindings

There is a potential for confusion between those two actions and they have qualitatively different outcomes - the default binding is more of a user-data destroying action (though there's always `reflog`...)

This PR updates the suggested `vim` binding to lowercase `u`. This makes `u` the keybinding for:
- "reset file" in status view.
- "reset current hunk" in diff view.

Those two actions have the same scope - undo unstaged changes in working directory, so having the same key-binding makes sense.


I followed the checklist:
- [ ] I added unittests [N/A: no functional changes]
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog