### PR TITLE
Auto return to the tree view if the last hunk in a file was staged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * use [tombi](https://github.com/tombi-toml/tombi) for all toml file formatting
 * open the external editor from the status diff view [[@WaterWhisperer](https://github.com/WaterWhisperer)] ([#2805](https://github.com/gitui-org/gitui/issues/2805))
+* auto return to the tree view after staging the last hunk from the status diff view [[@WaterWhisperer](https://github.com/WaterWhisperer)] ([#2748](https://github.com/gitui-org/gitui/issues/2748))
 
 ### Fixes
 * crash when opening submodule ([#2895](https://github.com/gitui-org/gitui/issues/2895))

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -64,7 +64,7 @@ impl StatusTree {
 		self.update_visibility(None, 0, true);
 		self.available_selections = self.setup_available_selections();
 
-		//NOTE: now that visibility is set we can make sure selection is visible
+		// NOTE: now that visibility is set we can make sure selection is visible
 		if let Some(idx) = self.selection {
 			self.selection = Some(self.find_visible_idx(idx));
 		}

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -456,13 +456,27 @@ impl Status {
 	}
 
 	fn update_status(&mut self) -> Result<()> {
+		let diff_before_update = self.diff.current();
+
 		let stage_status = self.git_status_stage.last()?;
 		self.index.set_items(&stage_status.items)?;
 
 		let workdir_status = self.git_status_workdir.last()?;
 		self.index_wd.set_items(&workdir_status.items)?;
 
-		self.update_diff()?;
+		if Self::should_exit_diff_focus_after_status_update(
+			self.git_action_executed,
+			self.is_focus_on_diff(),
+			&diff_before_update,
+			self.selected_path().as_ref(),
+		) {
+			self.switch_focus(match self.diff_target {
+				DiffTarget::Stage => Focus::Stage,
+				DiffTarget::WorkingDir => Focus::WorkDir,
+			})?;
+		} else {
+			self.update_diff()?;
+		}
 
 		if self.git_action_executed {
 			self.git_action_executed = false;
@@ -480,6 +494,18 @@ impl Status {
 		}
 
 		Ok(())
+	}
+
+	fn should_exit_diff_focus_after_status_update(
+		git_action_executed: bool,
+		is_focus_on_diff: bool,
+		diff_before_update: &(String, bool),
+		selected_path_after_update: Option<&(String, bool)>,
+	) -> bool {
+		git_action_executed
+			&& is_focus_on_diff
+			&& !diff_before_update.0.is_empty()
+			&& selected_path_after_update != Some(diff_before_update)
 	}
 
 	///


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2748.

It changes the following:
- auto return to the tree view after staging the last hunk from the status diff view

[录屏 2026年04月12日 16时40分45秒.webm](https://github.com/user-attachments/assets/9f598f71-d31a-4deb-a6b6-bc20da0ca4e9)

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog