### PR TITLE
fix(revlog): clear commit message area when switching commits (#2680)

### DIFF
--- a/src/components/commit_details/details.rs
+++ b/src/components/commit_details/details.rs
@@ -20,6 +20,7 @@ use ratatui::{
 	layout::{Constraint, Direction, Layout, Rect},
 	style::{Modifier, Style},
 	text::{Line, Span, Text},
+	widgets::Clear,
 	Frame,
 };
 use std::{borrow::Cow, cell::Cell};
@@ -70,6 +71,7 @@ impl DetailsComponent {
 		});
 
 		self.scroll.reset();
+		self.current_width.set(0);
 
 		if let Some(tags) = tags {
 			self.tags.extend(tags);
@@ -303,6 +305,7 @@ impl DrawableComponent for DetailsComponent {
 
 		let can_scroll = usize::from(height) < number_of_lines;
 
+		f.render_widget(Clear, chunks[1]);
 		f.render_widget(
 			dialog_paragraph(
 				&format!(


### PR DESCRIPTION
## Summary

When browsing commits in the log view, fragments of a previous commit message could remain visible until the window was resized.

Clear the message panel before each redraw and reset the cached wrap width when `set_commit` runs so the new message fully replaces the old content.

Closes #2680.

## Test plan

- [ ] Log tab → show commit details → move up/down through commits with different message lengths
- [ ] No ghost text from the previous commit message
- [ ] Resize still works as before