### PR TITLE
Automatically convert spaces to dashes in branch names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * use [tombi](https://github.com/tombi-toml/tombi) for all toml file formatting
 * open the external editor from the status diff view [[@WaterWhisperer](https://github.com/WaterWhisperer)] ([#2805](https://github.com/gitui-org/gitui/issues/2805))
+* automatically convert spaces to dashes when creating or renaming a branch [[@pbouillon]](https//pbouillon.github.io)] ([#2916](https://github.com/gitui-org/gitui/pull/2916))
 
 ### Fixes
 * crash when opening submodule ([#2895](https://github.com/gitui-org/gitui/issues/2895))

--- a/src/popups/create_branch.rs
+++ b/src/popups/create_branch.rs
@@ -65,9 +65,9 @@ impl Component for CreateBranchPopup {
 					kind,
 					state,
 				}) => Cow::Owned(Event::Key(KeyEvent {
-					code: KeyCode::Char(strings::normalize_branch_name_char(
-						*c,
-					)),
+					code: KeyCode::Char(
+						strings::normalize_branch_name_char(*c),
+					),
 					modifiers: *modifiers,
 					kind: *kind,
 					state: *state,

--- a/src/popups/create_branch.rs
+++ b/src/popups/create_branch.rs
@@ -11,9 +11,10 @@ use crate::{
 };
 use anyhow::Result;
 use asyncgit::sync::{self, RepoPathRef};
-use crossterm::event::Event;
+use crossterm::event::{Event, KeyCode, KeyEvent};
 use easy_cast::Cast;
 use ratatui::{layout::Rect, widgets::Paragraph, Frame};
+use std::borrow::Cow;
 
 pub struct CreateBranchPopup {
 	repo: RepoPathRef,
@@ -57,11 +58,28 @@ impl Component for CreateBranchPopup {
 
 	fn event(&mut self, ev: &Event) -> Result<EventState> {
 		if self.is_visible() {
-			if self.input.event(ev)?.is_consumed() {
+			let ev = match ev {
+				Event::Key(KeyEvent {
+					code: KeyCode::Char(c),
+					modifiers,
+					kind,
+					state,
+				}) => Cow::Owned(Event::Key(KeyEvent {
+					code: KeyCode::Char(strings::normalize_branch_name_char(
+						*c,
+					)),
+					modifiers: *modifiers,
+					kind: *kind,
+					state: *state,
+				})),
+				_ => Cow::Borrowed(ev),
+			};
+
+			if self.input.event(&ev)?.is_consumed() {
 				return Ok(EventState::Consumed);
 			}
 
-			if let Event::Key(e) = ev {
+			if let Event::Key(e) = ev.as_ref() {
 				if key_match(e, self.key_config.keys.enter) {
 					self.create_branch();
 				}

--- a/src/popups/rename_branch.rs
+++ b/src/popups/rename_branch.rs
@@ -65,9 +65,9 @@ impl Component for RenameBranchPopup {
 					kind,
 					state,
 				}) => Cow::Owned(Event::Key(KeyEvent {
-					code: KeyCode::Char(strings::normalize_branch_name_char(
-						*c,
-					)),
+					code: KeyCode::Char(
+						strings::normalize_branch_name_char(*c),
+					),
 					modifiers: *modifiers,
 					kind: *kind,
 					state: *state,

--- a/src/popups/rename_branch.rs
+++ b/src/popups/rename_branch.rs
@@ -11,9 +11,10 @@ use crate::{
 };
 use anyhow::Result;
 use asyncgit::sync::{self, RepoPathRef};
-use crossterm::event::Event;
+use crossterm::event::{Event, KeyCode, KeyEvent};
 use easy_cast::Cast;
 use ratatui::{layout::Rect, widgets::Paragraph, Frame};
+use std::borrow::Cow;
 
 pub struct RenameBranchPopup {
 	repo: RepoPathRef,
@@ -57,11 +58,28 @@ impl Component for RenameBranchPopup {
 
 	fn event(&mut self, ev: &Event) -> Result<EventState> {
 		if self.is_visible() {
-			if self.input.event(ev)?.is_consumed() {
+			let ev = match ev {
+				Event::Key(KeyEvent {
+					code: KeyCode::Char(c),
+					modifiers,
+					kind,
+					state,
+				}) => Cow::Owned(Event::Key(KeyEvent {
+					code: KeyCode::Char(strings::normalize_branch_name_char(
+						*c,
+					)),
+					modifiers: *modifiers,
+					kind: *kind,
+					state: *state,
+				})),
+				_ => Cow::Borrowed(ev),
+			};
+
+			if self.input.event(&ev)?.is_consumed() {
 				return Ok(EventState::Consumed);
 			}
 
-			if let Event::Key(e) = ev {
+			if let Event::Key(e) = ev.as_ref() {
 				if key_match(e, self.key_config.keys.enter) {
 					self.rename_branch();
 				}

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -439,10 +439,10 @@ pub fn ellipsis_trim_start(s: &str, width: usize) -> Cow<'_, str> {
 }
 
 pub const fn normalize_branch_name_char(c: char) -> char {
-    match c {
-        ' ' => '-',
-        c => c,
-    }
+	match c {
+		' ' => '-',
+		c => c,
+	}
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -438,6 +438,13 @@ pub fn ellipsis_trim_start(s: &str, width: usize) -> Cow<'_, str> {
 	}
 }
 
+pub const fn normalize_branch_name_char(c: char) -> char {
+    match c {
+        ' ' => '-',
+        c => c,
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum CheckoutOptions {
 	KeepLocalChanges,
@@ -1932,5 +1939,21 @@ pub mod commands {
 			"Go to the given line",
 			CMD_GROUP_GENERAL,
 		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_spaces_are_replaced_by_dashes_in_branch_name() {
+		let input = "feature/auto replace spaces in branch name";
+		let output: String =
+			input.chars().map(normalize_branch_name_char).collect();
+		assert_eq!(
+			output,
+			"feature/auto-replace-spaces-in-branch-name"
+		);
 	}
 }


### PR DESCRIPTION
This Pull Request does not close an existing issue.

It changes the following:

- Spaces typed in the branch name input are automatically converted to dashes, keeping branch names valid without requiring the user to type dashes manually
- This applies to both the create branch and rename branch popups

This behavior is consistent with how VS Code handles branch name creation, and with how lazygit handles it too. For instance, here's how the branch creation popup is displayed in VS Code:

<img width="607" height="73" alt="vscode branch creation example" src="https://github.com/user-attachments/assets/aeda9507-6791-422b-b0c6-13a9f61cd25f" />


I'm a long-time gitui user and genuinely love the project but, as I used different tools as part of my professional and personal workflow, this is a small quality-of-life feature I kept missing when coming from other git tools, especially when the issue name is quite long.

I'm not familiar with Rust and wasn't able to set up the toolchain locally, so rather than testing manually I enabled GitHub Actions on my fork and made sure the [full CI pipeline passed](https://github.com/pBouillon/gitui/actions/runs/24824341363). Given my limited Rust experience, I may have missed something or done things in a non-idiomatic way. Please let me know if you feel like any change is needed here.

I followed the checklist:

- [x] I added unittests
- [x] I ran `make check` without errors
- [ ] I tested the overall application
- [ ] I added an appropriate item to the changelog