### PR TITLE
fix: avoid panic when filesystem watcher hits permission errors

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -49,15 +49,20 @@ impl RepoWatcher {
 		loop {
 			let ev = receiver.recv()?;
 
-			if let Ok(ev) = ev {
-				log::debug!("notify events: {}", ev.len());
+			match ev {
+				Ok(events) => {
+					log::debug!("notify events: {}", events.len());
 
-				for (idx, ev) in ev.iter().enumerate() {
-					log::debug!("notify [{idx}]: {ev:?}");
+					for (idx, event) in events.iter().enumerate() {
+						log::debug!("notify [{idx}]: {event:?}");
+					}
+
+					if !events.is_empty() {
+						sender.send(())?;
+					}
 				}
-
-				if !ev.is_empty() {
-					sender.send(())?;
+				Err(e) => {
+					log::warn!("notify debouncer error: {e}");
 				}
 			}
 		}
@@ -71,12 +76,27 @@ fn create_watcher(
 ) {
 	scope_time!("create_watcher");
 
-	let mut bouncer =
-		new_debouncer(timeout, tx).expect("Watch create error");
-	bouncer
+	let mut bouncer = match new_debouncer(timeout, tx) {
+		Ok(bouncer) => bouncer,
+		Err(e) => {
+			log::warn!(
+				"failed to create filesystem watcher: {e}; \
+				 file change notifications disabled"
+			);
+			return;
+		}
+	};
+
+	if let Err(e) = bouncer
 		.watcher()
-		.watch(Path::new(&workdir), RecursiveMode::Recursive)
-		.expect("Watch error");
+		.watch(Path::new(workdir), RecursiveMode::Recursive)
+	{
+		log::warn!(
+			"failed to watch repository for changes ({e}); \
+			 file change notifications disabled"
+		);
+		return;
+	}
 
 	std::mem::forget(bouncer);
 }


### PR DESCRIPTION
## Summary

- Replace `expect` calls in the notify watcher setup with error handling.
- When watch setup fails (e.g. permission denied on a subdirectory owned by another user), log a warning and continue without file notifications instead of panicking.
- Log debouncer errors in the forwarder loop instead of ignoring the `Err` variant.

## Test plan

- [x] `cargo build`
- [ ] Manual: `git init`, create root-owned dir per #2900, run `gitui --watcher` — should start without panic (auto-refresh may be disabled)

Fixes #2900