### PR TITLE
fix(staging): preserve no-trailing-newline when staging partial hunks

### DIFF
--- a/asyncgit/src/sync/staging/mod.rs
+++ b/asyncgit/src/sync/staging/mod.rs
@@ -13,10 +13,20 @@ use std::{collections::HashSet, fs::File, io::Read};
 
 const NEWLINE: char = '\n';
 
-#[derive(Default)]
 struct NewFromOldContent {
 	lines: Vec<String>,
 	old_index: usize,
+	trailing_newline: bool,
+}
+
+impl Default for NewFromOldContent {
+	fn default() -> Self {
+		Self {
+			lines: Vec::new(),
+			old_index: 0,
+			trailing_newline: true,
+		}
+	}
 }
 
 impl NewFromOldContent {
@@ -57,14 +67,11 @@ impl NewFromOldContent {
 		for line in old_lines.iter().skip(self.old_index) {
 			self.lines.push((*line).to_string());
 		}
-		let lines = self.lines.join("\n");
-		if lines.ends_with(NEWLINE) {
-			lines
-		} else {
-			let mut lines = lines;
+		let mut lines = self.lines.join("\n");
+		if self.trailing_newline && !lines.ends_with(NEWLINE) {
 			lines.push(NEWLINE);
-			lines
 		}
+		lines
 	}
 }
 
@@ -133,6 +140,18 @@ pub fn apply_selection(
 					|| hunk_line.origin_value()
 						== DiffLineType::AddEOFNL
 				{
+					let applying = (is_staged && !selected_line)
+						|| (!is_staged && selected_line);
+					new_content.trailing_newline = if hunk_line
+						.origin_value()
+						== DiffLineType::DeleteEOFNL
+					{
+						// old had newline, new doesn't; applying removal -> no newline
+						!applying
+					} else {
+						// AddEOFNL: old had no newline, new does; applying addition -> newline
+						applying
+					};
 					break;
 				}
 

--- a/asyncgit/src/sync/staging/stage_tracked.rs
+++ b/asyncgit/src/sync/staging/stage_tracked.rs
@@ -143,6 +143,48 @@ c = 4";
 	}
 
 	#[test]
+	fn test_stage_preserves_no_trailing_newline() {
+		// Both files have no trailing newline
+		static FILE_1: &str = "line1\nline2";
+		static FILE_2: &str = "line1_changed\nline2";
+
+		let (path, repo) = repo_init().unwrap();
+		let path: &RepoPath = &path.path().to_str().unwrap().into();
+
+		write_commit_file(&repo, "test.txt", FILE_1, "c1");
+		repo_write_file(&repo, "test.txt", FILE_2).unwrap();
+
+		// Stage only the changed first line
+		stage_lines(
+			path,
+			"test.txt",
+			false,
+			&[DiffLinePosition {
+				old_lineno: Some(1),
+				new_lineno: Some(1),
+			}],
+		)
+		.unwrap();
+
+		// Read the staged blob and verify it has no trailing newline
+		let git_repo = repo(path).unwrap();
+		let mut index = git_repo.index().unwrap();
+		index.read(true).unwrap();
+		let entry = index
+			.get_path(Path::new("test.txt"), 0)
+			.expect("entry not found");
+		let blob = git_repo.find_blob(entry.id).unwrap();
+		let staged = std::str::from_utf8(blob.content()).unwrap();
+
+		assert!(
+			!staged.ends_with('\n'),
+			"staged content must not gain a trailing newline; got: {:?}",
+			staged
+		);
+		assert_eq!(staged, "line1_changed\nline2");
+	}
+
+	#[test]
 	fn test_unstage() {
 		static FILE_1: &str = r"0
 ";


### PR DESCRIPTION
## Summary

`finish()` in `NewFromOldContent` unconditionally appended `\n` to the reconstructed file content, even when the original file had no trailing newline. The `DeleteEOFNL` / `AddEOFNL` diff markers were silently discarded with a bare `break`, so staging or discarding a single line in a no-newline file would silently corrupt it by adding a newline.

- Add `trailing_newline: bool` field to `NewFromOldContent` (default `true`).
- In `apply_selection`, when `DeleteEOFNL` or `AddEOFNL` is encountered, set `trailing_newline` based on whether the change is being applied or reverted, then `break`.
- In `finish()`, only append `\n` when `self.trailing_newline` is true.
- Add `test_stage_preserves_no_trailing_newline` in `stage_tracked.rs` that stages a single changed line in a two-line file with no trailing newline and asserts the staged blob content is also newline-free.