### PR TITLE
Enable `unstable-sha256` for `git2`

### DIFF
--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = "0.5"
 dirs = "6.0"
 easy-cast = "0.5"
 fuzzy-matcher = "0.3"
-git2 = { version = "0.21", features = ["https"] }
+git2 = { version = "0.21", features = ["https", "unstable-sha256"] }
 git2-hooks = { path = "../git2-hooks", version = "0.7" }
 gix = { version = "0.84.0", default-features = false, features = ["mailmap", "max-performance", "revision", "sha1", "sha256", "status"] }
 log = "0.4"


### PR DESCRIPTION
This PR is a follow-up to #2962 and #2967. It enables the `unstable-sha256` feature for `git2`. This change should enable `gitui` to work with SHA-256 repos since SHA-256 support for `gitoxide` was enabled via #2967 already.
