### PR TITLE
fix(watcher): store Debouncer in RepoWatcher to prevent OS handle leak

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Sender};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use notify_debouncer_mini::{new_debouncer, DebounceEventResult};
-use scopetime::scope_time;
+use notify_debouncer_mini::{
+	new_debouncer, DebounceEventResult, Debouncer,
+};
 use std::{path::Path, thread, time::Duration};
 
 pub struct RepoWatcher {
 	receiver: crossbeam_channel::Receiver<()>,
+	_watcher: Debouncer<RecommendedWatcher>,
 }
 
 impl RepoWatcher {
@@ -18,12 +20,13 @@ impl RepoWatcher {
 
 		let (tx, rx) = std::sync::mpsc::channel();
 
-		let workdir = workdir.to_string();
-
-		thread::spawn(move || {
-			let timeout = Duration::from_secs(2);
-			create_watcher(timeout, tx, &workdir);
-		});
+		let timeout = Duration::from_secs(2);
+		let mut bouncer =
+			new_debouncer(timeout, tx).expect("Watch create error");
+		bouncer
+			.watcher()
+			.watch(Path::new(workdir), RecursiveMode::Recursive)
+			.expect("Watch error");
 
 		let (out_tx, out_rx) = unbounded();
 
@@ -34,7 +37,10 @@ impl RepoWatcher {
 			}
 		});
 
-		Self { receiver: out_rx }
+		Self {
+			receiver: out_rx,
+			_watcher: bouncer,
+		}
 	}
 
 	///
@@ -62,21 +68,4 @@ impl RepoWatcher {
 			}
 		}
 	}
-}
-
-fn create_watcher(
-	timeout: Duration,
-	tx: std::sync::mpsc::Sender<DebounceEventResult>,
-	workdir: &str,
-) {
-	scope_time!("create_watcher");
-
-	let mut bouncer =
-		new_debouncer(timeout, tx).expect("Watch create error");
-	bouncer
-		.watcher()
-		.watch(Path::new(&workdir), RecursiveMode::Recursive)
-		.expect("Watch error");
-
-	std::mem::forget(bouncer);
 }


### PR DESCRIPTION
## Summary

- `create_watcher` called `std::mem::forget(bouncer)` to keep the OS file-watcher handle alive, but this permanently leaks the handle on every call — one leak per submodule repo opened, never cleaned up.
- Fix: remove `create_watcher` (and the thread that called it). Create the `Debouncer` inline in `RepoWatcher::new` and store it in a new `_watcher: Debouncer<RecommendedWatcher>` field so the OS handle is properly released when `RepoWatcher` is dropped.
- Also removes the now-unused `scopetime` import.

## Test plan

- [ ] Open a repo with submodules and verify file-watching still works
- [ ] Confirm no extra OS handles accumulate (e.g. via `lsof`/Process Explorer) when opening multiple repos
