### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04, ubuntu-24.04-riscv]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,6 +101,11 @@ jobs:
         env:
           GITUI_RELEASE: 1
         run: make release-linux-arm
+      - name: Build Release Linux RISCV64
+        if: matrix.os == 'ubuntu-24.04-riscv'
+        env:
+          GITUI_RELEASE: 1
+        run: make release-linux-riscv64
 
       - name: Set SHA
         if: matrix.os == 'macos-latest'

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,12 @@ build-linux-arm-release:
 	cargo build --release --target=armv7-unknown-linux-gnueabihf --locked
 	cargo build --release --target=arm-unknown-linux-gnueabihf --locked
 
+release-linux-riscv64:
+	cargo build --release --locked
+	strip target/release/gitui
+	mkdir -p release
+	tar -C ./target/release/ -czvf ./release/gitui-linux-riscv64.tar.gz ./gitui
+
 test:
 	cargo nextest run --workspace
 


### PR DESCRIPTION
Adds riscv64 release binary using native RISE riscv64 runners (ubuntu-24.04-riscv), following the same pattern as the ARM build:
- New OS matrix entry: ubuntu-24.04-riscv
- New Makefile target: release-linux-riscv64
- Builds natively with cargo (no cross needed)

RISE runners are provided by the RISE Project (https://riseproject.dev/), free for open source. To enable: install https://github.com/apps/rise-risc-v-runners on this repository.

Build validated: https://github.com/gounthar/gitui/actions/runs/23478676152

Closes #2891