### PR TITLE
fix: AltGr commit input (Windows) and clearer repo open errors

### DIFF
--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -24,20 +24,51 @@ pub struct Head {
 	pub id: CommitId,
 }
 
+fn format_repo_open_error(err: &str, path: &Path) -> String {
+	let err_lower = err.to_ascii_lowercase();
+
+	if err_lower.contains("bare") {
+		return format!(
+			"repository at '{}' appears to be bare; pass an explicit worktree with -w",
+			path.display()
+		);
+	}
+
+	if err_lower.contains("not found")
+		|| err_lower.contains("could not find")
+		|| err_lower.contains("no such file")
+		|| err_lower.contains("failed to discover")
+	{
+		return format!(
+			"could not open git repository at '{}' ({err})\n\
+			 hint: verify the path exists and is readable (sandboxing may block access)",
+			path.display()
+		);
+	}
+
+	format!(
+		"could not open git repository at '{}': {err}",
+		path.display()
+	)
+}
+
 ///
 pub fn repo_open_error(repo_path: &RepoPath) -> Option<String> {
+	let path = repo_path.gitpath();
+
 	if let Err(e) = Repository::open_ext(
-		repo_path.gitpath(),
+		path,
 		RepositoryOpenFlags::FROM_ENV,
 		Vec::<&Path>::new(),
 	) {
-		return Some(e.to_string());
+		return Some(format_repo_open_error(&e.to_string(), path));
 	}
 
-	gix::ThreadSafeRepository::discover_with_environment_overrides(
-		repo_path.gitpath(),
-	)
-	.map_or_else(|e| Some(e.to_string()), |_| None)
+	gix::ThreadSafeRepository::discover_with_environment_overrides(path)
+		.map_or_else(
+			|e| Some(format_repo_open_error(&e.to_string(), path)),
+			|_| None,
+		)
 }
 
 ///
@@ -480,6 +511,17 @@ mod tests {
 		assert!(stage_add_all(repo_path, "sub", None).is_err());
 
 		Ok(())
+	}
+
+	#[test]
+	fn format_repo_open_error_not_found() {
+		let msg = format_repo_open_error(
+			"repository not found",
+			Path::new("/i4/repo"),
+		);
+		assert!(msg.contains("could not open git repository"));
+		assert!(msg.contains("sandboxing"));
+		assert!(!msg.to_ascii_lowercase().contains("non-bare"));
 	}
 
 	#[test]

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -259,15 +259,31 @@ impl TextInputComponent {
 		}
 	}
 
+	fn is_text_char_input(ctrl: bool, alt: bool) -> bool {
+		if !ctrl && !alt {
+			return true;
+		}
+
+		#[cfg(windows)]
+		{
+			// AltGr is commonly reported as Ctrl+Alt on Windows (e.g. German `{` `}`)
+			if ctrl && alt {
+				return true;
+			}
+		}
+
+		false
+	}
+
 	#[allow(clippy::too_many_lines, clippy::unnested_or_patterns)]
 	fn process_inputs(ta: &mut TextArea<'_>, input: &Input) -> bool {
 		match input {
 			Input {
 				key: Key::Char(c),
-				ctrl: false,
-				alt: false,
+				ctrl,
+				alt,
 				..
-			} => {
+			} if Self::is_text_char_input(*ctrl, *alt) => {
 				ta.insert_char(*c);
 				true
 			}
@@ -886,5 +902,17 @@ mod tests {
 			ta.move_cursor(CursorMove::WordBack);
 			assert_eq!(ta.cursor(), save_cursor);
 		}
+	}
+
+	#[test]
+	fn test_is_text_char_input_without_modifiers() {
+		assert!(TextInputComponent::is_text_char_input(false, false));
+		assert!(!TextInputComponent::is_text_char_input(true, false));
+	}
+
+	#[test]
+	#[cfg(windows)]
+	fn test_is_text_char_input_altgr() {
+		assert!(TextInputComponent::is_text_char_input(true, true));
 	}
 }


### PR DESCRIPTION
## Summary

- **#2848**: On Windows, AltGr is often reported as `Ctrl+Alt`. The commit message `TextInput` previously ignored any `Char` event with modifiers, so German layout characters like `{` `}` `[` `]` could not be typed. `is_text_char_input` now accepts `Ctrl+Alt` as text input on Windows while still rejecting lone `Ctrl` shortcuts.
- **#2866**: `repo_open_error` now maps common discovery / not-found failures to a clearer message (path, underlying error, sandboxing hint) instead of surfacing misleading bare-repo wording from lower layers.

## Test plan

- [x] `cargo test -p asyncgit format_repo_open_error_not_found`
- [x] `cargo test -p gitui test_is_text_char_input_without_modifiers`
- [ ] Manual on Windows: commit popup, AltGr `{` `}` in message field

Fixes #2848
Fixes #2866