### PR TITLE
Add a keybinding to redraw the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* keybinding to redraw the TUI (Ctrl+l by default) [[@acuteenvy](https://github.com/acuteenvy)] ([#2956](https://github.com/gitui-org/gitui/pull/2956))
+
 ### Changed
 * use [tombi](https://github.com/tombi-toml/tombi) for all toml file formatting
 * open the external editor from the status diff view [[@WaterWhisperer](https://github.com/WaterWhisperer)] ([#2805](https://github.com/gitui-org/gitui/issues/2805))

--- a/src/app.rs
+++ b/src/app.rs
@@ -360,6 +360,12 @@ impl App {
 				) {
 					self.options_popup.show()?;
 					NeedsUpdate::ALL
+				} else if key_match(
+					k,
+					self.key_config.keys.redraw_tui,
+				) {
+					self.requires_redraw.set(true);
+					NeedsUpdate::empty()
 				} else {
 					NeedsUpdate::empty()
 				};

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -129,6 +129,7 @@ pub struct KeysList {
 	pub commit: GituiKeyEvent,
 	pub newline: GituiKeyEvent,
 	pub goto_line: GituiKeyEvent,
+	pub redraw_tui: GituiKeyEvent,
 }
 
 #[rustfmt::skip]
@@ -227,6 +228,7 @@ impl Default for KeysList {
 			commit: GituiKeyEvent::new(KeyCode::Char('d'),  KeyModifiers::CONTROL),
 			newline: GituiKeyEvent::new(KeyCode::Enter,  KeyModifiers::empty()),
 			goto_line: GituiKeyEvent::new(KeyCode::Char('L'),  KeyModifiers::SHIFT),
+			redraw_tui: GituiKeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL),
 		}
 	}
 }


### PR DESCRIPTION
This Pull Request fixes/closes #2703.

It changes the following:
- Ctrl+l now redraws the TUI.

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
I'm getting errors from `tombi`:
```
Error: "./asyncgit/Cargo.toml" is not formatted
Error: "./Cargo.toml" is not formatted
11 files did not need formatting
2 files failed to be formatted
```
but I didn't touch these files.

- [x] I tested the overall application
- [x] I added an appropriate item to the changelog