### PR TITLE
fix: run pre-commit hook before opening commit dialog

### DIFF
--- a/src/popups/commit.rs
+++ b/src/popups/commit.rs
@@ -235,19 +235,6 @@ impl CommitPopup {
 		let verify = self.verify;
 		self.verify = true;
 
-		if verify {
-			// run pre commit hook - can reject commit
-			if let HookResult::NotOk(e) =
-				sync::hooks_pre_commit(&self.repo.borrow())?
-			{
-				log::error!("pre-commit hook error: {e}");
-				self.queue.push(InternalEvent::ShowErrorMsg(
-					format!("pre-commit hook error:\n{e}"),
-				));
-				return Ok(CommitResult::Aborted);
-			}
-		}
-
 		let mut msg =
 			commit_message_prettify(&self.repo.borrow(), msg)?;
 
@@ -349,6 +336,21 @@ impl CommitPopup {
 		self.verify = !self.verify;
 	}
 
+	fn run_pre_commit_hook(&self) -> Result<bool> {
+		if self.verify {
+			if let HookResult::NotOk(e) =
+				sync::hooks_pre_commit(&self.repo.borrow())?
+			{
+				log::error!("pre-commit hook error: {e}");
+				self.queue.push(InternalEvent::ShowErrorMsg(
+					format!("pre-commit hook error:\n{e}"),
+				));
+				return Ok(false);
+			}
+		}
+		Ok(true)
+	}
+
 	pub fn open(&mut self, reword: Option<CommitId>) -> Result<()> {
 		//only clear text if it was not a normal commit dlg before, so to preserve old commit msg that was edited
 		if !matches!(self.mode, Mode::Normal) {
@@ -441,6 +443,10 @@ impl CommitPopup {
 		};
 
 		self.mode = mode;
+
+		if !self.run_pre_commit_hook()? {
+			return Ok(());
+		}
 
 		let mut msg = self.input.get_text().to_string();
 		if let HookResult::NotOk(e) = sync::hooks_prepare_commit_msg(


### PR DESCRIPTION
Closes #1711

The `pre-commit` hook was running after the user typed their commit message, wasting time composing messages that would get rejected. Per Git documentation: "The pre-commit hook is run first, before you even type in a commit message."

**Before:** User opens commit dialog → types message → submits → pre-commit rejects → message wasted
**After:** User opens commit dialog → pre-commit runs first → if rejected, dialog never opens

Hook execution order is now:
1. `pre-commit` — when dialog opens (before user types)
2. `prepare-commit-msg` — when dialog opens (populates message)
3. `commit-msg` — when user submits
4. `post-commit` — after commit

This matches the behavior described in the Git docs and aligns with GUI clients like Fork.

**Note:** The `verify` toggle (`Ctrl+F`) is respected — if disabled, the pre-commit hook is skipped at open time as well.
