### PR TITLE
fix(popups): command-bar toggle ([.]) works inside diff/commit viewer popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * crash when opening submodule ([#2895](https://github.com/gitui-org/gitui/issues/2895))
 * when staging the last file in a directory, the first item after the directory is no longer skipped [[@Tillerino](https://github.com/Tillerino)] ([#2748](https://github.com/gitui-org/gitui/issues/2748))
 * index-out-of-bounds panic when unstaging lines near the end of a diff ([#2953](https://github.com/gitui-org/gitui/issues/2953))
+* the command bar `more`/`less` toggle ([.]) now works inside the diff/commit viewer popups (inspect commit, compare, file history, blame), which previously swallowed the key
 
 ## [0.28.1] - 2026-03-21
 

--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -255,6 +255,12 @@ impl Component for BlameFilePopup {
 	) -> Result<EventState> {
 		if self.is_visible() {
 			if let Event::Key(key) = event {
+				// let the command bar more/less toggle ([.])
+				// bubble up to the app-level handler
+				if key_match(key, self.key_config.keys.cmd_bar_toggle)
+				{
+					return Ok(EventState::NotConsumed);
+				}
 				if key_match(key, self.key_config.keys.exit_popup) {
 					self.hide_stacked(false);
 				} else if key_match(key, self.key_config.keys.move_up)

--- a/src/popups/compare_commits.rs
+++ b/src/popups/compare_commits.rs
@@ -117,6 +117,11 @@ impl Component for CompareCommitsPopup {
 			}
 
 			if let Event::Key(e) = ev {
+				// let the command bar more/less toggle ([.])
+				// bubble up to the app-level handler
+				if key_match(e, self.key_config.keys.cmd_bar_toggle) {
+					return Ok(EventState::NotConsumed);
+				}
 				if key_match(e, self.key_config.keys.exit_popup) {
 					if self.diff.focused() {
 						self.details.focus(true);

--- a/src/popups/file_revlog.rs
+++ b/src/popups/file_revlog.rs
@@ -501,6 +501,12 @@ impl Component for FileRevlogPopup {
 			}
 
 			if let Event::Key(key) = event {
+				// let the command bar more/less toggle ([.])
+				// bubble up to the app-level handler
+				if key_match(key, self.key_config.keys.cmd_bar_toggle)
+				{
+					return Ok(EventState::NotConsumed);
+				}
 				if key_match(key, self.key_config.keys.exit_popup) {
 					if self.diff.focused() {
 						self.diff.focus(false);

--- a/src/popups/inspect_commit.rs
+++ b/src/popups/inspect_commit.rs
@@ -154,6 +154,11 @@ impl Component for InspectCommitPopup {
 			}
 
 			if let Event::Key(e) = ev {
+				// let the command bar more/less toggle ([.])
+				// bubble up to the app-level handler
+				if key_match(e, self.key_config.keys.cmd_bar_toggle) {
+					return Ok(EventState::NotConsumed);
+				}
 				if key_match(e, self.key_config.keys.exit_popup) {
 					if self.diff.focused() {
 						self.details.focus(true);


### PR DESCRIPTION
The **Inspect Commit**, **Compare**, **File History** and **Blame** popups consume every key while open (a blanket `return Ok(EventState::Consumed)` at the end of their `event()`), so the command bar `more`/`less` toggle (`.`, `cmd_bar_toggle`) never reaches the app-level handler in `App::event` and does nothing inside those popups.

### Fix
Pass the `cmd_bar_toggle` key through (`NotConsumed`) at the top of each of those four popups' key handling, so it bubbles up to the existing app-level toggle. Everything else stays modal.

These popups host no text input, so letting `.` through can't hijack typing.

### Before / after
- **Before:** enter Inspect Commit (Enter on a commit in the Log tab), or open Compare / File History / Blame, then press `.` — the command bar never expands, even though `more [.]` is shown.
- **After:** `.` toggles `more`/`less` in all four viewers, matching the behaviour in the main tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
