### PR TITLE
fix(revlog): avoid panic when async log fetch fails (#2713)

### DIFF
--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -146,6 +146,13 @@ impl AsyncLog {
 	}
 
 	///
+	pub fn invalidate(&self) {
+		if let Ok(mut head) = self.current_head.lock() {
+			*head = None;
+		}
+	}
+
+	///
 	pub fn fetch(&self) -> Result<FetchStatus> {
 		self.background.store(false, Ordering::Relaxed);
 
@@ -176,18 +183,21 @@ impl AsyncLog {
 		rayon_core::spawn(move || {
 			scope_time!("async::revlog");
 
-			Self::fetch_helper(
+			if let Err(e) = Self::fetch_helper(
 				&repo_path,
 				&arc_current,
 				&arc_background,
 				&sender,
 				filter,
-			)
-			.expect("failed to fetch");
+			) {
+				log::error!("revlog fetch_helper: {e}");
+			}
 
 			arc_pending.store(false, Ordering::Relaxed);
 
-			Self::notify(&sender);
+			if let Err(e) = sender.send(AsyncGitNotification::Log) {
+				log::error!("revlog notify error: {e}");
+			}
 		});
 
 		Ok(FetchStatus::Started)


### PR DESCRIPTION
## Summary
- Replace `.expect("failed to fetch")` in the revlog background worker with error logging, consistent with `asyncgit::status`.
- Log channel send failures instead of panicking when notifying the UI.

## Test plan
- [x] `cargo check -p asyncgit`

Fixes #2713