### PR TITLE
fix(asyncgit): log diff/blame notification channel errors

### DIFF
--- a/asyncgit/src/blame.rs
+++ b/asyncgit/src/blame.rs
@@ -124,13 +124,13 @@ impl AsyncBlame {
 
 			arc_pending.fetch_sub(1, Ordering::Relaxed);
 
-			sender
-				.send(if notify {
-					AsyncGitNotification::Blame
-				} else {
-					AsyncGitNotification::FinishUnchanged
-				})
-				.expect("error sending blame");
+			if let Err(e) = sender.send(if notify {
+				AsyncGitNotification::Blame
+			} else {
+				AsyncGitNotification::FinishUnchanged
+			}) {
+				log::error!("blame notify error: {e}");
+			}
 		});
 
 		Ok(None)

--- a/asyncgit/src/diff.rs
+++ b/asyncgit/src/diff.rs
@@ -140,13 +140,13 @@ impl AsyncDiff {
 
 			arc_pending.fetch_sub(1, Ordering::Relaxed);
 
-			sender
-				.send(if notify {
-					AsyncGitNotification::Diff
-				} else {
-					AsyncGitNotification::FinishUnchanged
-				})
-				.expect("error sending diff");
+			if let Err(e) = sender.send(if notify {
+				AsyncGitNotification::Diff
+			} else {
+				AsyncGitNotification::FinishUnchanged
+			}) {
+				log::error!("diff notify error: {e}");
+			}
 		});
 
 		Ok(None)


### PR DESCRIPTION
## Summary
- Replace `.expect("error sending diff")` and `.expect("error sending blame")` with error logging when the async notification channel is unavailable (e.g. UI shutting down).

## Test plan
- [x] `cargo check -p asyncgit`

Related to #2713 (same panic-avoidance pattern in async workers).