### PR TITLE
fix: actually truncate over-long commit messages and submodule paths in lists

### DIFF
--- a/src/popups/branchlist.rs
+++ b/src/popups/branchlist.rs
@@ -503,10 +503,13 @@ impl BranchListPopup {
 			let mut commit_message =
 				displaybranch.top_commit_message.clone();
 			if commit_message.len() > commit_message_length {
-				commit_message.unicode_truncate(
-					commit_message_length
-						.saturating_sub(THREE_DOTS_LENGTH),
-				);
+				commit_message = commit_message
+					.unicode_truncate(
+						commit_message_length
+							.saturating_sub(THREE_DOTS_LENGTH),
+					)
+					.0
+					.to_string();
 				commit_message += THREE_DOTS;
 			}
 

--- a/src/popups/submodules.rs
+++ b/src/popups/submodules.rs
@@ -361,9 +361,12 @@ impl SubmodulesListPopup {
 				.to_string();
 
 			if module_path.len() > name_length {
-				module_path.unicode_truncate(
-					name_length.saturating_sub(THREE_DOTS_LENGTH),
-				);
+				module_path = module_path
+					.unicode_truncate(
+						name_length.saturating_sub(THREE_DOTS_LENGTH),
+					)
+					.0
+					.to_string();
 				module_path += THREE_DOTS;
 			}
 


### PR DESCRIPTION
In `branchlist.rs` and `submodules.rs`, the calls to `.unicode_truncate(...)` return the truncated string slice, but the return value is discarded. As a result the original untruncated string is kept and only `"..."` is appended, making the displayed entry longer than the available width.

The adjacent `branch_name` truncation in `branchlist.rs` already does this correctly (`.unicode_truncate(...).0.to_string()`). Applied the same pattern to `commit_message` in `branchlist.rs` and `module_path` in `submodules.rs`.