### PR TITLE
fix: resolve --file paths from any directory in the repo

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -197,7 +197,7 @@ impl App {
 
 		let mut select_file: Option<PathBuf> = None;
 		let tab = if let Some(file) = cliargs.select_file {
-			select_file = resolve_select_file(file, &repo.borrow())?;
+			select_file = resolve_select_file(file, &env.repo.borrow())?;
 			2
 		} else {
 			env.options.borrow().current_tab()

--- a/src/app.rs
+++ b/src/app.rs
@@ -148,6 +148,25 @@ impl Environment {
 	}
 }
 
+/// Resolves `--file` to a path relative to the repository workdir (as used by the file tree).
+fn resolve_select_file(file: PathBuf, repo: &RepoPath) -> Result<Option<PathBuf>> {
+	let workdir = PathBuf::from(repo_work_dir(repo)?);
+	let workdir_canon = workdir.canonicalize()?;
+
+	let candidates = [
+		file.canonicalize().ok(),
+		workdir.join(&file).canonicalize().ok(),
+	];
+
+	for abs in candidates.into_iter().flatten() {
+		if let Ok(rel) = abs.strip_prefix(&workdir_canon) {
+			return Ok(Some(Path::new(".").join(rel)));
+		}
+	}
+
+	Ok(None)
+}
+
 // public interface
 impl App {
 	///
@@ -178,14 +197,7 @@ impl App {
 
 		let mut select_file: Option<PathBuf> = None;
 		let tab = if let Some(file) = cliargs.select_file {
-			// convert to relative git path
-			if let Ok(abs) = file.canonicalize() {
-				if let Ok(path) = abs.strip_prefix(
-					env.repo.borrow().gitpath().canonicalize()?,
-				) {
-					select_file = Some(Path::new(".").join(path));
-				}
-			}
+			select_file = resolve_select_file(file, &repo.borrow())?;
 			2
 		} else {
 			env.options.borrow().current_tab()


### PR DESCRIPTION
## Summary
- Resolve `--file` against the repository workdir instead of `.git`
- Try both cwd-relative and workdir-relative paths so the flag works from subdirectories

Fixes #2871

## Test plan
- [ ] From repo root: `gitui --file frontend/src/index.html`
- [ ] From `frontend/`: `gitui --file src/index.html`
- [ ] From `frontend/`: `gitui --file frontend/src/index.html`