### PR TITLE
fix(reset_hunk): pass diff options to reversed diff so the correct hunk is discarded

### DIFF
--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -59,7 +59,8 @@ pub fn reset_hunk(
 			res
 		});
 
-		let diff = get_diff_raw(&repo, file_path, false, true, None)?;
+		let diff =
+			get_diff_raw(&repo, file_path, false, true, options)?;
 
 		repo.apply(&diff, ApplyLocation::WorkDir, Some(&mut opt))?;
 


### PR DESCRIPTION
`reset_hunk` found the target hunk index by diffing with the caller's `options`, but then applied the reversed diff with `None` options. When non-default options (e.g. `ignore_whitespace`, `interhunk_lines`) are in use, the positional index can select the wrong hunk, corrupting the working tree.

`unstage_hunk` already passes `options` to both diffs correctly. This commit mirrors that pattern in `reset_hunk`.