### PR TITLE
fix: honor info/exclude in linked worktrees

### DIFF
--- a/asyncgit/src/sync/repository.rs
+++ b/asyncgit/src/sync/repository.rs
@@ -68,11 +68,26 @@ pub fn repo(repo_path: &RepoPath) -> Result<Repository> {
 	Ok(repo)
 }
 
+/// Path to pass to `gix::discover` so linked worktrees resolve `info/exclude` correctly.
+pub(crate) fn repo_discover_path(repo_path: &RepoPath) -> Result<PathBuf> {
+	if let Some(workdir) = repo_path.workdir() {
+		return Ok(workdir.to_path_buf());
+	}
+
+	let git_repo = repo(repo_path)?;
+	git_repo
+		.workdir()
+		.ok_or(crate::error::Error::NoWorkDir)
+		.map(|path| path.to_path_buf())
+}
+
 pub fn gix_repo(repo_path: &RepoPath) -> Result<gix::Repository> {
-	let mut repo: gix::Repository = gix::ThreadSafeRepository::discover_with_environment_overrides(
-		repo_path.gitpath(),
-	)
-	.map(Into::into)?;
+	let discover_path = repo_discover_path(repo_path)?;
+	let mut repo: gix::Repository =
+		gix::ThreadSafeRepository::discover_with_environment_overrides(
+			&discover_path,
+		)
+		.map(Into::into)?;
 
 	if let Some(workdir) = repo_path.workdir() {
 		repo.set_workdir(Some(workdir.into()))?;

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -1,7 +1,8 @@
 //! sync git api (various methods)
 
 use super::{
-	repository::repo, CommitId, RepoPath, ShowUntrackedFilesConfig,
+	repository::{repo, repo_discover_path},
+	CommitId, RepoPath, ShowUntrackedFilesConfig,
 };
 use crate::{
 	error::{Error, Result},
@@ -35,7 +36,7 @@ pub fn repo_open_error(repo_path: &RepoPath) -> Option<String> {
 	}
 
 	gix::ThreadSafeRepository::discover_with_environment_overrides(
-		repo_path.gitpath(),
+		repo_discover_path(repo_path).ok()?,
 	)
 	.map_or_else(|e| Some(e.to_string()), |_| None)
 }


### PR DESCRIPTION
## Summary

- Discover the gix repository from the worktree workdir instead of `gitpath()` alone.
- Linked worktrees use a `.git` file; discovering from `"."` or the git dir path could skip `.git/info/exclude` rules that apply in the main worktree.

Fixes #2876

## Test plan

- [ ] In a repo with a linked worktree, add a pattern to `.git/info/exclude`
- [ ] Confirm ignored files are hidden in the linked worktree status view (same as main worktree)