### PR TITLE
make branch_compare_upstream async

### DIFF
--- a/asyncgit/src/branch_compare.rs
+++ b/asyncgit/src/branch_compare.rs
@@ -1,0 +1,73 @@
+use crate::{
+	asyncjob::{AsyncJob, RunParams},
+	error::Result,
+	sync::{branch::branch_compare_upstream, BranchCompare, RepoPath},
+	AsyncGitNotification,
+};
+use std::sync::{Arc, Mutex};
+
+enum JobState {
+	Request {
+		repo: RepoPath,
+		branch: String,
+	},
+	Response(Result<BranchCompare>),
+}
+
+///
+#[derive(Clone, Default)]
+pub struct AsyncBranchCompareJob {
+	state: Arc<Mutex<Option<JobState>>>,
+}
+
+impl AsyncBranchCompareJob {
+	///
+	pub fn new(repo: RepoPath, branch: String) -> Self {
+		Self {
+			state: Arc::new(Mutex::new(Some(JobState::Request {
+				repo,
+				branch,
+			}))),
+		}
+	}
+
+	///
+	pub fn result(&self) -> Option<Result<BranchCompare>> {
+		if let Ok(mut state) = self.state.lock() {
+			if let Some(state) = state.take() {
+				return match state {
+					JobState::Request { .. } => None,
+					JobState::Response(result) => Some(result),
+				};
+			}
+		}
+
+		None
+	}
+}
+
+impl AsyncJob for AsyncBranchCompareJob {
+	type Notification = AsyncGitNotification;
+	type Progress = ();
+
+	fn run(
+		&mut self,
+		_params: RunParams<Self::Notification, Self::Progress>,
+	) -> Result<Self::Notification> {
+		if let Ok(mut state) = self.state.lock() {
+			*state = state.take().map(|state| match state {
+				JobState::Request { repo, branch } => {
+					let compare =
+						branch_compare_upstream(&repo, &branch);
+
+					JobState::Response(compare)
+				}
+				JobState::Response(result) => {
+					JobState::Response(result)
+				}
+			});
+		}
+
+		Ok(AsyncGitNotification::BranchCompare)
+	}
+}

--- a/asyncgit/src/lib.rs
+++ b/asyncgit/src/lib.rs
@@ -45,6 +45,7 @@ It wraps libraries like git2 and gix.
 
 pub mod asyncjob;
 mod blame;
+mod branch_compare;
 mod branches;
 pub mod cached;
 mod commit_files;
@@ -66,6 +67,7 @@ mod treefiles;
 
 pub use crate::{
 	blame::{AsyncBlame, BlameParams},
+	branch_compare::AsyncBranchCompareJob,
 	branches::AsyncBranchesJob,
 	commit_files::{AsyncCommitFiles, CommitFilesParams},
 	diff::{AsyncDiff, DiffParams, DiffType},
@@ -124,6 +126,8 @@ pub enum AsyncGitNotification {
 	Fetch,
 	///
 	Branches,
+	///
+	BranchCompare,
 	///
 	TreeFiles,
 	///


### PR DESCRIPTION
Wraps the synchronous branch_compare_upstream function in an async job to prevent UI blocking on large repositories. Follows the existing pattern from AsyncBranchesJob.

closes #1850