### PR TITLE
fix: expand tabs to 8-column stops in diff and file views

### DIFF
--- a/src/string_utils.rs
+++ b/src/string_utils.rs
@@ -1,5 +1,5 @@
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 ///
 pub fn trim_length_left(s: &str, width: usize) -> &str {
@@ -15,13 +15,36 @@ pub fn trim_length_left(s: &str, width: usize) -> &str {
 	s
 }
 
-//TODO: allow customize tabsize
+const TAB_WIDTH: usize = 8;
+
+// TODO: allow customize tabsize (e.g. via .editorconfig)
 pub fn tabs_to_spaces(input: String) -> String {
-	if input.contains('\t') {
-		input.replace('\t', "  ")
-	} else {
-		input
+	if !input.contains('\t') {
+		return input;
 	}
+
+	let mut out = String::with_capacity(input.len());
+	let mut column = 0usize;
+
+	for ch in input.chars() {
+		match ch {
+			'\t' => {
+				let spaces = TAB_WIDTH - (column % TAB_WIDTH);
+				out.extend(std::iter::repeat_n(' ', spaces));
+				column += spaces;
+			}
+			'\n' => {
+				out.push('\n');
+				column = 0;
+			}
+			ch => {
+				out.push(ch);
+				column += ch.width().unwrap_or(0);
+			}
+		}
+	}
+
+	out
 }
 
 /// This function will return a str slice which start at specified offset.
@@ -50,5 +73,14 @@ mod test {
 	fn test_trim() {
 		assert_eq!(trim_length_left("👍foo", 3), "foo");
 		assert_eq!(trim_length_left("👍foo", 4), "foo");
+	}
+
+	#[test]
+	fn test_tabs_to_spaces() {
+		use super::tabs_to_spaces;
+
+		assert_eq!(tabs_to_spaces("no-tabs".into()), "no-tabs");
+		assert_eq!(tabs_to_spaces("\tfoo".into()), "        foo");
+		assert_eq!(tabs_to_spaces("a\tb".into()), "a       b");
 	}
 }


### PR DESCRIPTION
## Summary

- Expand hard tabs using 8-column tab stops (was a fixed two spaces per tab).
- Applies everywhere `tabs_to_spaces` is used: diff view, syntax highlighting, and blame.

## Test plan

- [x] `cargo test tabs_to_spaces`
- [ ] Manual: open a file with leading hard tabs in the diff view and confirm 8-column alignment

Fixes #2803