### PR TITLE
fix: exit diff view with move-left (h)

### DIFF
--- a/src/popups/compare_commits.rs
+++ b/src/popups/compare_commits.rs
@@ -133,7 +133,12 @@ impl Component for CompareCommitsPopup {
 					self.diff.focus(true);
 				} else if key_match(e, self.key_config.keys.move_left)
 				{
-					self.hide_stacked(false);
+					if self.diff.focused() {
+						self.details.focus(true);
+						self.diff.focus(false);
+					} else {
+						self.hide_stacked(false);
+					}
 				}
 
 				return Ok(EventState::Consumed);

--- a/src/popups/file_revlog.rs
+++ b/src/popups/file_revlog.rs
@@ -513,6 +513,12 @@ impl Component for FileRevlogPopup {
 				) && self.can_focus_diff()
 				{
 					self.diff.focus(true);
+				} else if key_match(
+					key,
+					self.key_config.keys.move_left,
+				) && self.diff.focused()
+				{
+					self.diff.focus(false);
 				} else if key_match(key, self.key_config.keys.enter) {
 					if let Some(commit_id) = self.selected_commit() {
 						self.hide_stacked(true);

--- a/src/popups/inspect_commit.rs
+++ b/src/popups/inspect_commit.rs
@@ -170,7 +170,12 @@ impl Component for InspectCommitPopup {
 					self.diff.focus(true);
 				} else if key_match(e, self.key_config.keys.move_left)
 				{
-					self.hide_stacked(false);
+					if self.diff.focused() {
+						self.details.focus(true);
+						self.diff.focus(false);
+					} else {
+						self.hide_stacked(false);
+					}
 				} else if key_match(
 					e,
 					self.key_config.keys.open_file_tree,

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -847,6 +847,16 @@ impl Component for Status {
 					self.switch_focus(Focus::Diff).map(Into::into)
 				} else if key_match(
 					k,
+					self.key_config.keys.move_left,
+				) && self.is_focus_on_diff()
+				{
+					self.switch_focus(match self.diff_target {
+						DiffTarget::Stage => Focus::Stage,
+						DiffTarget::WorkingDir => Focus::WorkDir,
+					})
+					.map(Into::into)
+				} else if key_match(
+					k,
 					self.key_config.keys.exit_popup,
 				) {
 					self.switch_focus(match self.diff_target {


### PR DESCRIPTION
## Summary

- **Status tab:** `move-left` leaves the diff pane (same as Esc), returning focus to the file list.
- **Inspect commit / file revlog / compare commits popups:** `move-left` unfocuses diff when focused; otherwise keeps existing behavior.

Fixes #2806

## Test plan

- [ ] Status tab: focus diff with `l` / Right, exit with `h` / Left
- [ ] Inspect commit popup: same flow
- [ ] Esc still works as before