### PR TITLE
fix(branchlist): propagate error instead of panicking in switch_to_selected_branch

### DIFF
--- a/src/popups/branchlist.rs
+++ b/src/popups/branchlist.rs
@@ -586,8 +586,7 @@ impl BranchListPopup {
 			&self.repo.borrow(),
 			StatusType::WorkingDir,
 			None,
-		)
-		.expect("Could not get status");
+		)?;
 
 		let selected_branch = &self.branches[self.selection as usize];
 		if status.is_empty() {


### PR DESCRIPTION
`switch_to_selected_branch` calls `get_status(...).expect(...)`, which panics the whole app on any error (e.g. transient IO or permission failure). The function already returns `Result<()>` and is invoked via `try_or_popup!`, so propagating with `?` instead lets the error surface as a popup rather than a crash.

## Change

Replace `.expect("Could not get status")` with `?` in `src/popups/branchlist.rs`.
