### PR TITLE
fix(staging): prevent index out of bounds when unstaging at buffer end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * crash when opening submodule ([#2895](https://github.com/gitui-org/gitui/issues/2895))
+* prevent a panic when unstaging near the end of the diff buffer ([#2953](https://github.com/gitui-org/gitui/issues/2953))
 * when staging the last file in a directory, the first item after the directory is no longer skipped [[@Tillerino](https://github.com/Tillerino)] ([#2748](https://github.com/gitui-org/gitui/issues/2748))
 
 ## [0.28.1] - 2026-03-21

--- a/asyncgit/src/sync/staging/mod.rs
+++ b/asyncgit/src/sync/staging/mod.rs
@@ -39,8 +39,10 @@ impl NewFromOldContent {
 	}
 
 	fn add_old_line(&mut self, old_lines: &[&str]) {
-		self.lines.push(old_lines[self.old_index].to_string());
-		self.old_index += 1;
+		if self.old_index < old_lines.len() {
+			self.lines.push(old_lines[self.old_index].to_string());
+			self.old_index += 1;
+		}
 	}
 
 	fn catchup_to_hunkstart(


### PR DESCRIPTION
Fixes #2953

When unstaging lines near the end of a diff buffer, `old_index` could reach `old_lines.len()`, causing an index out of bounds panic in `add_old_line`. Add a bounds check to handle this edge case gracefully.

## Changes
- `asyncgit/src/sync/staging/mod.rs`: Added bounds check in `add_old_line` to prevent panic when `old_index >= old_lines.len()`

## Verification
- `cargo check` passes
- Fix is a minimal, defensive bounds check that prevents the panic without changing behavior for valid inputs

## Root Cause
The panic occurred at `asyncgit/src/sync/staging/mod.rs:42:25` with message: `index out of bounds: the len is 151 but the index is 151`. This happened when pressing 's' (Unstage lines) at almost the end of the buffer in the Diff view.