### PR TITLE
fix(taglist): avoid usize underflow on empty tag list

### DIFF
--- a/src/popups/taglist.rs
+++ b/src/popups/taglist.rs
@@ -387,8 +387,10 @@ impl TagListPopup {
 		let mut table_state = self.table_state.take();
 
 		let old_selection = table_state.selected().unwrap_or(0);
-		let max_selection =
-			self.tags.as_ref().map_or(0, |tags| tags.len() - 1);
+		let max_selection = self
+			.tags
+			.as_ref()
+			.map_or(0, |tags| tags.len().saturating_sub(1));
 
 		let new_selection = match scroll_type {
 			ScrollType::Up => old_selection.saturating_sub(1),


### PR DESCRIPTION
In `move_selection`, `max_selection` is computed as `tags.len() - 1`. When the tag list is an empty `Vec`, this underflows: panic in debug builds, `usize::MAX` in release (causing an out-of-bounds selection).

Fix: use `saturating_sub(1)` so the result is `0` for an empty list.