### PR TITLE
fix(submodules): use forward slashes in submodule name lookup on Windows

### DIFF
--- a/asyncgit/src/sync/hunks.rs
+++ b/asyncgit/src/sync/hunks.rs
@@ -59,7 +59,8 @@ pub fn reset_hunk(
 			res
 		});
 
-		let diff = get_diff_raw(&repo, file_path, false, true, None)?;
+		let diff =
+			get_diff_raw(&repo, file_path, false, true, options)?;
 
 		repo.apply(&diff, ApplyLocation::WorkDir, Some(&mut opt))?;
 


### PR DESCRIPTION
`submodule_parent_info` derives the submodule name from the stripped path using `to_string_lossy()`. On Windows this produces backslash-separated components (e.g. `sub\nested`), but `libgit2`'s `find_submodule` expects forward slashes. The lookup always fails on Windows, so `submodule_parent_info` returns `None` for any submodule.

Fix: call `.replace('\', "/")` on the lossy string before passing it to `find_submodule`.