### PR TITLE
fix(watcher): don't panic when a subdirectory can't be watched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * crash when opening submodule ([#2895](https://github.com/gitui-org/gitui/issues/2895))
 * when staging the last file in a directory, the first item after the directory is no longer skipped [[@Tillerino](https://github.com/Tillerino)] ([#2748](https://github.com/gitui-org/gitui/issues/2748))
 * index-out-of-bounds panic when unstaging lines near the end of a diff ([#2953](https://github.com/gitui-org/gitui/issues/2953))
+* `--watcher` panic when a watched repo contains a directory owned by another user; live-refresh is now disabled instead of crashing ([#2900](https://github.com/gitui-org/gitui/issues/2900))
 
 ## [0.28.1] - 2026-03-21
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -73,10 +73,38 @@ fn create_watcher(
 
 	let mut bouncer =
 		new_debouncer(timeout, tx).expect("Watch create error");
-	bouncer
+
+	match bouncer
 		.watcher()
 		.watch(Path::new(&workdir), RecursiveMode::Recursive)
-		.expect("Watch error");
+	{
+		Ok(()) => std::mem::forget(bouncer),
+		Err(e) => {
+			// e.g. a subdirectory owned by another user can make the
+			// recursive watch fail with `PermissionDenied`. Live
+			// updates are disabled in that case, but gitui should
+			// still start up normally instead of crashing (#2900).
+			log::error!(
+				"failed to watch '{workdir}' for changes, live-refresh disabled: {e}"
+			);
+		}
+	}
+}
 
-	std::mem::forget(bouncer);
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_create_watcher_does_not_panic_on_watch_error() {
+		// a path that cannot be watched (e.g. because it does not
+		// exist, or - as in #2900 - because a subdirectory is owned
+		// by another user) must not crash gitui.
+		let (tx, _rx) = std::sync::mpsc::channel();
+		create_watcher(
+			Duration::from_millis(100),
+			tx,
+			"/nonexistent/gitui-watcher-test-path",
+		);
+	}
 }


### PR DESCRIPTION
## Bug

`gitui --watcher` panics with "GitUI was closed due to an unexpected panic" whenever the recursive `notify` watch fails to add a watch for some subdirectory of the repo, e.g. when that subdirectory is owned by a different user (root-owned, or created via a container/`podman`) and the OS returns `PermissionDenied`.

```
panicked at src/watcher.rs:79:10:
Watch error: Error { kind: Io(Os { code: 13, kind: PermissionDenied, message: "Permission denied" }), paths: ["/home/user/gitui-test/mydir"] }
```

The panic happens on a background thread (spawned in `RepoWatcher::new`), but the process-wide panic hook tears down the terminal as soon as it fires, so the user just sees gitui close.

Repro (from #2900):
```sh
mkdir projectX && cd projectX && git init
podman run --rm -v "$(pwd):/workdir" alpine:latest /bin/sh -c \
  'mkdir /workdir/test && chown 1000:1000 /workdir/test && chmod 700 /workdir/test'
RUST_BACKTRACE=1 RUST_LOG=debug gitui --watcher
```

## Fix

Replace the fatal `.expect("Watch error")` in `create_watcher` (`src/watcher.rs`) with a `match` on the `watch()` result: on success the debouncer is kept alive as before, on failure the error is logged and the function returns without panicking. gitui starts up normally and keeps working, just without live file-watching for that session (comparable to running with `--updater ticker`).

## Testing

- Added `watcher::tests::test_create_watcher_does_not_panic_on_watch_error`, which calls `create_watcher` with a path that can't be watched and asserts it doesn't panic. This exercises the exact code path from the issue without needing root/container setup to reproduce the `PermissionDenied` specifically.
- `cargo fmt -- --check` — clean
- `cargo clippy --workspace --all-features` — clean
- `cargo test --bin gitui` — 80 passed, 0 failed (includes the new test)
- `cargo test --workspace` — 175/177 pass; the 2 failures (`sync::sign::tests::test_openpgp_sign_and_verify_e2e`, `sync::sign::tests::test_x509_sign_and_verify_e2e`) are pre-existing on `upstream/master` unmodified, caused by `gpg`/`gpgsm` not being installed on my machine, unrelated to this change.

Added a CHANGELOG entry under `Unreleased`.

Fixes #2900