### PR TITLE
fix(blame): correct scrollbar max so thumb reaches bottom at last line

### DIFF
--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -158,23 +158,7 @@ impl DrawableComponent for BlameFilePopup {
 				f,
 				area,
 				&self.theme,
-				// April 2021: `draw_scrollbar` assumes that the last parameter
-				// is `scroll_top`.  Therefore, it subtracts the area’s height
-				// before calculating the position of the scrollbar. To account
-				// for that, we add the current height.
-				number_of_rows + (area.height as usize),
-				// April 2021: we don’t have access to `table_state.offset`
-				// (it’s private), so we use `table_state.selected()` as a
-				// replacement.
-				//
-				// Other widgets, for example `BranchListComponent`, manage
-				// scroll state themselves and use `self.scroll_top` in this
-				// situation.
-				//
-				// There are plans to change `render_stateful_widgets`, so this
-				// might be acceptable as an interim solution.
-				//
-				// https://github.com/fdehau/tui-rs/issues/448
+				number_of_rows.saturating_sub(1),
 				table_state.selected().unwrap_or(0),
 				ui::Orientation::Vertical,
 			);


### PR DESCRIPTION
## Summary

The `draw_scrollbar` call in `BlameFilePopup::draw` has used a stale workaround since April 2021, when `tui-rs` internally subtracted `area.height` from the `max` parameter before computing the thumb position. That subtraction was never part of our own `draw_scrollbar` (in `src/ui/scrollbar.rs`), so passing `number_of_rows + area.height` as `max` inflates it artificially.

**Effect:** The scrollbar thumb never reaches the bottom. For a 100-line file displayed in a 30-row terminal, the furthest the thumb travels is `99 / 130 ≈ 76%` — even when the cursor is on the last line.

**Fix:** Pass `number_of_rows.saturating_sub(1)` as `max`, matching the pattern used by `taglist` and `fuzzy_find` (which pass `len.saturating_sub(1)` and work correctly). Remove the now-obsolete comments.

## Test plan

- Open blame on a file with more lines than the terminal height
- Scroll to the last line with `End`
- Confirm the scrollbar thumb is now at the bottom of the scrollbar track