### PR TITLE
feat(theme): add Gruvbox Light preset theme (#2749)

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -36,6 +36,10 @@ Notes:
 
 ## Preset Themes
 
+This repository ships example themes under [`themes/`](themes/):
+
+* **Gruvbox Light** — copy `themes/gruvbox-light.ron` to your [configuration directory](#configuration) and run `gitui -t gruvbox-light.ron`
+
 You can find preset themes by Catppuccin [here](https://github.com/catppuccin/gitui.git).
 
 ## Syntax Highlighting

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -398,4 +398,16 @@ mod tests {
 		assert_eq!(theme.selection_fg, Color::Rgb(255, 255, 255));
 		assert_eq!(theme.syntax, "InspiredGitHub");
 	}
+
+	#[test]
+	fn test_gruvbox_light_preset_loads() {
+		let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+			.join("themes/gruvbox-light.ron");
+		let theme = Theme::init(&path);
+
+		assert_eq!(theme.command_fg, Color::Rgb(60, 56, 54));
+		assert_eq!(theme.selection_bg, Color::Rgb(235, 219, 178));
+		assert_eq!(theme.commit_hash, Color::Rgb(69, 133, 136));
+		assert_eq!(theme.syntax, "InspiredGitHub");
+	}
 }

--- a/themes/gruvbox-light.ron
+++ b/themes/gruvbox-light.ron
@@ -1,0 +1,27 @@
+// Gruvbox Light preset — use with: gitui -t gruvbox-light.ron
+// (copy to your gitui config directory first; see THEMES.md)
+(
+    selected_tab: Some("#458588"),
+    command_fg: Some("#3c3836"),
+    selection_bg: Some("#ebdbb2"),
+    selection_fg: Some("#3c3836"),
+    use_selection_fg: Some(true),
+    cmdbar_bg: Some("#ebdbb2"),
+    disabled_fg: Some("#928374"),
+    diff_line_add: Some("#98971a"),
+    diff_line_delete: Some("#cc241d"),
+    diff_file_added: Some("#98971a"),
+    diff_file_removed: Some("#cc241d"),
+    diff_file_moved: Some("#b16286"),
+    diff_file_modified: Some("#d79921"),
+    commit_hash: Some("#458588"),
+    commit_time: Some("#928374"),
+    commit_author: Some("#689d6a"),
+    danger_fg: Some("#cc241d"),
+    push_gauge_bg: Some("#458588"),
+    push_gauge_fg: Some("#fbf1c7"),
+    tag_fg: Some("#d65d0e"),
+    branch_fg: Some("#458588"),
+    block_title_focused: Some("#3c3836"),
+    syntax: Some("InspiredGitHub"),
+)


### PR DESCRIPTION
## Summary
- Add `themes/gruvbox-light.ron` using the Gruvbox light palette (from #2749).
- Document usage in `THEMES.md` (`gitui -t gruvbox-light.ron` after copying to the config dir).
- Use `InspiredGitHub` for syntax highlighting on light backgrounds.
- Add a unit test that the preset loads and parses expected colors.

## Test plan
- [x] `cargo test -p gitui test_gruvbox_light_preset_loads`

Fixes #2749