### PR TITLE
Fix Windows AltGr input in text fields

### DIFF
--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -616,7 +616,8 @@ impl TextInputComponent {
 				alt: true,
 				..
 			} => {
-				// On Windows, AltGr is commonly reported as Ctrl+Alt.
+				// On Windows, AltGr (Right Alt) can surface to applications as the Ctrl+Alt chord,
+				// so AltGr-generated characters may arrive with both `ctrl` and `alt` set.
 				if cfg!(windows) {
 					ta.insert_char(*c);
 					true


### PR DESCRIPTION
Fixes #2848.

On Windows, AltGr is commonly reported as Ctrl+Alt. Text input previously only inserted chars when neither Ctrl nor Alt were set, so AltGr-generated characters were dropped/(ㄒoㄒ)/

This change treats Ctrl+Alt+Char as regular character input on Windows, while preserving existing Ctrl+Alt shortcuts.

Tests: cargo test