### PR TITLE
fix(asyncgit): correct swapped current/total in pack_progress callback

### DIFF
--- a/asyncgit/src/sync/remotes/callbacks.rs
+++ b/asyncgit/src/sync/remotes/callbacks.rs
@@ -71,7 +71,7 @@ impl Callbacks {
 
 		let this = self.clone();
 		callbacks.pack_progress(move |stage, current, total| {
-			this.pack_progress(stage, total, current);
+			this.pack_progress(stage, current, total);
 		});
 
 		let this = self.clone();
@@ -118,8 +118,8 @@ impl Callbacks {
 	fn pack_progress(
 		&self,
 		stage: git2::PackBuilderStage,
-		total: usize,
 		current: usize,
+		total: usize,
 	) {
 		log::debug!("packing: {stage:?} - {current}/{total}");
 		self.sender.clone().map(|sender| {


### PR DESCRIPTION
`Callbacks::callbacks` registers a `pack_progress` closure that receives `(stage, current, total)` from git2 but forwards them as `(stage, total, current)` to the private `pack_progress` method. The method's parameter names then label the git2 `current` as `total` and vice versa, so `ProgressNotification::Packing { current, total }` is emitted with the values inverted.

This makes the packing progress bar count from ~100% down to 0% (or saturate immediately) instead of advancing from 0% to 100%.

Fix: pass `current, total` in the correct order and align the private method's parameter names to match.