### PR TITLE
Update `git2` to 0.21 across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,16 +1273,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -2606,15 +2604,13 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2633,20 +2629,6 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2985,12 +2967,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -2611,6 +2613,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -2967,6 +2970,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = "0.5"
 dirs = "6.0"
 easy-cast = "0.5"
 fuzzy-matcher = "0.3"
-git2 = "0.20"
+git2 = { version = "0.21", features = ["cred"] }
 git2-hooks = { path = "../git2-hooks", version = "0.7" }
 gix = { version = "0.78.0", default-features = false, features = [
   "mailmap",

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = "0.5"
 dirs = "6.0"
 easy-cast = "0.5"
 fuzzy-matcher = "0.3"
-git2 = { version = "0.21", features = ["cred"] }
+git2 = { version = "0.21", features = ["https"] }
 git2-hooks = { path = "../git2-hooks", version = "0.7" }
 gix = { version = "0.78.0", default-features = false, features = [
   "mailmap",

--- a/asyncgit/src/sync/branch/mod.rs
+++ b/asyncgit/src/sync/branch/mod.rs
@@ -160,7 +160,9 @@ pub fn get_branches_info(
 				.branch_upstream_remote(&reference)
 				.ok()
 				.as_ref()
-				.and_then(git2::Buf::as_str)
+				.and_then(|upstream_remote| {
+					git2::Buf::as_str(upstream_remote).ok()
+				})
 				.map(String::from);
 
 			let name_bytes = branch.name_bytes()?;
@@ -332,7 +334,7 @@ pub fn checkout_branch(
 		Some(&mut git2::build::CheckoutBuilder::new()),
 	)?;
 
-	let branch_ref = branch_ref.name().ok_or_else(|| {
+	let branch_ref = branch_ref.name().map_err(|_| {
 		Error::Generic(String::from("branch ref not found"))
 	});
 

--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -70,7 +70,7 @@ pub(crate) fn signature_allow_undefined_name(
 				config.get_entry("user.name"),
 				config.get_entry("user.email"),
 			) {
-				if let Some(email) = email_entry.value() {
+				if let Ok(email) = email_entry.value() {
 					return Signature::now("unknown", email);
 				}
 			};

--- a/asyncgit/src/sync/commit_filter.rs
+++ b/asyncgit/src/sync/commit_filter.rs
@@ -214,9 +214,9 @@ pub fn filter_commit_by_search(
 				let author = get_author_of_commit(&commit, &mailmap);
 				[author.email(), author.name()].iter().any(
 					|opt_haystack| {
-						opt_haystack.as_ref().ok().is_some_and(
-							|haystack| filter.match_text(haystack),
-						)
+						opt_haystack.as_ref().is_ok_and(|haystack| {
+							filter.match_text(haystack)
+						})
 					},
 				)
 			} else {

--- a/asyncgit/src/sync/commit_filter.rs
+++ b/asyncgit/src/sync/commit_filter.rs
@@ -170,7 +170,11 @@ pub fn filter_commit_by_search(
 				.fields
 				.contains(SearchFields::MESSAGE_SUMMARY)
 				.then(|| {
-					commit.summary().map(|msg| filter.match_text(msg))
+					commit
+						.summary()
+						.ok()
+						.flatten()
+						.map(|msg| filter.match_text(msg))
 				})
 				.flatten()
 				.unwrap_or_default();
@@ -180,7 +184,11 @@ pub fn filter_commit_by_search(
 				.fields
 				.contains(SearchFields::MESSAGE_BODY)
 				.then(|| {
-					commit.body().map(|msg| filter.match_text(msg))
+					commit
+						.body()
+						.ok()
+						.flatten()
+						.map(|msg| filter.match_text(msg))
 				})
 				.flatten()
 				.unwrap_or_default();
@@ -206,9 +214,9 @@ pub fn filter_commit_by_search(
 				let author = get_author_of_commit(&commit, &mailmap);
 				[author.email(), author.name()].iter().any(
 					|opt_haystack| {
-						opt_haystack.is_some_and(|haystack| {
-							filter.match_text(haystack)
-						})
+						opt_haystack.as_ref().ok().is_some_and(
+							|haystack| filter.match_text(haystack),
+						)
 					},
 				)
 			} else {

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -20,7 +20,7 @@ pub struct CommitId(Oid);
 
 impl Default for CommitId {
 	fn default() -> Self {
-		Self(Oid::zero())
+		Self(Oid::ZERO_SHA1)
 	}
 }
 
@@ -146,6 +146,7 @@ pub fn get_commits_info(
 			let message = get_message(&c, Some(message_length_limit));
 			let author = get_author_of_commit(&c, &mailmap)
 				.name()
+				.ok()
 				.map_or_else(
 					|| String::from("<unknown>"),
 					String::from,

--- a/asyncgit/src/sync/config.rs
+++ b/asyncgit/src/sync/config.rs
@@ -136,7 +136,7 @@ pub fn get_config_string_repo(
 	};
 
 	if entry.has_value() {
-		Ok(entry.value().map(std::string::ToString::to_string))
+		Ok(entry.value().ok().map(std::string::ToString::to_string))
 	} else {
 		Ok(None)
 	}

--- a/asyncgit/src/sync/cred.rs
+++ b/asyncgit/src/sync/cred.rs
@@ -42,7 +42,9 @@ pub fn need_username_password(repo_path: &RepoPath) -> Result<bool> {
 		repo.find_remote(&get_default_remote_in_repo(&repo)?)?;
 	let url = remote
 		.pushurl()
-		.or_else(|| remote.url())
+		.ok()
+		.flatten()
+		.or_else(|| remote.url().ok())
 		.ok_or(Error::UnknownRemote)?
 		.to_owned();
 	let is_http = url.starts_with("http");
@@ -58,11 +60,8 @@ pub fn need_username_password_for_fetch(
 	let repo = repo(repo_path)?;
 	let remote = repo
 		.find_remote(&get_default_remote_for_fetch_in_repo(&repo)?)?;
-	let url = remote
-		.url()
-		.or_else(|| remote.url())
-		.ok_or(Error::UnknownRemote)?
-		.to_owned();
+	let url =
+		remote.url().map_err(|_| Error::UnknownRemote)?.to_owned();
 	let is_http = url.starts_with("http");
 	Ok(is_http)
 }
@@ -78,7 +77,9 @@ pub fn need_username_password_for_push(
 		.find_remote(&get_default_remote_for_push_in_repo(&repo)?)?;
 	let url = remote
 		.pushurl()
-		.or_else(|| remote.url())
+		.ok()
+		.flatten()
+		.or_else(|| remote.url().ok())
 		.ok_or(Error::UnknownRemote)?
 		.to_owned();
 	let is_http = url.starts_with("http");
@@ -93,6 +94,7 @@ pub fn extract_username_password(
 	let url = repo
 		.find_remote(&get_default_remote_in_repo(&repo)?)?
 		.url()
+		.ok()
 		.ok_or(Error::UnknownRemote)?
 		.to_owned();
 	let mut helper = CredentialHelper::new(&url);
@@ -122,6 +124,7 @@ pub fn extract_username_password_for_fetch(
 	let url = repo
 		.find_remote(&get_default_remote_for_fetch_in_repo(&repo)?)?
 		.url()
+		.ok()
 		.ok_or(Error::UnknownRemote)?
 		.to_owned();
 	let mut helper = CredentialHelper::new(&url);
@@ -151,6 +154,7 @@ pub fn extract_username_password_for_push(
 	let url = repo
 		.find_remote(&get_default_remote_for_push_in_repo(&repo)?)?
 		.url()
+		.ok()
 		.ok_or(Error::UnknownRemote)?
 		.to_owned();
 	let mut helper = CredentialHelper::new(&url);

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -179,7 +179,9 @@ pub fn hooks_pre_push(
 	let git_remote = repo.find_remote(remote)?;
 	let url = git_remote
 		.pushurl()
-		.or_else(|| git_remote.url())
+		.ok()
+		.flatten()
+		.or_else(|| git_remote.url().ok())
 		.ok_or_else(|| {
 			crate::error::Error::Generic(format!(
 				"remote '{remote}' has no URL configured"

--- a/asyncgit/src/sync/remotes/mod.rs
+++ b/asyncgit/src/sync/remotes/mod.rs
@@ -88,8 +88,12 @@ pub fn get_remotes(repo_path: &RepoPath) -> Result<Vec<String>> {
 
 	let repo = repo(repo_path)?;
 	let remotes = repo.remotes()?;
-	let remotes: Vec<String> =
-		remotes.iter().flatten().map(String::from).collect();
+	let remotes: Vec<String> = remotes
+		.iter()
+		.flatten()
+		.flatten()
+		.map(String::from)
+		.collect();
 
 	Ok(remotes)
 }
@@ -102,7 +106,7 @@ pub fn get_remote_url(
 	let repo = repo(repo_path)?;
 	let remote = repo.find_remote(remote_name)?.clone();
 	let url = remote.url();
-	if let Some(u) = url {
+	if let Ok(u) = url {
 		return Ok(Some(u.to_string()));
 	}
 	Ok(None)
@@ -241,9 +245,9 @@ pub(crate) fn get_default_remote_in_repo(
 	let remotes = repo.remotes()?;
 
 	// if `origin` exists return that
-	let found_origin = remotes
-		.iter()
-		.any(|r| r.is_some_and(|r| r == DEFAULT_REMOTE_NAME));
+	let found_origin = remotes.iter().any(|r| {
+		r.ok().flatten().is_some_and(|r| r == DEFAULT_REMOTE_NAME)
+	});
 	if found_origin {
 		return Ok(DEFAULT_REMOTE_NAME.into());
 	}
@@ -252,8 +256,9 @@ pub(crate) fn get_default_remote_in_repo(
 	if remotes.len() == 1 {
 		let first_remote = remotes
 			.iter()
-			.next()
 			.flatten()
+			.flatten()
+			.next()
 			.map(String::from)
 			.ok_or_else(|| {
 				Error::Generic("no remote found".into())
@@ -306,6 +311,7 @@ pub fn fetch_all(
 	let remotes = repo
 		.remotes()?
 		.iter()
+		.flatten()
 		.flatten()
 		.map(String::from)
 		.collect::<Vec<_>>();

--- a/asyncgit/src/sync/remotes/mod.rs
+++ b/asyncgit/src/sync/remotes/mod.rs
@@ -215,8 +215,7 @@ pub(crate) fn get_default_remote_for_push_in_repo(
 	if let Some(branch) = branch {
 		let remote_name = bytes2string(branch.name_bytes()?)?;
 
-		let entry_name =
-			format!("branch.{remote_name}.pushRemote");
+		let entry_name = format!("branch.{remote_name}.pushRemote");
 
 		if let Ok(entry) = config.get_entry(&entry_name) {
 			return bytes2string(entry.value_bytes());

--- a/asyncgit/src/sync/remotes/mod.rs
+++ b/asyncgit/src/sync/remotes/mod.rs
@@ -165,7 +165,7 @@ pub(crate) fn get_default_remote_for_fetch_in_repo(
 	if let Some(branch) = branch {
 		let remote_name = bytes2string(branch.name_bytes()?)?;
 
-		let entry_name = format!("branch.{}.remote", &remote_name);
+		let entry_name = format!("branch.{remote_name}.remote");
 
 		if let Ok(entry) = config.get_entry(&entry_name) {
 			return bytes2string(entry.value_bytes());
@@ -216,7 +216,7 @@ pub(crate) fn get_default_remote_for_push_in_repo(
 		let remote_name = bytes2string(branch.name_bytes()?)?;
 
 		let entry_name =
-			format!("branch.{}.pushRemote", &remote_name);
+			format!("branch.{remote_name}.pushRemote");
 
 		if let Ok(entry) = config.get_entry(&entry_name) {
 			return bytes2string(entry.value_bytes());
@@ -226,7 +226,7 @@ pub(crate) fn get_default_remote_for_push_in_repo(
 			return bytes2string(entry.value_bytes());
 		}
 
-		let entry_name = format!("branch.{}.remote", &remote_name);
+		let entry_name = format!("branch.{remote_name}.remote");
 
 		if let Ok(entry) = config.get_entry(&entry_name) {
 			return bytes2string(entry.value_bytes());

--- a/asyncgit/src/sync/remotes/tags.rs
+++ b/asyncgit/src/sync/remotes/tags.rs
@@ -89,7 +89,9 @@ pub fn tags_missing_remote(
 
 	let mut local_tags = tags
 		.iter()
-		.filter_map(|tag| tag.map(|tag| format!("refs/tags/{tag}")))
+		.filter_map(|tag| {
+			tag.ok().flatten().map(|tag| format!("refs/tags/{tag}"))
+		})
 		.collect::<HashSet<_>>();
 	let remote_tags =
 		remote_tag_refs(repo_path, remote, basic_credential)?;

--- a/asyncgit/src/sync/sign.rs
+++ b/asyncgit/src/sync/sign.rs
@@ -239,7 +239,7 @@ impl Sign for GPGSign {
 		if !output.status.success() {
 			return Err(SignError::Shellout(format!(
 				"failed to sign data, program '{}' exited non-zero: {}",
-				&self.program,
+				self.program,
 				std::str::from_utf8(&output.stderr)
 					.unwrap_or("[error could not be read from stderr]")
 			)));
@@ -250,7 +250,7 @@ impl Sign for GPGSign {
 
 		if !stderr.contains("\n[GNUPG:] SIG_CREATED ") {
 			return Err(SignError::Shellout(
-				format!("failed to sign data, program '{}' failed, SIG_CREATED not seen in stderr", &self.program),
+				format!("failed to sign data, program '{}' failed, SIG_CREATED not seen in stderr", self.program),
 			));
 		}
 

--- a/asyncgit/src/sync/submodules.rs
+++ b/asyncgit/src/sync/submodules.rs
@@ -65,7 +65,7 @@ fn submodule_to_info(s: &Submodule, r: &Repository) -> SubmoduleInfo {
 		path: s.path().to_path_buf(),
 		id: s.workdir_id().map(CommitId::from),
 		head_id: s.head_id().map(CommitId::from),
-		url: s.url().map(String::from),
+		url: s.url().ok().flatten().map(String::from),
 		status,
 	}
 }

--- a/asyncgit/src/sync/tree.rs
+++ b/asyncgit/src/sync/tree.rs
@@ -161,7 +161,7 @@ mod tests {
 			.map(|f| TreeFile {
 				path: PathBuf::from(f),
 				filemode: 0,
-				id: Oid::zero(),
+				id: Oid::ZERO_SHA1,
 			})
 			.collect::<Vec<_>>();
 
@@ -186,7 +186,7 @@ mod tests {
 			.map(|f| TreeFile {
 				path: PathBuf::from(f),
 				filemode: 0,
-				id: Oid::zero(),
+				id: Oid::ZERO_SHA1,
 			})
 			.collect::<Vec<_>>();
 
@@ -210,7 +210,7 @@ mod tests {
 			.map(|f| TreeFile {
 				path: PathBuf::from(f),
 				filemode: 0,
-				id: Oid::zero(),
+				id: Oid::ZERO_SHA1,
 			})
 			.collect::<Vec<_>>();
 

--- a/git2-hooks/Cargo.toml
+++ b/git2-hooks/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 keywords = ["git"]
 
 [dependencies]
-git2 = ">=0.17"
+git2 = "0.21"
 gix-path = "0.11"
 log = "0.4"
 shellexpand = "3.1"

--- a/git2-hooks/src/lib.rs
+++ b/git2-hooks/src/lib.rs
@@ -837,7 +837,7 @@ exit 2
 		let res = hooks_prepare_commit_msg(
 			&repo,
 			None,
-			PrepareCommitMsgSource::Commit(git2::Oid::zero()),
+			PrepareCommitMsgSource::Commit(git2::Oid::ZERO_SHA1),
 			&mut msg,
 		)
 		.unwrap();

--- a/git2-testing/Cargo.toml
+++ b/git2-testing/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["git"]
 
 [dependencies]
 env_logger = "0.11"
-git2 = ">=0.17"
+git2 = "0.21"
 log = "0.4"
 tempfile = "3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,7 +161,7 @@ impl App {
 		key_config: KeyConfig,
 	) -> Result<Self> {
 		let repo = RefCell::new(cliargs.repo_path.clone());
-		log::trace!("open repo at: {:?}", &repo);
+		log::trace!("open repo at: {repo:?}");
 
 		let repo_path_text =
 			repo_work_dir(&repo.borrow()).unwrap_or_default();

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -558,7 +558,7 @@ impl CommitList {
 
 		// commit msg
 		txt.push(Span::styled(
-			format!("{:message_width$}", &e.msg),
+			format!("{:message_width$}", e.msg),
 			style_msg,
 		));
 

--- a/src/components/utils/statustree.rs
+++ b/src/components/utils/statustree.rs
@@ -437,7 +437,7 @@ impl StatusTree {
 			if matches!(item_kind, FileTreeItemKind::Path(PathCollapsed(collapsed)) if collapsed)
 			{
 				// we encountered an inner path that is still collapsed
-				inner_collapsed = Some(format!("{}/", &item_path));
+				inner_collapsed = Some(format!("{item_path}/"));
 			}
 
 			if prefix

--- a/src/ui/reflow.rs
+++ b/src/ui/reflow.rs
@@ -44,7 +44,7 @@ impl<'a> LineComposer<'a> for WordWrapper<'a, '_> {
 			return None;
 		}
 		std::mem::swap(&mut self.current_line, &mut self.next_line);
-		self.next_line.truncate(0);
+		self.next_line.clear();
 
 		let mut current_line_width = self
 			.current_line
@@ -175,7 +175,7 @@ impl<'a> LineComposer<'a> for LineTruncator<'a, '_> {
 			return None;
 		}
 
-		self.current_line.truncate(0);
+		self.current_line.clear();
 		let mut current_line_width = 0;
 
 		let mut skip_rest = false;


### PR DESCRIPTION
This PR updates the `git2` dependency to 0.21.

Among other things, this brings a new feature flag: `unstable-sha256`. This feature flag is not enabled in this PR. This could be done in a follow-up.

Breaking changes in upstream changelog: https://github.com/rust-lang/git2-rs/blob/main/CHANGELOG.md#changed

Relevant for `gitui`:

- “The `ssh`, `https`, and `cred` Cargo features are no longer enabled by default.” `asyncgit` now explicitly enables `https`.
- “Many string accessors that previously returned `Option<&str>` now return `Result<&str, Error>` or `Result<Option<&str>, Error>`, so callers can distinguish a missing value from a non-UTF-8 one.” In this PR, I’ve decided to keep the existing behaviour by treating `Err` values as `None`. Let me know if you want any changes here!